### PR TITLE
Implement HUD score component with event-driven updates

### DIFF
--- a/src/hud/components/Score.test.ts
+++ b/src/hud/components/Score.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { Score, teardownScore } from "./Score";
+import { emitScoreEvent, resetHudEventBus } from "../events";
+import { formatScore } from "../utils/formatScore";
+
+describe("Score HUD component", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+  });
+
+  afterEach(() => {
+    resetHudEventBus();
+  });
+
+  it("renders the initial score", () => {
+    const controller = Score.mount(container);
+    expect(container.textContent).toBe(formatScore(0));
+    teardownScore(controller);
+  });
+
+  it("updates when a score event is emitted", () => {
+    const controller = Score.mount(container);
+
+    emitScoreEvent(42);
+
+    expect(container.textContent).toBe(formatScore(42));
+    teardownScore(controller);
+  });
+
+  it("stops reacting after teardown", () => {
+    const controller = Score.mount(container);
+
+    teardownScore(controller);
+    emitScoreEvent(15);
+
+    // The container is empty once destroyed; ensure the score is not re-added.
+    expect(container.textContent).toBe("");
+  });
+});

--- a/src/hud/components/Score.ts
+++ b/src/hud/components/Score.ts
@@ -1,0 +1,61 @@
+import { hudEventBus, type ScoreEvent } from "../events";
+import { formatScore } from "../utils/formatScore";
+
+export interface ScoreController {
+  /** Root element containing the rendered score. */
+  readonly element: HTMLElement;
+  /**
+   * Remove the component from the DOM and unsubscribe from HUD events.
+   * Safe to call multiple times.
+   */
+  destroy(): void;
+}
+
+function createScoreElement(initialScore: number): {
+  element: HTMLElement;
+  textNode: Text;
+} {
+  const element = document.createElement("span");
+  element.className = "hud-score";
+
+  const textNode = document.createTextNode(formatScore(initialScore));
+  element.append(textNode);
+
+  return { element, textNode };
+}
+
+function scheduleUpdate(textNode: Text, event: ScoreEvent): void {
+  // Update the text node directly to avoid layout reflows. This ensures the
+  // HUD stays responsive without triggering expensive DOM work.
+  textNode.nodeValue = formatScore(event.value);
+}
+
+export const Score = {
+  mount(container: HTMLElement): ScoreController {
+    const { element, textNode } = createScoreElement(0);
+
+    container.replaceChildren(element);
+
+    const unsubscribe = hudEventBus.on("score", (event) => {
+      scheduleUpdate(textNode, event);
+    });
+
+    let destroyed = false;
+
+    return {
+      element,
+      destroy() {
+        if (destroyed) return;
+        destroyed = true;
+        unsubscribe();
+        if (element.parentElement === container) {
+          container.removeChild(element);
+        }
+      },
+    };
+  },
+};
+
+export function teardownScore(controller: ScoreController | null | undefined): void {
+  controller?.destroy();
+}

--- a/src/hud/events.ts
+++ b/src/hud/events.ts
@@ -1,0 +1,61 @@
+export interface ScoreEvent {
+  /** The new score value reported by the game loop. */
+  value: number;
+}
+
+export interface HudEvents {
+  score: ScoreEvent;
+}
+
+type EventKey = keyof HudEvents;
+
+type Listener<K extends EventKey> = (payload: HudEvents[K]) => void;
+
+type ListenerRegistry = {
+  [K in EventKey]?: Set<Listener<K>>;
+};
+
+/**
+ * Minimal typed event bus for heads-up-display components. Components can
+ * subscribe to events and receive strongly typed payloads.
+ */
+class HudEventBus {
+  private listeners: ListenerRegistry = {};
+
+  on<K extends EventKey>(type: K, handler: Listener<K>): () => void {
+    const handlers = (this.listeners[type] ??= new Set());
+    handlers.add(handler);
+
+    return () => {
+      handlers.delete(handler);
+      if (handlers.size === 0) {
+        delete this.listeners[type];
+      }
+    };
+  }
+
+  emit<K extends EventKey>(type: K, payload: HudEvents[K]): void {
+    const handlers = this.listeners[type];
+    if (!handlers) return;
+
+    for (const handler of handlers) {
+      handler(payload);
+    }
+  }
+
+  clear(): void {
+    this.listeners = {};
+  }
+}
+
+export const hudEventBus = new HudEventBus();
+
+export function emitScoreEvent(value: number): void {
+  hudEventBus.emit("score", { value });
+}
+
+export function resetHudEventBus(): void {
+  hudEventBus.clear();
+}
+
+export type { HudEventBus };

--- a/src/hud/utils/formatScore.ts
+++ b/src/hud/utils/formatScore.ts
@@ -1,0 +1,13 @@
+/**
+ * Format a numeric score for HUD display. The function clamps negative and
+ * non-finite values to zero, floors fractional values, and pads the result
+ * to three digits so the UI remains stable as the score grows.
+ */
+export function formatScore(score: number): string {
+  if (!Number.isFinite(score) || score < 0) {
+    score = 0;
+  }
+
+  const rounded = Math.floor(score);
+  return rounded.toString().padStart(3, "0");
+}


### PR DESCRIPTION
## Summary
- add a HUD event bus with typed score events
- implement the score HUD component that renders and tears down cleanly
- provide a score formatter and tests that verify event-driven updates

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e061864a5c83289d11a580fdeb6d4a