### PR TITLE
Add combo toast HUD component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
 node_modules/
+coverage/
 public/assets/models/bird.glb
 public/assets/textures/bird_atlas.png

--- a/src/hud/components/ComboToast.test.ts
+++ b/src/hud/components/ComboToast.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ComboToast, HUD_COMBO } from "./ComboToast";
+
+describe("ComboToast", () => {
+  let comboToast: ComboToast;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.useFakeTimers();
+    comboToast = new ComboToast();
+  });
+
+  afterEach(() => {
+    comboToast.destroy();
+    vi.runOnlyPendingTimers();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("removes toast nodes after the animation completes", () => {
+    const detail = { streak: 4, bonus: 150 };
+    window.dispatchEvent(new CustomEvent(HUD_COMBO, { detail }));
+
+    const toast = document.querySelector<HTMLElement>(".combo-toast");
+    expect(toast).not.toBeNull();
+
+    toast?.dispatchEvent(new Event("animationend"));
+
+    expect(document.querySelector(".combo-toast")).toBeNull();
+  });
+});

--- a/src/hud/components/ComboToast.ts
+++ b/src/hud/components/ComboToast.ts
@@ -1,0 +1,128 @@
+import "../styles/combo-toast.css";
+
+export const HUD_COMBO = "HUD_COMBO" as const;
+
+export interface ComboToastEventDetail {
+  streak: number;
+  bonus?: number;
+  message?: string;
+}
+
+export type ComboToastEvent = CustomEvent<ComboToastEventDetail>;
+
+export interface ComboToastOptions {
+  host?: HTMLElement;
+  durationMs?: number;
+  formatMessage?: (detail: ComboToastEventDetail) => string;
+}
+
+const DEFAULT_DURATION_MS = 800;
+
+function defaultMessage(detail: ComboToastEventDetail): string {
+  if (detail.message && detail.message.trim().length > 0) {
+    return detail.message;
+  }
+
+  const safeStreak = Number.isFinite(detail.streak)
+    ? Math.max(1, Math.round(detail.streak))
+    : 1;
+  const streakLabel = `x${safeStreak} Combo!`;
+
+  if (detail.bonus && Number.isFinite(detail.bonus) && detail.bonus > 0) {
+    const bonusLabel = `+${Math.round(detail.bonus)}`;
+    return `${streakLabel} ${bonusLabel}`;
+  }
+
+  return streakLabel;
+}
+
+export class ComboToast {
+  private readonly host: HTMLElement;
+  private readonly container: HTMLElement;
+  private readonly timers = new Map<HTMLElement, number>();
+  private readonly handleComboBound: (event: Event) => void;
+  private readonly formatMessage: (detail: ComboToastEventDetail) => string;
+  private readonly duration: number;
+
+  constructor(options: ComboToastOptions = {}) {
+    if (typeof document === "undefined") {
+      throw new Error("ComboToast requires a DOM environment.");
+    }
+
+    this.host = options.host ?? document.body;
+    this.duration = Math.max(0, options.durationMs ?? DEFAULT_DURATION_MS);
+    this.formatMessage = options.formatMessage ?? defaultMessage;
+
+    this.container = document.createElement("div");
+    this.container.className = "combo-toast-layer";
+    this.container.setAttribute("aria-live", "polite");
+    this.container.setAttribute("aria-atomic", "false");
+    this.host.appendChild(this.container);
+
+    this.handleComboBound = (event: Event) => {
+      this.handleCombo(event as ComboToastEvent);
+    };
+
+    window.addEventListener(
+      HUD_COMBO,
+      this.handleComboBound as EventListener,
+      { passive: true }
+    );
+  }
+
+  private handleCombo(event: ComboToastEvent) {
+    const detail = event.detail;
+    if (!detail || !Number.isFinite(detail.streak)) {
+      return;
+    }
+
+    const toast = document.createElement("div");
+    toast.className = "combo-toast";
+    toast.textContent = this.formatMessage(detail);
+    toast.setAttribute("role", "status");
+    this.container.appendChild(toast);
+    this.container.classList.add("has-active-toast");
+
+    const cleanup = () => {
+      this.teardownToast(toast);
+    };
+
+    toast.addEventListener("animationend", cleanup, { once: true });
+
+    const fallbackId = window.setTimeout(cleanup, this.duration + 50);
+    this.timers.set(toast, fallbackId);
+  }
+
+  private teardownToast(toast: HTMLElement) {
+    const timerId = this.timers.get(toast);
+    if (typeof timerId === "number") {
+      window.clearTimeout(timerId);
+      this.timers.delete(toast);
+    }
+
+    toast.remove();
+
+    if (!this.container.childElementCount) {
+      this.container.classList.remove("has-active-toast");
+    }
+  }
+
+  destroy() {
+    window.removeEventListener(
+      HUD_COMBO,
+      this.handleComboBound as EventListener
+    );
+
+    this.timers.forEach((timeoutId, toast) => {
+      window.clearTimeout(timeoutId);
+      if (toast.isConnected) {
+        toast.remove();
+      }
+    });
+    this.timers.clear();
+
+    if (this.container.isConnected) {
+      this.container.remove();
+    }
+  }
+}

--- a/src/hud/styles/combo-toast.css
+++ b/src/hud/styles/combo-toast.css
@@ -1,0 +1,67 @@
+.combo-toast-layer {
+  position: fixed;
+  top: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+  z-index: 40;
+  min-width: 0;
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+
+.combo-toast-layer.has-active-toast {
+  opacity: 1;
+}
+
+.combo-toast {
+  --combo-toast-duration: 0.8s;
+  position: relative;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(22, 28, 45, 0.9);
+  color: #f7f9ff;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  box-shadow: 0 10px 28px rgba(12, 16, 31, 0.4);
+  animation: combo-toast-pop var(--combo-toast-duration) ease-out forwards;
+  will-change: transform, opacity;
+  opacity: 0;
+}
+
+.combo-toast::after {
+  content: "";
+  display: block;
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 0 24px rgba(255, 204, 102, 0.35);
+  opacity: 0.6;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+@keyframes combo-toast-pop {
+  0% {
+    transform: translateY(10px) scale(0.92);
+    opacity: 0;
+  }
+  12% {
+    transform: translateY(-6px) scale(1.04);
+    opacity: 1;
+  }
+  65% {
+    transform: translateY(-18px) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-32px) scale(0.94);
+    opacity: 0;
+  }
+}

--- a/src/types/imports.d.ts
+++ b/src/types/imports.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";


### PR DESCRIPTION
## Summary
- add a HUD ComboToast component that listens for the HUD_COMBO event and displays streak messages
- style combo toasts with floating/fading animation and timed cleanup
- cover the component with a unit test and add CSS module typing support

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0618d67cc8328b41ac5d473ac01ae