### PR TITLE
Refactor game loop into systems module

### DIFF
--- a/src/game/systems/index.js
+++ b/src/game/systems/index.js
@@ -1,1 +1,2 @@
 export { CONFIG, createGameState, resetGameState } from "./state.js";
+export { initializeGameLoop, startGame, handleCanvasClick } from "./loop.js";

--- a/src/game/systems/loop.js
+++ b/src/game/systems/loop.js
@@ -1,0 +1,96 @@
+import { Bird, Pipe } from "../entities/index.js";
+import { CONFIG, resetGameState } from "./state.js";
+
+let state = null;
+
+function ensureState() {
+  if (!state) {
+    throw new Error("Game state has not been initialized.");
+  }
+}
+
+export function initializeGameLoop(gameState) {
+  state = gameState;
+  startGame();
+}
+
+export function startGame() {
+  ensureState();
+
+  if (state.animationFrameId !== null) {
+    cancelAnimationFrame(state.animationFrameId);
+    state.animationFrameId = null;
+  }
+
+  resetGameState(state);
+  state.bird = new Bird(50, state.canvas.height / 2);
+  state.pipes.push(new Pipe(state.canvas.width, state.canvas.height, CONFIG.gapSize));
+  runGameLoop();
+}
+
+function runGameLoop() {
+  ensureState();
+
+  state.animationFrameId = null;
+  const { ctx, canvas } = state;
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  state.bird.update(CONFIG.gravity);
+  state.bird.draw(ctx);
+
+  for (let i = state.pipes.length - 1; i >= 0; i -= 1) {
+    const pipe = state.pipes[i];
+    pipe.update(
+      state.pipeSpeed,
+      state.bird,
+      () => {
+        state.gameOver = true;
+      },
+      () => {
+        state.score += 1;
+        if (state.score > 0 && state.score % 100 === 0) {
+          state.pipeSpeed += 0.5;
+        }
+      }
+    );
+
+    pipe.draw(ctx);
+
+    if (pipe.isOffScreen()) {
+      state.pipes.splice(i, 1);
+    }
+  }
+
+  if (state.frameCount % CONFIG.pipeInterval === 0) {
+    state.pipes.push(new Pipe(canvas.width, canvas.height, CONFIG.gapSize));
+  }
+
+  ctx.fillStyle = "#000";
+  ctx.font = "20px Arial";
+  ctx.fillText(`Score: ${state.score}`, 10, 30);
+
+  if (state.bird.isOutOfBounds(canvas.height)) {
+    state.gameOver = true;
+  }
+
+  if (!state.gameOver) {
+    state.frameCount += 1;
+    state.animationFrameId = requestAnimationFrame(runGameLoop);
+  } else {
+    ctx.fillStyle = "#000";
+    ctx.font = "30px Arial";
+    ctx.fillText("Game Over", canvas.width / 2 - 80, canvas.height / 2);
+    ctx.fillText("Click to play again", canvas.width / 2 - 100, canvas.height / 2 + 40);
+  }
+}
+
+export function handleCanvasClick() {
+  ensureState();
+
+  if (!state.gameOver) {
+    state.bird.jump();
+  } else {
+    startGame();
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,88 +1,11 @@
-import { Bird, Pipe } from "./game/entities/index.js";
-import { CONFIG, createGameState, resetGameState } from "./game/systems/index.js";
-
-let state;
-
-function startGame() {
-  if (state.animationFrameId !== null) {
-    cancelAnimationFrame(state.animationFrameId);
-    state.animationFrameId = null;
-  }
-
-  resetGameState(state);
-  state.bird = new Bird(50, state.canvas.height / 2);
-  state.pipes.push(new Pipe(state.canvas.width, state.canvas.height, CONFIG.gapSize));
-  runGameLoop();
-}
-
-function runGameLoop() {
-  state.animationFrameId = null;
-  const { ctx, canvas } = state;
-
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-  state.bird.update(CONFIG.gravity);
-  state.bird.draw(ctx);
-
-  for (let i = state.pipes.length - 1; i >= 0; i -= 1) {
-    const pipe = state.pipes[i];
-    pipe.update(
-      state.pipeSpeed,
-      state.bird,
-      () => {
-        state.gameOver = true;
-      },
-      () => {
-        state.score += 1;
-        if (state.score > 0 && state.score % 100 === 0) {
-          state.pipeSpeed += 0.5;
-        }
-      }
-    );
-
-    pipe.draw(ctx);
-
-    if (pipe.isOffScreen()) {
-      state.pipes.splice(i, 1);
-    }
-  }
-
-  if (state.frameCount % CONFIG.pipeInterval === 0) {
-    state.pipes.push(new Pipe(canvas.width, canvas.height, CONFIG.gapSize));
-  }
-
-  ctx.fillStyle = "#000";
-  ctx.font = "20px Arial";
-  ctx.fillText(`Score: ${state.score}`, 10, 30);
-
-  if (state.bird.isOutOfBounds(canvas.height)) {
-    state.gameOver = true;
-  }
-
-  if (!state.gameOver) {
-    state.frameCount += 1;
-    state.animationFrameId = requestAnimationFrame(runGameLoop);
-  } else {
-    ctx.fillStyle = "#000";
-    ctx.font = "30px Arial";
-    ctx.fillText("Game Over", canvas.width / 2 - 80, canvas.height / 2);
-    ctx.fillText("Click to play again", canvas.width / 2 - 100, canvas.height / 2 + 40);
-  }
-}
-
-function handleCanvasClick() {
-  if (!state.gameOver) {
-    state.bird.jump();
-  } else {
-    startGame();
-  }
-}
+import { createGameState, handleCanvasClick, initializeGameLoop } from "./game/systems/index.js";
 
 function init() {
   const canvas = document.getElementById("gameCanvas");
-  state = createGameState(canvas);
+  const state = createGameState(canvas);
+
+  initializeGameLoop(state);
   canvas.addEventListener("click", handleCanvasClick);
-  startGame();
 }
 
 window.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## Summary
- move the game loop orchestration into a dedicated `src/game/systems/loop.js` module that fits the new directory layout
- re-export loop helpers from the systems barrel and simplify `src/main.js` to initialization only

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04beec9cc8328905bcd1d0ae4985b