### PR TITLE
Add HUD design tokens and refactor styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Flappy Bird 3D</title>
+    <link rel="stylesheet" href="./src/hud/styles/tokens.css" />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>

--- a/src/hud/styles/tokens.css
+++ b/src/hud/styles/tokens.css
@@ -1,0 +1,111 @@
+:root {
+  /* Typography */
+  --hud-font-family-sans: "Inter", "Segoe UI", system-ui, sans-serif;
+  --hud-font-weight-normal: 400;
+  --hud-font-weight-semibold: 600;
+  --hud-font-weight-bold: 700;
+  --hud-font-size-label: 0.75rem;
+  --hud-font-size-value: 2rem;
+  --hud-font-size-body: 1rem;
+  --hud-font-size-footer: 0.95rem;
+  --hud-font-size-kbd: 0.85em;
+  --hud-font-size-message-min: 1.25rem;
+  --hud-font-size-message-max: 1.75rem;
+  --hud-letter-spacing-label: 0.08em;
+  --hud-letter-spacing-button: 0.02em;
+
+  /* Spacing scale */
+  --hud-space-4xs: 2px;
+  --hud-space-3xs: 4px;
+  --hud-space-2xs: 6px;
+  --hud-space-xs: 8px;
+  --hud-space-sm: 12px;
+  --hud-space-md: 16px;
+  --hud-space-lg: 20px;
+  --hud-space-xl: 24px;
+  --hud-space-2xl: 32px;
+  --hud-space-3xl: 40px;
+
+  /* Radii */
+  --hud-radius-sm: 6px;
+  --hud-radius-md: 16px;
+  --hud-radius-lg: 18px;
+  --hud-radius-xl: 24px;
+  --hud-radius-pill: 999px;
+
+  /* Layout sizing */
+  --hud-size-layout-max: 960px;
+  --hud-size-metric-min: 96px;
+  --hud-size-metric-wide: 160px;
+  --hud-size-stage-max-width: 540px;
+  --hud-size-stage-max-height: 85vh;
+  --hud-size-speed-height: 12px;
+  --hud-size-kbd-radius: 6px;
+  --hud-width-mobile-stage: 92vw;
+  --hud-width-stage-responsive: 80vw;
+  --hud-size-panel-min: 240px;
+  --hud-aspect-stage: 1.5238;
+  --hud-border-width-default: 1px;
+
+  /* Colors */
+  --hud-color-text-primary: #0b1f33;
+  --hud-color-text-muted: rgba(11, 31, 51, 0.7);
+  --hud-color-text-inverse: #ffffff;
+  --hud-color-surface: rgba(255, 255, 255, 0.75);
+  --hud-color-surface-strong: rgba(255, 255, 255, 0.82);
+  --hud-color-surface-contrast: rgba(255, 255, 255, 0.65);
+  --hud-color-overlay-inner: rgba(255, 255, 255, 0.82);
+  --hud-color-overlay-outer: rgba(255, 255, 255, 0.45);
+  --hud-color-border-subtle: rgba(0, 0, 0, 0.08);
+  --hud-color-border-strong: rgba(15, 23, 42, 0.12);
+  --hud-color-stage-outline: rgba(15, 23, 42, 0.08);
+  --hud-color-sky-top: #89cff0;
+  --hud-color-sky-mid: #d0f4f4;
+  --hud-color-sky-base: #f9f9f9;
+  --hud-color-speed-track: rgba(15, 23, 42, 0.12);
+  --hud-color-speed-low: #22c55e;
+  --hud-color-speed-mid: #facc15;
+  --hud-color-speed-high: #ef4444;
+  --hud-color-button-bg: #2563eb;
+  --hud-color-button-text: #ffffff;
+  --hud-color-button-shadow: rgba(37, 99, 235, 0.28);
+  --hud-color-button-shadow-hover: rgba(37, 99, 235, 0.36);
+  --hud-color-kbd-bg: rgba(15, 23, 42, 0.9);
+  --hud-color-kbd-highlight: rgba(255, 255, 255, 0.18);
+  --hud-color-focus-outer: rgba(37, 99, 235, 0.3);
+  --hud-color-focus-inner: rgba(37, 99, 235, 0.6);
+
+  /* Shadows */
+  --hud-shadow-panel: 0 12px 30px rgba(15, 23, 42, 0.12);
+  --hud-shadow-stage: 0 30px 60px rgba(15, 23, 42, 0.18);
+  --hud-shadow-footer: 0 12px 24px rgba(15, 23, 42, 0.08);
+  --hud-shadow-button: 0 12px 24px var(--hud-color-button-shadow);
+  --hud-shadow-button-hover: 0 16px 28px var(--hud-color-button-shadow-hover);
+  --hud-shadow-kbd: inset 0 -2px 0 var(--hud-color-kbd-highlight);
+
+  /* Blur */
+  --hud-blur-panel: 12px;
+  --hud-blur-overlay: 4px;
+
+  /* Outline */
+  --hud-outline-focus-width: 4px;
+  --hud-outline-focus-inset: 1px;
+  --hud-outline-stage-width: 1px;
+
+  /* Motion */
+  --hud-duration-speed: 0.25s;
+  --hud-duration-button: 0.2s;
+  --hud-duration-instant: 0.01ms;
+  --hud-easing-default: ease;
+  --hud-easing-emphasized: ease-out;
+  --hud-translate-button-hover: -2px;
+  --hud-space-fluid-stage: 5vw;
+  --hud-space-fluid-stage-tight: 8vw;
+  --hud-space-fluid-message: 2vw;
+
+  /* Safe area */
+  --hud-safe-top: max(env(safe-area-inset-top), 0px);
+  --hud-safe-right: max(env(safe-area-inset-right), 0px);
+  --hud-safe-bottom: max(env(safe-area-inset-bottom), 0px);
+  --hud-safe-left: max(env(safe-area-inset-left), 0px);
+}

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,3 +1,5 @@
+import "../hud/styles/tokens.css";
+
 const noop = () => {};
 
 function resolveElement(element) {

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,7 @@
 :root {
   color-scheme: light;
-  --hud-bg: rgba(255, 255, 255, 0.75);
-  --hud-border: rgba(0, 0, 0, 0.08);
-  --hud-text: #0b1f33;
-  --accent: #ff9f1c;
-  --button-bg: #2563eb;
-  --button-text: #ffffff;
-  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  font-family: var(--hud-font-family-sans);
+  font-weight: var(--hud-font-weight-normal);
 }
 
 * {
@@ -20,64 +15,74 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: linear-gradient(180deg, #89cff0 0%, #d0f4f4 60%, #f9f9f9 100%);
+  background: linear-gradient(
+    180deg,
+    var(--hud-color-sky-top) 0%,
+    var(--hud-color-sky-mid) 60%,
+    var(--hud-color-sky-base) 100%
+  );
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
-  color: var(--hud-text);
+  padding: calc(var(--hud-space-xl) + var(--hud-safe-top))
+      calc(var(--hud-space-xl) + var(--hud-safe-right))
+      calc(var(--hud-space-xl) + var(--hud-safe-bottom))
+      calc(var(--hud-space-xl) + var(--hud-safe-left));
+  color: var(--hud-color-text-primary);
+  font-size: var(--hud-font-size-body);
 }
 
 .game-layout {
-  width: min(960px, 100%);
+  width: min(var(--hud-size-layout-max), 100%);
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(var(--hud-size-panel-min), 1fr));
+  gap: var(--hud-space-md);
   align-items: start;
 }
 
 .hud-panel {
-  backdrop-filter: blur(12px);
-  background: var(--hud-bg);
-  border: 1px solid var(--hud-border);
-  border-radius: 18px;
-  padding: 16px 20px;
+  backdrop-filter: blur(var(--hud-blur-panel));
+  background: var(--hud-color-surface);
+  border: var(--hud-border-width-default) solid var(--hud-color-border-subtle);
+  border-radius: var(--hud-radius-lg);
+  padding: var(--hud-space-md) var(--hud-space-lg);
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: var(--hud-space-md);
   justify-content: center;
-  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  box-shadow: var(--hud-shadow-panel);
 }
 
 .hud-metric {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  min-width: 96px;
+  gap: var(--hud-space-3xs);
+  min-width: var(--hud-size-metric-min);
 }
 
 .hud-metric--wide {
-  flex: 1 1 160px;
+  flex: 1 1 var(--hud-size-metric-wide);
 }
 
 .hud-label {
-  font-size: 0.75rem;
+  font-size: var(--hud-font-size-label);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(11, 31, 51, 0.7);
+  letter-spacing: var(--hud-letter-spacing-label);
+  color: var(--hud-color-text-muted);
+  font-weight: var(--hud-font-weight-semibold);
 }
 
 .hud-value {
-  font-size: 2rem;
-  font-weight: 700;
+  font-size: var(--hud-font-size-value);
+  font-weight: var(--hud-font-weight-bold);
 }
 
 .speed-meter {
   position: relative;
   width: 100%;
-  height: 12px;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.12);
+  height: var(--hud-size-speed-height);
+  border-radius: var(--hud-radius-pill);
+  background: var(--hud-color-speed-track);
   overflow: hidden;
 }
 
@@ -85,8 +90,13 @@ body {
   position: absolute;
   inset: 0;
   width: 0;
-  background: linear-gradient(90deg, #22c55e, #facc15, #ef4444);
-  transition: width 0.25s ease-out;
+  background: linear-gradient(
+    90deg,
+    var(--hud-color-speed-low),
+    var(--hud-color-speed-mid),
+    var(--hud-color-speed-high)
+  );
+  transition: width var(--hud-duration-speed) var(--hud-easing-emphasized);
 }
 
 .game-stage {
@@ -94,26 +104,29 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.65);
-  border-radius: 24px;
-  padding: clamp(12px, 5vw, 32px);
-  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.18);
+  background: var(--hud-color-surface-contrast);
+  border-radius: var(--hud-radius-xl);
+  padding: clamp(var(--hud-space-sm), var(--hud-space-fluid-stage), var(--hud-space-2xl));
+  box-shadow: var(--hud-shadow-stage);
 }
 
 #gameCanvas {
-  width: min(540px, 80vw);
-  height: calc(min(540px, 80vw) * 1.5238);
-  max-height: 85vh;
-  border-radius: 18px;
+  width: min(var(--hud-size-stage-max-width), var(--hud-width-stage-responsive));
+  height: calc(
+    min(var(--hud-size-stage-max-width), var(--hud-width-stage-responsive)) *
+      var(--hud-aspect-stage)
+  );
+  max-height: var(--hud-size-stage-max-height);
+  border-radius: var(--hud-radius-lg);
   outline: none;
   background: transparent;
-  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 0 0 var(--hud-outline-stage-width) var(--hud-color-stage-outline);
 }
 
 #gameCanvas:focus-visible {
   box-shadow:
-    0 0 0 4px rgba(37, 99, 235, 0.3),
-    inset 0 0 0 1px rgba(37, 99, 235, 0.6);
+    0 0 0 var(--hud-outline-focus-width) var(--hud-color-focus-outer),
+    inset 0 0 0 var(--hud-outline-focus-inset) var(--hud-color-focus-inner);
 }
 
 .game-overlay {
@@ -123,13 +136,17 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  background: radial-gradient(circle at 50% 30%, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.45));
-  backdrop-filter: blur(4px);
-  border-radius: 18px;
+  gap: var(--hud-space-md);
+  background: radial-gradient(
+    circle at 50% 30%,
+    var(--hud-color-overlay-inner),
+    var(--hud-color-overlay-outer)
+  );
+  backdrop-filter: blur(var(--hud-blur-overlay));
+  border-radius: var(--hud-radius-lg);
   text-align: center;
-  padding: 32px;
-  transition: opacity 0.3s ease;
+  padding: var(--hud-space-2xl);
+  transition: opacity var(--hud-duration-speed) var(--hud-easing-default);
 }
 
 .game-overlay.is-hidden {
@@ -138,53 +155,62 @@ body {
 }
 
 .game-message {
-  font-size: clamp(1.25rem, 2vw, 1.75rem);
+  font-size: clamp(
+    var(--hud-font-size-message-min),
+    var(--hud-space-fluid-message),
+    var(--hud-font-size-message-max)
+  );
   margin: 0;
 }
 
 .game-button {
-  background: var(--button-bg);
-  color: var(--button-text);
+  background: var(--hud-color-button-bg);
+  color: var(--hud-color-button-text);
   border: none;
-  border-radius: 999px;
-  padding: 12px 32px;
-  font-size: 1rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  border-radius: var(--hud-radius-pill);
+  padding: var(--hud-space-sm) var(--hud-space-2xl);
+  font-size: var(--hud-font-size-body);
+  font-weight: var(--hud-font-weight-semibold);
+  letter-spacing: var(--hud-letter-spacing-button);
   cursor: pointer;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--hud-shadow-button);
+  transition:
+    transform var(--hud-duration-button) var(--hud-easing-default),
+    box-shadow var(--hud-duration-button) var(--hud-easing-default);
 }
 
 .game-button:hover,
 .game-button:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.36);
+  transform: translateY(var(--hud-translate-button-hover));
+  box-shadow: var(--hud-shadow-button-hover);
 }
 
 .game-footer {
   grid-column: 1 / -1;
   text-align: center;
-  font-size: 0.95rem;
-  background: var(--hud-bg);
-  border: 1px solid var(--hud-border);
-  border-radius: 16px;
-  padding: 12px 18px;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  font-size: var(--hud-font-size-footer);
+  background: var(--hud-color-surface);
+  border: var(--hud-border-width-default) solid var(--hud-color-border-subtle);
+  border-radius: var(--hud-radius-md);
+  padding: var(--hud-space-sm) calc(var(--hud-space-lg) - var(--hud-space-4xs));
+  box-shadow: var(--hud-shadow-footer);
 }
 
 kbd {
-  background: rgba(15, 23, 42, 0.9);
-  color: #fff;
-  padding: 2px 8px;
-  border-radius: 6px;
-  font-size: 0.85em;
-  box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.18);
+  background: var(--hud-color-kbd-bg);
+  color: var(--hud-color-text-inverse);
+  padding: var(--hud-space-4xs) var(--hud-space-xs);
+  border-radius: var(--hud-size-kbd-radius);
+  font-size: var(--hud-font-size-kbd);
+  box-shadow: var(--hud-shadow-kbd);
 }
 
 @media (max-width: 768px) {
   body {
-    padding: 16px;
+    padding: calc(var(--hud-space-lg) + var(--hud-safe-top))
+        calc(var(--hud-space-lg) + var(--hud-safe-right))
+        calc(var(--hud-space-lg) + var(--hud-safe-bottom))
+        calc(var(--hud-space-lg) + var(--hud-safe-left));
   }
 
   .game-layout {
@@ -192,20 +218,26 @@ kbd {
   }
 
   .game-stage {
-    padding: clamp(8px, 8vw, 24px);
+    padding: clamp(
+      var(--hud-space-xs),
+      var(--hud-space-fluid-stage-tight),
+      var(--hud-space-2xl)
+    );
   }
 
   #gameCanvas {
-    width: min(100%, 92vw);
-    height: calc(min(100%, 92vw) * 1.5238);
+    width: min(100%, var(--hud-width-mobile-stage));
+    height: calc(
+      min(100%, var(--hud-width-mobile-stage)) * var(--hud-aspect-stage)
+    );
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
   * {
-    animation-duration: 0.01ms !important;
+    animation-duration: var(--hud-duration-instant) !important;
     animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    transition-duration: var(--hud-duration-instant) !important;
     scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- add a reusable HUD design token stylesheet defining typography, spacing, sizing, color, motion, and safe-area variables
- refactor the HUD layout CSS to rely on the shared tokens and expose the stylesheet to the static page
- import the token stylesheet from the HUD controller module so Vite bundles include the custom properties

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0617e46e8832889f8da5f845fca8c