### PR TITLE
Add HUD event bus utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules/
 public/assets/models/bird.glb
 public/assets/textures/bird_atlas.png
+coverage/

--- a/src/hud/__tests__/hud-bus.test.ts
+++ b/src/hud/__tests__/hud-bus.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HUD_CHANNEL_SCORE_TICK } from "../hud-events";
+import {
+  hasSubscribers,
+  publish,
+  resetHudBus,
+  subscribe,
+  unsubscribe,
+} from "../hud-bus";
+
+afterEach(() => {
+  resetHudBus();
+});
+
+describe("hud bus score ticker", () => {
+  it("delivers score tick payloads to subscribers", () => {
+    const handler = vi.fn();
+    const unsubscribeHandler = subscribe(HUD_CHANNEL_SCORE_TICK, handler);
+
+    expect(hasSubscribers(HUD_CHANNEL_SCORE_TICK)).toBe(true);
+
+    const payload = { increment: 1, total: 5 } as const;
+    const published = publish(HUD_CHANNEL_SCORE_TICK, payload);
+
+    expect(published).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(payload);
+
+    unsubscribeHandler();
+    expect(hasSubscribers(HUD_CHANNEL_SCORE_TICK)).toBe(false);
+  });
+
+  it("returns false when publishing without subscribers", () => {
+    const payload = { increment: 2, total: 10 } as const;
+    const published = publish(HUD_CHANNEL_SCORE_TICK, payload);
+
+    expect(published).toBe(false);
+  });
+
+  it("supports multiple subscribers and targeted unsubscription", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    subscribe(HUD_CHANNEL_SCORE_TICK, first);
+    subscribe(HUD_CHANNEL_SCORE_TICK, second);
+
+    const payload = { increment: 3, total: 15 } as const;
+    publish(HUD_CHANNEL_SCORE_TICK, payload);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    const removed = unsubscribe(HUD_CHANNEL_SCORE_TICK, first);
+    expect(removed).toBe(true);
+    expect(hasSubscribers(HUD_CHANNEL_SCORE_TICK)).toBe(true);
+
+    resetHudBus();
+    expect(hasSubscribers(HUD_CHANNEL_SCORE_TICK)).toBe(false);
+  });
+
+  it("returns false when attempting to unsubscribe a handler that was never registered", () => {
+    const handler = vi.fn();
+    const removed = unsubscribe(HUD_CHANNEL_SCORE_TICK, handler);
+
+    expect(removed).toBe(false);
+  });
+});

--- a/src/hud/hud-bus.ts
+++ b/src/hud/hud-bus.ts
@@ -1,0 +1,83 @@
+import type { HudChannel, HudEventPayloads } from "./hud-events";
+
+type HudEventHandler<K extends HudChannel> = (payload: HudEventPayloads[K]) => void;
+
+type HandlerRegistry = {
+  [K in HudChannel]?: Set<HudEventHandler<K>>;
+};
+
+const registry: HandlerRegistry = {};
+
+function getHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K>> | undefined {
+  return registry[channel] as Set<HudEventHandler<K>> | undefined;
+}
+
+function ensureHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K>> {
+  let handlers = getHandlers(channel);
+
+  if (!handlers) {
+    handlers = new Set<HudEventHandler<K>>();
+    registry[channel] = handlers as Set<HudEventHandler<typeof channel>>;
+  }
+
+  return handlers;
+}
+
+export function subscribe<K extends HudChannel>(
+  channel: K,
+  handler: HudEventHandler<K>,
+): () => void {
+  const handlers = ensureHandlers(channel);
+  handlers.add(handler);
+
+  return () => {
+    unsubscribe(channel, handler);
+  };
+}
+
+export function unsubscribe<K extends HudChannel>(
+  channel: K,
+  handler: HudEventHandler<K>,
+): boolean {
+  const handlers = getHandlers(channel);
+
+  if (!handlers) {
+    return false;
+  }
+
+  const removed = handlers.delete(handler);
+
+  if (handlers.size === 0) {
+    delete registry[channel];
+  }
+
+  return removed;
+}
+
+export function publish<K extends HudChannel>(
+  channel: K,
+  payload: HudEventPayloads[K],
+): boolean {
+  const handlers = getHandlers(channel);
+
+  if (!handlers || handlers.size === 0) {
+    return false;
+  }
+
+  handlers.forEach((handler) => {
+    handler(payload);
+  });
+
+  return true;
+}
+
+export function hasSubscribers(channel: HudChannel): boolean {
+  const handlers = getHandlers(channel);
+  return !!handlers && handlers.size > 0;
+}
+
+export function resetHudBus(): void {
+  (Object.keys(registry) as HudChannel[]).forEach((channel) => {
+    delete registry[channel];
+  });
+}

--- a/src/hud/hud-events.ts
+++ b/src/hud/hud-events.ts
@@ -1,0 +1,16 @@
+export const HUD_CHANNEL_SCORE_TICK = "hud:score-tick" as const;
+
+export type HudChannel = typeof HUD_CHANNEL_SCORE_TICK;
+
+export interface HudEventPayloads {
+  [HUD_CHANNEL_SCORE_TICK]: {
+    /**
+     * The amount the score increased by for this tick.
+     */
+    increment: number;
+    /**
+     * The running total score after applying the increment.
+     */
+    total: number;
+  };
+}


### PR DESCRIPTION
## Summary
- add HUD channel constants for score tick messaging
- implement a strongly typed HUD event bus with subscribe, publish, and unsubscribe helpers
- cover the score tick flow with comprehensive Vitest specs for full branch coverage

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0617c98888328872626aeb52c2d69