### PR TITLE
Add HUD flag utility with tests

### DIFF
--- a/src/hud/hud-flag.test.ts
+++ b/src/hud/hud-flag.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { isHudEnabled } from "./hud-flag";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __HUD_FLAG_IMPORT_META_ENV__: Record<string, unknown> | undefined;
+}
+
+const ORIGINAL_PROCESS_ENV = { ...process.env };
+const ORIGINAL_IMPORT_META_ENV = globalThis.__HUD_FLAG_IMPORT_META_ENV__;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_PROCESS_ENV };
+  delete process.env.HUD_V1;
+  delete globalThis.__HUD_FLAG_IMPORT_META_ENV__;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_PROCESS_ENV };
+  if (ORIGINAL_IMPORT_META_ENV === undefined) {
+    delete globalThis.__HUD_FLAG_IMPORT_META_ENV__;
+  } else {
+    globalThis.__HUD_FLAG_IMPORT_META_ENV__ = ORIGINAL_IMPORT_META_ENV;
+  }
+});
+
+describe("isHudEnabled", () => {
+  it("returns false when no environment variables are defined", () => {
+    expect(isHudEnabled()).toBe(false);
+  });
+
+  it("respects HUD_V1 set through process.env", () => {
+    process.env.HUD_V1 = "true";
+
+    expect(isHudEnabled()).toBe(true);
+  });
+
+  it("treats false-like process.env values as disabled", () => {
+    process.env.HUD_V1 = "false";
+
+    expect(isHudEnabled()).toBe(false);
+  });
+
+  it("prefers the import.meta.env override when available", () => {
+    process.env.HUD_V1 = "false";
+    globalThis.__HUD_FLAG_IMPORT_META_ENV__ = { HUD_V1: "true" };
+
+    expect(isHudEnabled()).toBe(true);
+  });
+
+  it("supports boolean values in import.meta.env", () => {
+    globalThis.__HUD_FLAG_IMPORT_META_ENV__ = { HUD_V1: true };
+
+    expect(isHudEnabled()).toBe(true);
+  });
+});

--- a/src/hud/hud-flag.ts
+++ b/src/hud/hud-flag.ts
@@ -1,0 +1,62 @@
+const HUD_ENV_KEYS = ["true", "1", "yes", "on"];
+
+type EnvValue = string | boolean | undefined;
+
+declare global {
+  // Used only within tests to simulate a Vite-like import.meta.env value.
+  // eslint-disable-next-line no-var
+  var __HUD_FLAG_IMPORT_META_ENV__: Record<string, unknown> | undefined;
+}
+
+const normalizeValue = (value: EnvValue): boolean => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return HUD_ENV_KEYS.includes(normalized);
+  }
+
+  return false;
+};
+
+const getFromImportMetaEnv = (): EnvValue => {
+  const meta = import.meta as unknown as { env?: Record<string, unknown> };
+  const env = meta.env;
+
+  if (env && "HUD_V1" in env) {
+    return env.HUD_V1 as EnvValue;
+  }
+
+  const shim = globalThis.__HUD_FLAG_IMPORT_META_ENV__;
+  if (shim && "HUD_V1" in shim) {
+    return shim.HUD_V1 as EnvValue;
+  }
+
+  return undefined;
+};
+
+const getFromProcessEnv = (): EnvValue => {
+  if (typeof process === "undefined" || !process?.env) {
+    return undefined;
+  }
+
+  return process.env.HUD_V1 as EnvValue;
+};
+
+export const isHudEnabled = (): boolean => {
+  const importMetaValue = getFromImportMetaEnv();
+  if (importMetaValue !== undefined) {
+    return normalizeValue(importMetaValue);
+  }
+
+  const processEnvValue = getFromProcessEnv();
+  if (processEnvValue !== undefined) {
+    return normalizeValue(processEnvValue);
+  }
+
+  return false;
+};
+
+export default isHudEnabled;


### PR DESCRIPTION
## Summary
- add a HUD flag helper that reads the HUD_V1 environment value with sensible defaults
- cover the HUD flag behavior with Vitest using fake environment overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0618246588328ae963394f1f6faf8