### PR TITLE
Configure Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  // GitHub Pages serves the site from /<repo-name>/; update this string if the repository name changes.
+  base: '/flappy-bird/',
+});


### PR DESCRIPTION
## Summary
- add a Vite configuration file that sets the GitHub Pages base path to /flappy-bird/
- document how to update the base path when the repository name changes

## Testing
- not run (project does not have npm scripts configured)

------
https://chatgpt.com/codex/tasks/task_e_68e04a3808708328bd81d4c47d5f2066