### PR TITLE
Add HUD mounting utilities with DOM tests

### DIFF
--- a/src/hud/__tests__/mount.test.ts
+++ b/src/hud/__tests__/mount.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mountHud, unmountHud } from '../mount';
+
+describe('mountHud', () => {
+  beforeEach(() => {
+    unmountHud();
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('mounts the HUD root inside the document body by default', () => {
+    const container = mountHud();
+
+    expect(container.id).toBe('hud-root');
+    expect(document.body.contains(container)).toBe(true);
+    expect(document.querySelectorAll('#hud-root')).toHaveLength(1);
+  });
+
+  it('reuses the same HUD root on repeated mounts', () => {
+    const first = mountHud();
+    const second = mountHud();
+
+    expect(second).toBe(first);
+    expect(document.querySelectorAll('#hud-root')).toHaveLength(1);
+  });
+
+  it('moves the HUD root to a provided host element', () => {
+    const customHost = document.createElement('div');
+    document.body.append(customHost);
+
+    const container = mountHud(customHost);
+
+    expect(container.parentElement).toBe(customHost);
+    expect(customHost.contains(container)).toBe(true);
+  });
+
+  it('removes listeners and DOM nodes on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const container = mountHud();
+    const resizeCall = addSpy.mock.calls.find(([type]) => type === 'resize');
+
+    expect(resizeCall).toBeDefined();
+
+    const handler = resizeCall?.[1];
+
+    expect(handler).toBeTypeOf('function');
+
+    unmountHud();
+
+    expect(removeSpy).toHaveBeenCalledWith('resize', handler);
+    expect(document.contains(container)).toBe(false);
+    expect(document.getElementById('hud-root')).toBeNull();
+  });
+});

--- a/src/hud/mount.ts
+++ b/src/hud/mount.ts
@@ -1,0 +1,75 @@
+const HUD_ROOT_ID = 'hud-root';
+
+let hudContainer: HTMLElement | null = null;
+let resizeHandler: (() => void) | null = null;
+
+const resolveHost = (root?: HTMLElement): HTMLElement => {
+  const host = root ?? document.body;
+
+  if (!host) {
+    throw new Error('Cannot mount HUD: document.body is not available.');
+  }
+
+  return host;
+};
+
+const ensureContainer = (): HTMLElement => {
+  if (hudContainer && hudContainer.isConnected) {
+    return hudContainer;
+  }
+
+  const existing = document.getElementById(HUD_ROOT_ID) as HTMLElement | null;
+
+  if (existing) {
+    hudContainer = existing;
+    return existing;
+  }
+
+  const container = document.createElement('div');
+  container.id = HUD_ROOT_ID;
+  hudContainer = container;
+
+  return container;
+};
+
+const ensureResizeHandler = () => {
+  if (resizeHandler) {
+    return;
+  }
+
+  resizeHandler = () => {
+    if (!hudContainer) {
+      return;
+    }
+
+    hudContainer.dataset.viewport = `${window.innerWidth}x${window.innerHeight}`;
+  };
+
+  window.addEventListener('resize', resizeHandler);
+};
+
+export const mountHud = (root?: HTMLElement): HTMLElement => {
+  const host = resolveHost(root);
+  const container = ensureContainer();
+
+  if (container.parentElement !== host) {
+    host.appendChild(container);
+  }
+
+  ensureResizeHandler();
+  resizeHandler?.();
+
+  return container;
+};
+
+export const unmountHud = (): void => {
+  if (resizeHandler) {
+    window.removeEventListener('resize', resizeHandler);
+    resizeHandler = null;
+  }
+
+  if (hudContainer) {
+    hudContainer.remove();
+    hudContainer = null;
+  }
+};


### PR DESCRIPTION
## Summary
- add utilities to mount and unmount the singleton HUD root container
- register and clean up a viewport resize listener for the HUD container
- cover mounting behaviors with Vitest DOM tests

## Testing
- npm run test -- src/hud/__tests__/mount.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0617d57488328b1122d7715845266