### PR TITLE
Add HUD z-index registry and layer assignments

### DIFF
--- a/src/hud/styles/z.css
+++ b/src/hud/styles/z.css
@@ -1,0 +1,12 @@
+/*
+  Z-index registry for HUD and overlay surfaces.
+  Higher values appear above gameplay surfaces like the canvas.
+*/
+:root {
+  --z-background: 0;
+  --z-game-canvas: 0;
+  --z-hud: 10;
+  --z-overlay: 20;
+  --z-tooltip: 30;
+  --z-modal: 40;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,13 @@
+@import "./src/hud/styles/z.css";
+
+/*
+  Stack order reference:
+  --z-game-canvas: base playfield surface.
+  --z-hud: persistent HUD chrome surrounding the stage.
+  --z-overlay: blocking overlays such as the intro/game-over screen.
+  --z-tooltip: transient affordances that must float above overlays.
+*/
+
 :root {
   color-scheme: light;
   --hud-bg: rgba(255, 255, 255, 0.75);
@@ -37,6 +47,8 @@ body {
 }
 
 .hud-panel {
+  position: relative;
+  z-index: var(--z-hud);
   backdrop-filter: blur(12px);
   background: var(--hud-bg);
   border: 1px solid var(--hud-border);
@@ -101,6 +113,8 @@ body {
 }
 
 #gameCanvas {
+  position: relative;
+  z-index: var(--z-game-canvas);
   width: min(540px, 80vw);
   height: calc(min(540px, 80vw) * 1.5238);
   max-height: 85vh;
@@ -130,6 +144,7 @@ body {
   text-align: center;
   padding: 32px;
   transition: opacity 0.3s ease;
+  z-index: var(--z-overlay);
 }
 
 .game-overlay.is-hidden {


### PR DESCRIPTION
## Summary
- add a HUD layering registry at `src/hud/styles/z.css`
- import the registry into the global stylesheet and document the expected stacking order
- apply the shared z-index variables to the HUD panel, canvas, and overlay so HUD layers render above the canvas

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e0618b0fac8328b6d89bc1b4731787