### PR TITLE
Add deterministic PRNG for pipe spawning

### DIFF
--- a/src/game/entities/Pipe.js
+++ b/src/game/entities/Pipe.js
@@ -1,5 +1,31 @@
+function randomIntInRange(randomSource, min, max) {
+  if (max < min) {
+    throw new Error("max must be greater than or equal to min");
+  }
+
+  const range = max - min + 1;
+
+  if (randomSource && typeof randomSource.nextInt === "function") {
+    return randomSource.nextInt(min, max);
+  }
+
+  const randomValue = (() => {
+    if (typeof randomSource === "function") {
+      return randomSource();
+    }
+
+    if (randomSource && typeof randomSource.next === "function") {
+      return randomSource.next();
+    }
+
+    return Math.random();
+  })();
+
+  return Math.floor(randomValue * range) + min;
+}
+
 export class Pipe {
-  constructor(x, canvasHeight, gapSize) {
+  constructor(x, canvasHeight, gapSize, randomSource = Math.random) {
     this.x = x;
     this.width = 50;
     this.gapSize = gapSize;
@@ -8,7 +34,7 @@ export class Pipe {
 
     const minHeight = 50;
     const maxHeight = Math.max(minHeight, canvasHeight - gapSize - minHeight);
-    this.topHeight = Math.floor(Math.random() * (maxHeight - minHeight + 1)) + minHeight;
+    this.topHeight = randomIntInRange(randomSource, minHeight, maxHeight);
   }
 
   update(speed, bird, onCollision, onPass) {

--- a/src/game/systems/index.js
+++ b/src/game/systems/index.js
@@ -1,1 +1,6 @@
 export { CONFIG, createGameState, resetGameState } from "./state.js";
+export {
+  DeterministicPRNG,
+  createDeterministicPrng,
+  setDeterministicSeed,
+} from "./prng.ts";

--- a/src/game/systems/prng.test.ts
+++ b/src/game/systems/prng.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { Pipe } from "../entities/Pipe.js";
+import { DeterministicPRNG } from "./prng";
+
+describe("deterministic pipe spawning", () => {
+  function spawnSequence(seed) {
+    const prng = new DeterministicPRNG(seed);
+    const heights = [];
+
+    for (let i = 0; i < 10; i += 1) {
+      const pipe = new Pipe(0, 400, 120, prng);
+      heights.push(pipe.topHeight);
+    }
+
+    return heights;
+  }
+
+  it("produces identical spawn sequences for identical seeds", () => {
+    const firstRun = spawnSequence(123456);
+    const secondRun = spawnSequence(123456);
+
+    expect(secondRun).toEqual(firstRun);
+  });
+
+  it("produces different spawn sequences for different seeds", () => {
+    const firstRun = spawnSequence(42);
+    const secondRun = spawnSequence(1337);
+
+    expect(secondRun).not.toEqual(firstRun);
+  });
+});

--- a/src/game/systems/prng.ts
+++ b/src/game/systems/prng.ts
@@ -1,0 +1,132 @@
+const DEFAULT_STORAGE_KEY = "flappy-bird/prng-seed";
+
+export interface StorageAdapter {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+function resolveStorage(storage?: StorageAdapter | null): StorageAdapter | null {
+  if (storage) {
+    return storage;
+  }
+
+  if (typeof window !== "undefined" && typeof window.localStorage !== "undefined") {
+    return window.localStorage;
+  }
+
+  return null;
+}
+
+export class DeterministicPRNG {
+  private state: number;
+
+  private initialSeed: number;
+
+  private readonly storageKey: string;
+
+  constructor(seed: number = Date.now(), storageKey: string = DEFAULT_STORAGE_KEY) {
+    this.storageKey = storageKey;
+    this.initialSeed = 0;
+    this.state = 0;
+    this.seed(seed);
+  }
+
+  seed(seed: number): number {
+    const normalized = seed >>> 0;
+    this.initialSeed = normalized;
+    this.state = normalized;
+    return this.initialSeed;
+  }
+
+  reset(): void {
+    this.state = this.initialSeed;
+  }
+
+  next(): number {
+    this.state = (this.state + 0x6d2b79f5) >>> 0;
+    let t = this.state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }
+
+  nextInt(min: number, max: number): number {
+    if (max < min) {
+      throw new Error("max must be greater than or equal to min");
+    }
+
+    const range = max - min + 1;
+    return Math.floor(this.next() * range) + min;
+  }
+
+  getSeed(): number {
+    return this.initialSeed;
+  }
+
+  serializeSeed(): string {
+    return this.initialSeed.toString(10);
+  }
+
+  saveSeed(storage?: StorageAdapter | null): void {
+    const resolvedStorage = resolveStorage(storage);
+    if (!resolvedStorage) {
+      return;
+    }
+
+    resolvedStorage.setItem(this.storageKey, this.serializeSeed());
+  }
+
+  loadSeed(storage?: StorageAdapter | null): boolean {
+    const resolvedStorage = resolveStorage(storage);
+    if (!resolvedStorage) {
+      return false;
+    }
+
+    const storedValue = resolvedStorage.getItem(this.storageKey);
+    if (storedValue === null) {
+      return false;
+    }
+
+    const parsed = Number.parseInt(storedValue, 10);
+    if (Number.isNaN(parsed)) {
+      return false;
+    }
+
+    this.seed(parsed);
+    return true;
+  }
+}
+
+export interface CreatePrngOptions {
+  seed?: number;
+  storageKey?: string;
+  storage?: StorageAdapter | null;
+  autoLoad?: boolean;
+  autoSave?: boolean;
+}
+
+export function createDeterministicPrng(options: CreatePrngOptions = {}): DeterministicPRNG {
+  const {
+    seed = Date.now(),
+    storageKey = DEFAULT_STORAGE_KEY,
+    storage = undefined,
+    autoLoad = true,
+    autoSave = true,
+  } = options;
+
+  const prng = new DeterministicPRNG(seed, storageKey);
+  const resolvedStorage = resolveStorage(storage);
+
+  const loaded = autoLoad ? prng.loadSeed(resolvedStorage) : false;
+  if (!loaded && autoSave && resolvedStorage) {
+    prng.saveSeed(resolvedStorage);
+  }
+
+  return prng;
+}
+
+export function setDeterministicSeed(seed: number, storage?: StorageAdapter | null, storageKey: string = DEFAULT_STORAGE_KEY): number {
+  const prng = new DeterministicPRNG(seed, storageKey);
+  prng.saveSeed(storage);
+  return prng.getSeed();
+}

--- a/src/game/systems/state.js
+++ b/src/game/systems/state.js
@@ -1,3 +1,5 @@
+import { createDeterministicPrng } from "./prng.ts";
+
 export const CONFIG = {
   gravity: 0.6,
   gapSize: 100,
@@ -5,7 +7,7 @@ export const CONFIG = {
   initialPipeSpeed: 2,
 };
 
-export function createGameState(canvas) {
+export function createGameState(canvas, prng = createDeterministicPrng()) {
   return {
     canvas,
     ctx: canvas.getContext("2d"),
@@ -16,6 +18,7 @@ export function createGameState(canvas) {
     frameCount: 0,
     pipeSpeed: CONFIG.initialPipeSpeed,
     animationFrameId: null,
+    prng,
   };
 }
 
@@ -26,4 +29,7 @@ export function resetGameState(state) {
   state.frameCount = 0;
   state.pipeSpeed = CONFIG.initialPipeSpeed;
   state.animationFrameId = null;
+  if (state.prng && typeof state.prng.reset === "function") {
+    state.prng.reset();
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,10 @@ import { CONFIG, createGameState, resetGameState } from "./game/systems/index.js
 
 let state;
 
+function spawnPipe(xPosition) {
+  state.pipes.push(new Pipe(xPosition, state.canvas.height, CONFIG.gapSize, state.prng));
+}
+
 function startGame() {
   if (state.animationFrameId !== null) {
     cancelAnimationFrame(state.animationFrameId);
@@ -11,7 +15,7 @@ function startGame() {
 
   resetGameState(state);
   state.bird = new Bird(50, state.canvas.height / 2);
-  state.pipes.push(new Pipe(state.canvas.width, state.canvas.height, CONFIG.gapSize));
+  spawnPipe(state.canvas.width);
   runGameLoop();
 }
 
@@ -48,7 +52,7 @@ function runGameLoop() {
   }
 
   if (state.frameCount % CONFIG.pipeInterval === 0) {
-    state.pipes.push(new Pipe(canvas.width, canvas.height, CONFIG.gapSize));
+    spawnPipe(canvas.width);
   }
 
   ctx.fillStyle = "#000";


### PR DESCRIPTION
## Summary
- add a mulberry32-style deterministic PRNG with seed persistence helpers
- wire the shared PRNG into pipe spawning so gameplay randomness can be reproduced
- cover the deterministic spawning behaviour with Vitest unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e04bf256848328ae4264f174c8a5e4