### PR TITLE
Improve HUD accessibility contrast and scoreboard persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,60 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <canvas id="gameCanvas" width="400" height="400"></canvas>
+    <div class="game-shell">
+      <canvas id="gameCanvas" width="400" height="400"></canvas>
+      <section
+        id="hud"
+        class="hud"
+        aria-label="Gameplay heads-up display"
+        aria-live="polite"
+      >
+        <div class="hud-row">
+          <div class="hud-group" role="group" aria-label="Current score">
+            <span class="hud-label">Score</span>
+            <span id="hudScore" class="hud-value">0</span>
+          </div>
+          <div class="hud-group" role="group" aria-label="Best score">
+            <span class="hud-label">Best</span>
+            <span id="hudBest" class="hud-value">0</span>
+          </div>
+        </div>
+        <div class="hud-row hud-row--status">
+          <p id="hudStatus" class="hud-status">Tap or click to flap.</p>
+          <div class="hud-icons" role="group" aria-label="Power-up status">
+            <div
+              class="hud-icon"
+              data-power="speed"
+              data-active="false"
+              role="img"
+              aria-label="Speed boost inactive"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M13.5 2 4 14.2h6.3L9 22l9.5-12.2H12L13.5 2z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+            <div
+              class="hud-icon"
+              data-power="shield"
+              data-active="false"
+              role="img"
+              aria-label="Shield inactive"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M12 2 5 5v6c0 5.2 3.4 9.9 7 11 3.6-1.1 7-5.8 7-11V5l-7-3z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <span class="sr-only" id="hudPowerSummary">No active power-ups.</span>
+      </section>
+    </div>
     <script type="module" src="./src/main.js"></script>
   </body>
 </html>

--- a/src/game/systems/state.js
+++ b/src/game/systems/state.js
@@ -12,6 +12,7 @@ export function createGameState(canvas) {
     bird: null,
     pipes: [],
     score: 0,
+    bestScore: 0,
     gameOver: false,
     frameCount: 0,
     pipeSpeed: CONFIG.initialPipeSpeed,

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,67 @@
 import { Bird, Pipe } from "./game/entities/index.js";
 import { CONFIG, createGameState, resetGameState } from "./game/systems/index.js";
 
+const HUD_STATUS_DEFAULT = "Tap or click to flap.";
+const HUD_STATUS_GAME_OVER = "Game over. Click or tap to play again.";
+const BEST_SCORE_STORAGE_KEY = "flappy-bird-best-score";
+
 let state;
+let hudElements = null;
+
+function loadBestScore() {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return 0;
+  }
+
+  const storedValue = window.localStorage.getItem(BEST_SCORE_STORAGE_KEY);
+  if (storedValue === null) {
+    return 0;
+  }
+
+  const parsed = Number.parseInt(storedValue, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  return parsed;
+}
+
+function saveBestScore(value) {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+
+  window.localStorage.setItem(BEST_SCORE_STORAGE_KEY, String(value));
+}
+
+function updateHud(statusOverride) {
+  if (!hudElements || !state) {
+    return;
+  }
+
+  const finalStatus =
+    typeof statusOverride === "string"
+      ? statusOverride
+      : state.gameOver
+        ? HUD_STATUS_GAME_OVER
+        : HUD_STATUS_DEFAULT;
+
+  if (hudElements.score) {
+    hudElements.score.textContent = state.score.toString();
+  }
+
+  if (hudElements.best) {
+    hudElements.best.textContent = state.bestScore.toString();
+  }
+
+  if (hudElements.status) {
+    hudElements.status.textContent = finalStatus;
+  }
+
+  if (hudElements.root) {
+    hudElements.root.dataset.state = state.gameOver ? "game-over" : "playing";
+  }
+}
 
 function startGame() {
   if (state.animationFrameId !== null) {
@@ -12,6 +72,7 @@ function startGame() {
   resetGameState(state);
   state.bird = new Bird(50, state.canvas.height / 2);
   state.pipes.push(new Pipe(state.canvas.width, state.canvas.height, CONFIG.gapSize));
+  updateHud(HUD_STATUS_DEFAULT);
   runGameLoop();
 }
 
@@ -30,13 +91,21 @@ function runGameLoop() {
       state.pipeSpeed,
       state.bird,
       () => {
-        state.gameOver = true;
+        if (!state.gameOver) {
+          state.gameOver = true;
+          updateHud(HUD_STATUS_GAME_OVER);
+        }
       },
       () => {
         state.score += 1;
+        if (state.score > state.bestScore) {
+          state.bestScore = state.score;
+          saveBestScore(state.bestScore);
+        }
         if (state.score > 0 && state.score % 100 === 0) {
           state.pipeSpeed += 0.5;
         }
+        updateHud();
       }
     );
 
@@ -51,12 +120,11 @@ function runGameLoop() {
     state.pipes.push(new Pipe(canvas.width, canvas.height, CONFIG.gapSize));
   }
 
-  ctx.fillStyle = "#000";
-  ctx.font = "20px Arial";
-  ctx.fillText(`Score: ${state.score}`, 10, 30);
-
   if (state.bird.isOutOfBounds(canvas.height)) {
-    state.gameOver = true;
+    if (!state.gameOver) {
+      state.gameOver = true;
+      updateHud(HUD_STATUS_GAME_OVER);
+    }
   }
 
   if (!state.gameOver) {
@@ -80,7 +148,24 @@ function handleCanvasClick() {
 
 function init() {
   const canvas = document.getElementById("gameCanvas");
+  const hudRoot = document.getElementById("hud");
+  hudElements = hudRoot
+    ? {
+        root: hudRoot,
+        score: document.getElementById("hudScore"),
+        best: document.getElementById("hudBest"),
+        status: document.getElementById("hudStatus"),
+        powerSummary: document.getElementById("hudPowerSummary"),
+      }
+    : null;
+
+  if (hudElements?.powerSummary) {
+    hudElements.powerSummary.textContent = "No active power-ups.";
+  }
+
   state = createGameState(canvas);
+  state.bestScore = loadBestScore();
+  updateHud();
   canvas.addEventListener("click", handleCanvasClick);
   startGame();
 }

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,179 @@
+:root {
+  --hud-bg: rgba(15, 23, 42, 0.88);
+  --hud-border: rgba(148, 163, 184, 0.45);
+  --hud-text: #f8fafc;
+  --hud-subtext: #e2e8f0;
+  --hud-status-alert: #fca5a5;
+  --hud-icon-bg: rgba(30, 41, 59, 0.92);
+  --hud-icon-border: rgba(148, 163, 184, 0.55);
+  --hud-icon-inactive: #94a3b8;
+  --hud-icon-active-bg: #2563eb;
+  --hud-icon-active-color: #f8fafc;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #f0f0f0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background-color: #f0f4f8;
   display: flex;
   justify-content: center;
   align-items: center;
   min-height: 100vh;
+  padding: 1.5rem;
+  box-sizing: border-box;
+}
+
+.game-shell {
+  position: relative;
+  display: inline-block;
 }
 
 #gameCanvas {
-  border: 1px solid #000;
+  display: block;
+  border: 2px solid #111827;
+  border-radius: 12px;
   background-color: #fff;
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.25);
+}
+
+.hud {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.9rem 1rem;
+  background: var(--hud-bg);
+  color: var(--hud-text);
+  border-radius: 14px;
+  border: 1px solid var(--hud-border);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(6px);
+  min-width: 13rem;
+  max-width: calc(100% - 1.5rem);
+  pointer-events: none;
+}
+
+.hud-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hud-row--status {
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.hud-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 5rem;
+}
+
+.hud-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--hud-subtext);
+}
+
+.hud-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--hud-text);
+}
+
+.hud-status {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--hud-subtext);
+  max-width: 14rem;
+}
+
+.hud[data-state="game-over"] .hud-status {
+  color: var(--hud-status-alert);
+  font-weight: 600;
+}
+
+.hud-icons {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hud-icon {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 0.8rem;
+  background: var(--hud-icon-bg);
+  border: 1px solid var(--hud-icon-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--hud-icon-inactive);
+  transition: transform 0.2s ease, color 0.2s ease, background 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.hud-icon[data-active="true"] {
+  background: var(--hud-icon-active-bg);
+  color: var(--hud-icon-active-color);
+  border-color: rgba(37, 99, 235, 0.8);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.35);
+}
+
+.hud-icon svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1rem;
+  }
+
+  #gameCanvas {
+    width: 100%;
+    height: auto;
+  }
+
+  .hud {
+    top: 0.5rem;
+    left: 0.5rem;
+    padding: 0.75rem 0.85rem;
+    gap: 0.5rem;
+  }
+
+  .hud-row {
+    gap: 0.75rem;
+  }
+
+  .hud-value {
+    font-size: 1.4rem;
+  }
+
+  .hud-status {
+    font-size: 0.85rem;
+  }
 }


### PR DESCRIPTION
## Summary
- add a dedicated HUD overlay with accessible score, status text, and power-up icons
- refresh HUD styling with high-contrast color tokens and responsive layout adjustments
- sync the HUD with game state, including saved best score persistence

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e04c0777cc83288b6608201e810850