### PR TITLE
Add HUD i18n helper with locale fallbacks

### DIFF
--- a/src/hud/__tests__/hud-i18n.test.ts
+++ b/src/hud/__tests__/hud-i18n.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { getHudString } from '../hud-i18n';
+
+describe('getHudString', () => {
+  it('enforces valid HUD string keys at compile time', () => {
+    // @ts-expect-error - invalid key should not compile
+    getHudString('invalid-key', 'en');
+
+    // sanity assertion so the test has runtime expectations
+    expect(getHudString('scoreLabel', 'en')).toBe('Score');
+  });
+
+  it('returns English strings by default', () => {
+    expect(getHudString('tapToStart')).toBe('Tap to start');
+  });
+
+  it('selects localized strings for the provided locale', () => {
+    expect(getHudString('tapToStart', 'fr')).toBe('Touchez pour commencer');
+  });
+
+  it('normalizes locale subtags when looking up dictionaries', () => {
+    expect(getHudString('bestLabel', 'fr-CA')).toBe('Record');
+  });
+
+  it('falls back to English for unsupported locales', () => {
+    expect(getHudString('scoreLabel', 'de')).toBe('Score');
+  });
+});

--- a/src/hud/hud-i18n.ts
+++ b/src/hud/hud-i18n.ts
@@ -1,0 +1,42 @@
+const ENGLISH_DICTIONARY = {
+  scoreLabel: 'Score',
+  bestLabel: 'Best',
+  tapToStart: 'Tap to start',
+} as const;
+
+export type HudStringKey = keyof typeof ENGLISH_DICTIONARY;
+
+type HudDictionary = Record<HudStringKey, string>;
+
+const FRENCH_DICTIONARY: HudDictionary = {
+  scoreLabel: 'Score',
+  bestLabel: 'Record',
+  tapToStart: 'Touchez pour commencer',
+};
+
+const DICTIONARIES: Record<string, HudDictionary> = {
+  en: ENGLISH_DICTIONARY,
+  fr: FRENCH_DICTIONARY,
+};
+
+const DEFAULT_LOCALE = 'en';
+const LOCALE_SEPARATOR_REGEX = /[-_]/;
+
+const normalizeLocale = (locale?: string): string => {
+  if (!locale) {
+    return DEFAULT_LOCALE;
+  }
+
+  const primarySubtag = locale.toLowerCase().split(LOCALE_SEPARATOR_REGEX)[0];
+
+  return primarySubtag || DEFAULT_LOCALE;
+};
+
+const getHudDictionary = (locale?: string): HudDictionary => {
+  const normalizedLocale = normalizeLocale(locale);
+
+  return DICTIONARIES[normalizedLocale] ?? ENGLISH_DICTIONARY;
+};
+
+export const getHudString = (key: HudStringKey, locale?: string): string =>
+  getHudDictionary(locale)[key];


### PR DESCRIPTION
## Summary
- add a HUD i18n helper that exposes a type-safe `getHudString` function
- seed English and French translations with locale normalization and fallback handling
- cover locale selection and key safety with new unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0618134f88328b59b1d913d34e809