### PR TITLE
Add cached GLTF asset loader for Three.js scenes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "flappy-bird",
       "version": "0.1.0",
+      "dependencies": {
+        "three": "^0.180.0"
+      },
       "devDependencies": {
         "eslint": "^8.57.0",
         "typescript": "^5.4.0",
@@ -2589,6 +2592,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "typescript": "^5.4.0",
     "vite": "^5.2.0",
     "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "three": "^0.180.0"
   }
 }

--- a/src/rendering/three/assets.test.ts
+++ b/src/rendering/three/assets.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('three/examples/jsm/loaders/DRACOLoader.js', () => ({
+  __esModule: true,
+  DRACOLoader: class {
+    setDecoderPath() {
+      // noop for tests
+    }
+    dispose() {
+      // noop for tests
+    }
+  },
+}));
+
+const loadSpy = vi.fn(async (url: string) => ({
+  scene: { url },
+}));
+
+vi.mock('three/examples/jsm/loaders/GLTFLoader.js', () => ({
+  __esModule: true,
+  GLTFLoader: class {
+    loadAsync(url: string) {
+      return loadSpy(url);
+    }
+    setDRACOLoader() {
+      // noop for tests
+    }
+  },
+  GLTF: {} as unknown,
+}));
+
+vi.mock('three/examples/jsm/utils/SkeletonUtils.js', () => ({
+  __esModule: true,
+  clone: (scene: { url: string }) => ({
+    url: scene.url,
+    cloned: true,
+    timestamp: Symbol(scene.url),
+  }),
+}));
+
+vi.mock('three', () => ({
+  __esModule: true,
+  Group: class {},
+}));
+
+import {
+  MODEL_URLS,
+  clearSceneCache,
+  disposeLoaders,
+  getSceneClone,
+  loadCoreModel,
+  preloadScene,
+} from './assets';
+
+describe('three asset loader cache', () => {
+  beforeEach(() => {
+    clearSceneCache();
+    loadSpy.mockClear();
+  });
+
+  it('loads a scene once and returns cloned instances on subsequent requests', async () => {
+    const first = await getSceneClone('mock.glb');
+    const second = await getSceneClone('mock.glb');
+
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    expect(first).not.toBe(second);
+    expect(first.cloned).toBe(true);
+    expect(second.cloned).toBe(true);
+  });
+
+  it('shares cached data between preload and clone helpers', async () => {
+    await preloadScene(MODEL_URLS.bird);
+    const birdClone = await loadCoreModel.bird();
+
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    expect(birdClone.cloned).toBe(true);
+  });
+});
+
+afterAll(() => {
+  disposeLoaders();
+});

--- a/src/rendering/three/assets.ts
+++ b/src/rendering/three/assets.ts
@@ -1,0 +1,102 @@
+import { Group } from 'three';
+import { GLTFLoader, type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+import { clone as cloneWithSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js';
+
+/**
+ * Default locations for core game models. These are intentionally exported so callers can
+ * build UIs that reference the same canonical asset paths.
+ */
+export const MODEL_URLS = Object.freeze({
+  bird: '/assets/models/bird.glb',
+  pipe: '/assets/models/pipe.glb',
+  background: '/assets/models/background.glb',
+});
+
+const gltfCache = new Map<string, Promise<GLTF>>();
+
+let sharedLoader: GLTFLoader | null = null;
+let sharedDracoLoader: DRACOLoader | null = null;
+
+function getLoader(): GLTFLoader {
+  if (sharedLoader) {
+    return sharedLoader;
+  }
+
+  sharedLoader = new GLTFLoader();
+
+  // Configure optional Draco compression support if the decoder is available at runtime.
+  if (typeof window !== 'undefined') {
+    sharedDracoLoader = new DRACOLoader();
+    // The decoder path is relative to the built output. Projects that do not ship the Draco
+    // decoder can simply omit the files without breaking non-compressed assets.
+    sharedDracoLoader.setDecoderPath('/assets/draco/');
+    sharedLoader.setDRACOLoader(sharedDracoLoader);
+  }
+
+  return sharedLoader;
+}
+
+async function loadGLTF(url: string): Promise<GLTF> {
+  let promise = gltfCache.get(url);
+  if (!promise) {
+    promise = getLoader().loadAsync(url);
+    gltfCache.set(url, promise);
+  }
+
+  return promise;
+}
+
+function cloneScene(scene: GLTF['scene']): Group {
+  // SkeletonUtils.clone preserves skinning/bone hierarchies while also handling shared
+  // geometries, which is important for animated bird rigs.
+  return cloneWithSkeleton(scene) as Group;
+}
+
+/**
+ * Preloads and caches a GLTF scene, allowing renderers to request cloned copies without
+ * incurring multiple network requests.
+ */
+export async function preloadScene(url: string): Promise<void> {
+  await loadGLTF(url);
+}
+
+/**
+ * Loads a GLTF scene and returns a cloned instance that can be safely mutated by the caller
+ * without affecting the cached original.
+ */
+export async function getSceneClone(url: string): Promise<Group> {
+  const gltf = await loadGLTF(url);
+  return cloneScene(gltf.scene);
+}
+
+/**
+ * Convenience helper for retrieving cloned core game assets.
+ */
+export const loadCoreModel = {
+  bird: () => getSceneClone(MODEL_URLS.bird),
+  pipe: () => getSceneClone(MODEL_URLS.pipe),
+  background: () => getSceneClone(MODEL_URLS.background),
+} as const;
+
+/**
+ * Clears cached GLTF data. This is primarily useful for tests where we need to verify caching
+ * behaviour deterministically.
+ */
+export function clearSceneCache(): void {
+  gltfCache.clear();
+}
+
+/**
+ * Disposes loader resources. Generally only needed in test environments.
+ */
+export function disposeLoaders(): void {
+  gltfCache.clear();
+
+  if (sharedDracoLoader) {
+    sharedDracoLoader.dispose?.();
+    sharedDracoLoader = null;
+  }
+
+  sharedLoader = null;
+}


### PR DESCRIPTION
## Summary
- add a reusable GLTF asset loader with optional Draco support and scene caching
- expose helpers that return cloned scenes for renderers and convenience accessors for core models
- cover the loader with Vitest to verify cache hits after the first load

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e04bffd7ac83289973170f6ef568b6