### PR TITLE
Add HUD adapter and tests

### DIFF
--- a/src/hud/hud-adapter.test.ts
+++ b/src/hud/hud-adapter.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { publishSpy, isHudEnabledMock } = vi.hoisted(() => ({
+  publishSpy: vi.fn(),
+  isHudEnabledMock: vi.fn(() => true),
+}));
+
+vi.mock('./hud-bus', () => ({
+  publishHudEvent: publishSpy,
+  HUD_EVENTS: {
+    score: 'hud:score',
+    gameOver: 'hud:game-over',
+    pause: 'hud:pause',
+  },
+}));
+
+vi.mock('./hud-settings', () => ({
+  isHudEnabled: isHudEnabledMock,
+}));
+
+import { hud, onGameOver, onPause, onScore, type GameOverPayload } from './hud-adapter';
+import { HUD_EVENTS } from './hud-bus';
+
+describe('hud adapter', () => {
+  beforeEach(() => {
+    publishSpy.mockClear();
+    isHudEnabledMock.mockReturnValue(true);
+  });
+
+  it('publishes score deltas to the bus when enabled', () => {
+    onScore(3);
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith(HUD_EVENTS.score, { delta: 3 });
+  });
+
+  it('stops publishing when the HUD is disabled', () => {
+    isHudEnabledMock.mockReturnValue(false);
+
+    onScore(5);
+
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards game over payloads untouched', () => {
+    const payload: GameOverPayload = { score: 9, bestScore: 42, reason: 'test' };
+
+    onGameOver(payload);
+
+    expect(publishSpy).toHaveBeenCalledWith(HUD_EVENTS.gameOver, payload);
+  });
+
+  it('forwards pause state updates', () => {
+    onPause(true);
+
+    expect(publishSpy).toHaveBeenCalledWith(HUD_EVENTS.pause, { isPaused: true });
+  });
+
+  it('exposes namespaced helpers that reference the same implementations', () => {
+    expect(hud.onScore).toBe(onScore);
+    expect(hud.onGameOver).toBe(onGameOver);
+    expect(hud.onPause).toBe(onPause);
+  });
+});

--- a/src/hud/hud-adapter.ts
+++ b/src/hud/hud-adapter.ts
@@ -1,0 +1,48 @@
+import { HUD_EVENTS, HudEventName, publishHudEvent } from './hud-bus';
+import { isHudEnabled } from './hud-settings';
+
+export interface ScoreEventPayload {
+  delta: number;
+}
+
+export type GameOverPayload = {
+  score: number;
+  bestScore: number;
+  reason?: string;
+  [key: string]: unknown;
+};
+
+export interface PauseEventPayload {
+  isPaused: boolean;
+}
+
+function dispatchIfEnabled<EventName extends HudEventName, Payload>(
+  event: EventName,
+  payload: Payload
+): void {
+  if (!isHudEnabled()) {
+    return;
+  }
+
+  publishHudEvent(event, payload);
+}
+
+export function onScore(delta: number): void {
+  const payload: ScoreEventPayload = { delta };
+  dispatchIfEnabled(HUD_EVENTS.score, payload);
+}
+
+export function onGameOver(payload: GameOverPayload): void {
+  dispatchIfEnabled(HUD_EVENTS.gameOver, payload);
+}
+
+export function onPause(isPaused: boolean): void {
+  const payload: PauseEventPayload = { isPaused };
+  dispatchIfEnabled(HUD_EVENTS.pause, payload);
+}
+
+export const hud = {
+  onScore,
+  onGameOver,
+  onPause,
+} as const;

--- a/src/hud/hud-bus.ts
+++ b/src/hud/hud-bus.ts
@@ -1,0 +1,55 @@
+export const HUD_EVENTS = {
+  score: 'hud:score',
+  gameOver: 'hud:game-over',
+  pause: 'hud:pause',
+} as const;
+
+export type HudEventName = (typeof HUD_EVENTS)[keyof typeof HUD_EVENTS];
+
+export type HudEventHandler<Payload = unknown> = (payload: Payload) => void;
+
+const subscribers = new Map<HudEventName, Set<HudEventHandler>>();
+
+export function publishHudEvent<EventName extends HudEventName>(
+  event: EventName,
+  payload: Parameters<HudEventHandler>[0]
+): void {
+  const handlers = subscribers.get(event);
+  if (!handlers) {
+    return;
+  }
+
+  handlers.forEach((handler) => {
+    handler(payload);
+  });
+}
+
+export function subscribeToHudEvent<EventName extends HudEventName>(
+  event: EventName,
+  handler: HudEventHandler
+): () => void {
+  let handlers = subscribers.get(event);
+  if (!handlers) {
+    handlers = new Set();
+    subscribers.set(event, handlers);
+  }
+
+  handlers.add(handler);
+
+  return () => {
+    const currentHandlers = subscribers.get(event);
+    if (!currentHandlers) {
+      return;
+    }
+
+    currentHandlers.delete(handler);
+
+    if (currentHandlers.size === 0) {
+      subscribers.delete(event);
+    }
+  };
+}
+
+export function clearHudBus(): void {
+  subscribers.clear();
+}

--- a/src/hud/hud-settings.ts
+++ b/src/hud/hud-settings.ts
@@ -1,0 +1,9 @@
+let hudEnabled = true;
+
+export function isHudEnabled(): boolean {
+  return hudEnabled;
+}
+
+export function setHudEnabled(enabled: boolean): void {
+  hudEnabled = enabled;
+}


### PR DESCRIPTION
## Summary
- add a HUD adapter that forwards score, game over, and pause events to the HUD bus when enabled
- provide lightweight HUD bus and settings helpers to keep the adapter DOM-free and tree-shakable
- cover the adapter’s event forwarding logic with unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e061830a7c8328a9f724576b28b929