### PR TITLE
Document HUD performance hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ npm run test
 npm run typecheck
 ```
 
+## HUD performance guidelines
+
+Documented HUD performance hints live in [docs/hud-perf.md](docs/hud-perf.md). Review the checklist before adjusting scoreboard, overlay, or control styles so frequent updates stay isolated from the rest of the layout.
+
 ## Production Build
 
 ```bash

--- a/docs/hud-perf.md
+++ b/docs/hud-perf.md
@@ -1,0 +1,22 @@
+# HUD Performance Notes
+
+The HUD (scoreboard, speed meter, and overlay) renders on top of the WebGL canvas and updates every frame. Lightweight layout and paint scopes help prevent HUD updates from triggering expensive reflows inside the rest of the page.
+
+## Current CSS hints
+
+- `.hud-panel` now opts into `contain: layout paint;` so score updates stay isolated from the surrounding layout grid.
+- `.speed-meter__fill` promotes to its own compositor layer via `transform: translateZ(0);` and declares `will-change: width;` to smooth rapid progress updates.
+- `.game-overlay` adds `contain: layout paint;` and `will-change: opacity;` to keep fade transitions inexpensive when showing or hiding the overlay.
+- `.game-button` declares `will-change: transform;` so hover/focus transforms can reuse the same compositor layer.
+
+## Implementation guidelines
+
+- Prefer `contain: layout paint;` (or stricter scopes) for HUD wrappers that update frequently but do not need to influence the page outside their bounds.
+- Reserve `will-change` for properties that change during gameplay (score, overlay opacity, progress indicators). Remove the hint if the animation or transition is removed to avoid holding unnecessary layers.
+- When animating width/opacity on HUD elements, pair the change with a no-op transform (e.g., `translateZ(0)`) if you observe jank. This can be toggled per-element instead of globally enabling GPU compositing.
+- Verify changes in DevTools’ Rendering and Performance panels: ensure frequent HUD updates no longer invalidate layout for the entire document and that compositor layers stay bounded to the HUD components.
+
+## Future considerations
+
+- If we add HUD popovers or tooltips, wrap them in containers with `contain: layout style;` and delay expensive shadow/blur effects until they are visible.
+- Measure the HUD with the Performance profiler before adding new CSS filters or heavy box-shadows; trim or wrap them in separate layers if they appear as hotspots.

--- a/styles.css
+++ b/styles.css
@@ -47,6 +47,7 @@ body {
   gap: 16px;
   justify-content: center;
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+  contain: layout paint;
 }
 
 .hud-metric {
@@ -87,6 +88,8 @@ body {
   width: 0;
   background: linear-gradient(90deg, #22c55e, #facc15, #ef4444);
   transition: width 0.25s ease-out;
+  will-change: width;
+  transform: translateZ(0);
 }
 
 .game-stage {
@@ -130,6 +133,8 @@ body {
   text-align: center;
   padding: 32px;
   transition: opacity 0.3s ease;
+  will-change: opacity;
+  contain: layout paint;
 }
 
 .game-overlay.is-hidden {
@@ -154,6 +159,7 @@ body {
   cursor: pointer;
   box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  will-change: transform;
 }
 
 .game-button:hover,


### PR DESCRIPTION
## Summary
- add containment and compositor hints to the HUD panel, overlay, progress meter, and call-to-action button
- document current HUD performance considerations in docs/hud-perf.md with guidance for future changes
- reference the new HUD performance notes from the project README

## Testing
- `npm run lint` *(fails: existing ESLint configuration reports parsing errors in TypeScript and generated assets that predate this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e0618c2cd88328a14ed46ad90a8ed1