### PR TITLE
Add locale-aware score formatting utility

### DIFF
--- a/src/hud/util/__tests__/formatScore.test.ts
+++ b/src/hud/util/__tests__/formatScore.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { formatScore } from '../formatScore';
+
+describe('formatScore', () => {
+  it('formats scores using the provided locale', () => {
+    expect(formatScore(1234567, 'de-DE')).toBe('1.234.567');
+  });
+
+  it('formats scores using the runtime default locale when none is provided', () => {
+    const value = 654321;
+    const expected = new Intl.NumberFormat(undefined, {
+      useGrouping: true,
+      maximumFractionDigits: 0,
+    }).format(value);
+
+    expect(formatScore(value)).toBe(expected);
+  });
+
+  it('falls back to manual formatting when the locale is invalid', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(formatScore(7654321, 'invalid-locale')).toBe('7,654,321');
+
+    warnSpy.mockRestore();
+  });
+
+  it('handles negative and non-finite values gracefully', () => {
+    expect(formatScore(-123456, 'en-US')).toBe('-123,456');
+    expect(formatScore(Number.NaN, 'en-US')).toBe('0');
+    expect(formatScore(Number.POSITIVE_INFINITY, 'en-US')).toBe('0');
+  });
+});

--- a/src/hud/util/formatScore.ts
+++ b/src/hud/util/formatScore.ts
@@ -1,0 +1,22 @@
+export function formatScore(value: number, locale?: string): string {
+  const safeValue = Number.isFinite(value) ? Math.trunc(value) : 0;
+
+  try {
+    return new Intl.NumberFormat(locale, {
+      useGrouping: true,
+      maximumFractionDigits: 0,
+    }).format(safeValue);
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn('Falling back to manual score formatting:', error);
+    }
+  }
+
+  const absolute = Math.abs(safeValue).toString();
+  const grouped = absolute.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+  return safeValue < 0 ? `-${grouped}` : grouped;
+}
+
+export default formatScore;


### PR DESCRIPTION
## Summary
- add a HUD score formatting helper that prefers Intl.NumberFormat but falls back to manual grouping
- add locale-aware unit tests covering default, custom, and fallback formatting scenarios

## Testing
- npm run test -- formatScore

------
https://chatgpt.com/codex/tasks/task_e_68e06185c3608328bcd8f848a5e969d4