### PR TITLE
Add HUD layout playground

### DIFF
--- a/playgrounds/hud-layout.html
+++ b/playgrounds/hud-layout.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>HUD Layout Playground</title>
+    <link rel="stylesheet" href="../styles.css" />
+    <style>
+      body {
+        background: radial-gradient(circle at 50% 0%, #27213c 0%, #090b26 55%, #05040f 100%);
+      }
+
+      .game-stage__placeholder {
+        position: relative;
+        display: grid;
+        place-items: center;
+        flex: 1 1 auto;
+        border-radius: 1.25rem;
+        border: 2px dashed rgba(255, 255, 255, 0.2);
+        background: linear-gradient(
+          160deg,
+          rgba(255, 255, 255, 0.08) 0%,
+          rgba(255, 255, 255, 0.02) 60%,
+          rgba(255, 255, 255, 0.01) 100%
+        );
+        color: rgba(255, 255, 255, 0.6);
+        font-size: 1.125rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      .game-stage__placeholder::after {
+        content: "HUD Preview";
+      }
+
+      .game-playground {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 3rem;
+      }
+
+      .game-layout {
+        gap: 1.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="game-layout game-playground" aria-labelledby="playgroundTitle">
+      <header class="hud-panel" aria-label="Game dashboard">
+        <div class="hud-metric" aria-live="polite">
+          <span class="hud-label">Score</span>
+          <span id="scoreValue" class="hud-value">0</span>
+        </div>
+        <div class="hud-metric" aria-live="polite">
+          <span class="hud-label">Best</span>
+          <span id="bestValue" class="hud-value">0</span>
+        </div>
+        <div class="hud-metric hud-metric--wide">
+          <span class="hud-label">Speed</span>
+          <div
+            id="speedProgress"
+            class="speed-meter"
+            role="progressbar"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="0"
+            aria-label="Pipe speed"
+          >
+            <span id="speedFill" class="speed-meter__fill"></span>
+          </div>
+        </div>
+      </header>
+
+      <section class="game-stage" aria-label="HUD layout preview">
+        <div class="game-stage__placeholder" role="img" aria-label="HUD background placeholder"></div>
+        <div id="gameOverlay" class="game-overlay" aria-live="assertive">
+          <p id="gameMessage" class="game-message">Tap or press Space to start</p>
+          <button id="startButton" type="button" class="game-button">Play</button>
+        </div>
+      </section>
+
+      <footer class="game-footer" aria-live="polite">
+        <h1 id="playgroundTitle" class="hud-label" style="font-size: 1.5rem">HUD Layout Playground</h1>
+        <p>
+          This standalone playground mounts the HUD components with mock data so designers can iterate on layout and accessibility without the Three.js canvas.
+        </p>
+        <p>
+          Use the <strong>Play</strong> button to trigger a simulated round, or wait for it to start automatically.
+        </p>
+      </footer>
+    </main>
+
+    <script type="module" src="./hud-layout.ts"></script>
+  </body>
+</html>

--- a/playgrounds/hud-layout.ts
+++ b/playgrounds/hud-layout.ts
@@ -1,0 +1,95 @@
+import { createHudController } from "../src/rendering/index.js";
+
+type TimerHandle = number | undefined;
+
+const hud = createHudController({
+  score: "#scoreValue",
+  best: "#bestValue",
+  message: "#gameMessage",
+  overlay: "#gameOverlay",
+  startButton: "#startButton",
+  speedBar: "#speedFill",
+  speedProgress: "#speedProgress",
+});
+
+let bestScore = 24;
+let roundTimer: TimerHandle;
+let resetTimer: TimerHandle;
+let autoStartTimer: TimerHandle;
+
+const clearTimer = (handle: TimerHandle, cancel: (id: number) => void): TimerHandle => {
+  if (typeof handle === "number") {
+    cancel(handle);
+  }
+  return undefined;
+};
+
+const clearRoundTimer = () => {
+  roundTimer = clearTimer(roundTimer, window.clearInterval);
+};
+
+const clearResetTimer = () => {
+  resetTimer = clearTimer(resetTimer, window.clearTimeout);
+};
+
+const clearAutoStartTimer = () => {
+  autoStartTimer = clearTimer(autoStartTimer, window.clearTimeout);
+};
+
+const scheduleAutoStart = () => {
+  clearAutoStartTimer();
+  autoStartTimer = window.setTimeout(() => {
+    startDemoRound();
+  }, 3200);
+};
+
+const finishRound = (score: number) => {
+  bestScore = Math.max(bestScore, score);
+  hud.setBest(bestScore);
+  hud.showGameOver(score, bestScore);
+
+  resetTimer = window.setTimeout(() => {
+    hud.setScore(0);
+    hud.setSpeed(0);
+    hud.showIntro();
+    scheduleAutoStart();
+  }, 2200);
+};
+
+function startDemoRound() {
+  clearRoundTimer();
+  clearResetTimer();
+  clearAutoStartTimer();
+
+  hud.showRunning();
+
+  let score = 0;
+  let speed = 0;
+
+  roundTimer = window.setInterval(() => {
+    score += Math.floor(Math.random() * 3) + 1;
+    speed = Math.min(1, speed + 0.08 + Math.random() * 0.05);
+
+    hud.setScore(score);
+    hud.setSpeed(speed);
+
+    if (score >= 42) {
+      clearRoundTimer();
+      finishRound(score);
+    }
+  }, 850);
+}
+
+hud.setScore(0);
+hud.setBest(bestScore);
+hud.setSpeed(0);
+hud.showIntro();
+hud.onStart(startDemoRound);
+
+scheduleAutoStart();
+
+window.addEventListener("beforeunload", () => {
+  clearRoundTimer();
+  clearResetTimer();
+  clearAutoStartTimer();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,6 @@
     "noEmit": true,
     "types": ["vitest", "vite/client", "node"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "playgrounds/**/*"],
   "exclude": ["dist", "node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         birdPreview: resolve(__dirname, 'bird-preview.html'),
+        hudLayout: resolve(__dirname, 'playgrounds/hud-layout.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary
- add a HUD-only playground page for designers to iterate without the game canvas
- drive the HUD with scripted mock score, speed, and game-state events
- include the playground in the Vite multi-page build configuration and TypeScript project

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0618bc1248328bc802ad3f40463bd