### PR TITLE
Add DangerBlink HUD component and tests

### DIFF
--- a/src/hud/components/DangerBlink.ts
+++ b/src/hud/components/DangerBlink.ts
@@ -1,0 +1,158 @@
+export const HUD_DANGER_EVENT = "HUD_DANGER" as const;
+
+export type DangerLevel = "none" | "low" | "medium" | "high" | "critical";
+
+export interface DangerEventDetail {
+  level: DangerLevel | number;
+}
+
+export interface DangerBlinkOptions {
+  eventTarget?: EventTarget;
+  initialLevel?: DangerLevel;
+}
+
+const DEFAULT_LEVEL: DangerLevel = "none";
+
+export const DANGER_LEVEL_CLASSES = {
+  none: "danger-blink--none",
+  low: "danger-blink--low",
+  medium: "danger-blink--medium",
+  high: "danger-blink--high",
+  critical: "danger-blink--critical",
+} as const satisfies Record<DangerLevel, string>;
+
+export const DANGER_LEVEL_INTENSITY = {
+  none: 0,
+  low: 0.3,
+  medium: 0.55,
+  high: 0.75,
+  critical: 1,
+} as const satisfies Record<DangerLevel, number>;
+
+const LEVELS = new Set<DangerLevel>(["none", "low", "medium", "high", "critical"]);
+
+let fallbackEventTarget: EventTarget | null = null;
+
+function getDefaultEventTarget(): EventTarget {
+  if (
+    typeof window !== "undefined" &&
+    window &&
+    typeof window.addEventListener === "function"
+  ) {
+    return window;
+  }
+
+  if (!fallbackEventTarget) {
+    fallbackEventTarget = new EventTarget();
+  }
+
+  return fallbackEventTarget;
+}
+
+function isDangerLevel(value: unknown): value is DangerLevel {
+  return typeof value === "string" && LEVELS.has(value as DangerLevel);
+}
+
+function normaliseLevel(value: unknown): DangerLevel | null {
+  if (isDangerLevel(value)) {
+    return value;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    if (value <= 0) return "none";
+    if (value < 2) return "low";
+    if (value < 3) return "medium";
+    if (value < 4) return "high";
+    return "critical";
+  }
+
+  return null;
+}
+
+export class DangerBlink {
+  private readonly element: HTMLElement;
+
+  private readonly eventTarget: EventTarget;
+
+  private readonly handleDangerBound: (event: Event) => void;
+
+  private currentLevel: DangerLevel = DEFAULT_LEVEL;
+
+  private readonly levelClasses: string[];
+
+  constructor(element: HTMLElement, options: DangerBlinkOptions = {}) {
+    if (!element) {
+      throw new Error("DangerBlink requires a target element");
+    }
+
+    this.element = element;
+    this.element.classList.add("danger-blink");
+    this.levelClasses = Object.values(DANGER_LEVEL_CLASSES);
+
+    this.eventTarget = options.eventTarget ?? getDefaultEventTarget();
+    this.handleDangerBound = this.handleDanger.bind(this);
+
+    this.eventTarget.addEventListener(HUD_DANGER_EVENT, this.handleDangerBound);
+
+    this.applyLevel(options.initialLevel ?? DEFAULT_LEVEL, true);
+  }
+
+  get level(): DangerLevel {
+    return this.currentLevel;
+  }
+
+  public setLevel(level: DangerLevel): void {
+    if (!isDangerLevel(level)) {
+      throw new Error(`Unsupported danger level: ${String(level)}`);
+    }
+
+    this.applyLevel(level);
+  }
+
+  public destroy(): void {
+    this.eventTarget.removeEventListener(
+      HUD_DANGER_EVENT,
+      this.handleDangerBound
+    );
+  }
+
+  private handleDanger(event: Event): void {
+    if (!(event instanceof CustomEvent)) {
+      return;
+    }
+
+    const detail = event.detail as Partial<DangerEventDetail> | null;
+    if (!detail) {
+      return;
+    }
+
+    const level = normaliseLevel(detail.level);
+    if (!level) {
+      return;
+    }
+
+    this.applyLevel(level);
+  }
+
+  private applyLevel(level: DangerLevel, force = false): void {
+    if (!force && level === this.currentLevel) {
+      return;
+    }
+
+    for (const className of this.levelClasses) {
+      this.element.classList.remove(className);
+    }
+
+    const levelClass = DANGER_LEVEL_CLASSES[level];
+    if (levelClass) {
+      this.element.classList.add(levelClass);
+    }
+
+    this.element.style.setProperty(
+      "--danger-blink-intensity",
+      DANGER_LEVEL_INTENSITY[level].toString()
+    );
+
+    this.currentLevel = level;
+  }
+}

--- a/src/hud/components/__tests__/DangerBlink.test.ts
+++ b/src/hud/components/__tests__/DangerBlink.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+
+import {
+  DANGER_LEVEL_CLASSES,
+  DANGER_LEVEL_INTENSITY,
+  DangerBlink,
+  HUD_DANGER_EVENT,
+} from "../DangerBlink";
+
+describe("DangerBlink", () => {
+  let container: HTMLElement;
+  let component: DangerBlink;
+  let eventTarget: EventTarget;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    eventTarget = new EventTarget();
+    component = new DangerBlink(container, { eventTarget });
+  });
+
+  afterEach(() => {
+    component.destroy();
+    container.remove();
+  });
+
+  it("initialises with the none level applied", () => {
+    expect(container.classList.contains("danger-blink")).toBe(true);
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.none)).toBe(true);
+    expect(component.level).toBe("none");
+    expect(
+      container.style.getPropertyValue("--danger-blink-intensity").trim()
+    ).toBe(String(DANGER_LEVEL_INTENSITY.none));
+  });
+
+  it("updates classes and intensity when receiving string levels", () => {
+    eventTarget.dispatchEvent(
+      new CustomEvent(HUD_DANGER_EVENT, { detail: { level: "medium" } })
+    );
+
+    expect(component.level).toBe("medium");
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.none)).toBe(false);
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.medium)).toBe(true);
+    expect(
+      container.style.getPropertyValue("--danger-blink-intensity").trim()
+    ).toBe(String(DANGER_LEVEL_INTENSITY.medium));
+
+    eventTarget.dispatchEvent(
+      new CustomEvent(HUD_DANGER_EVENT, { detail: { level: "critical" } })
+    );
+
+    expect(component.level).toBe("critical");
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.medium)).toBe(
+      false
+    );
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.critical)).toBe(
+      true
+    );
+    expect(
+      container.style.getPropertyValue("--danger-blink-intensity").trim()
+    ).toBe(String(DANGER_LEVEL_INTENSITY.critical));
+  });
+
+  it("normalises numeric payloads to the appropriate level", () => {
+    eventTarget.dispatchEvent(
+      new CustomEvent(HUD_DANGER_EVENT, { detail: { level: 2 } })
+    );
+
+    expect(component.level).toBe("medium");
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.medium)).toBe(true);
+
+    eventTarget.dispatchEvent(
+      new CustomEvent(HUD_DANGER_EVENT, { detail: { level: 4 } })
+    );
+
+    expect(component.level).toBe("critical");
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.critical)).toBe(
+      true
+    );
+  });
+
+  it("ignores unsupported payloads", () => {
+    eventTarget.dispatchEvent(
+      new CustomEvent(HUD_DANGER_EVENT, { detail: { level: "bogus" } })
+    );
+
+    expect(component.level).toBe("none");
+    expect(container.classList.contains(DANGER_LEVEL_CLASSES.none)).toBe(true);
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -6,6 +6,7 @@
   --accent: #ff9f1c;
   --button-bg: #2563eb;
   --button-text: #ffffff;
+  --danger-blink-duration: 1.1s;
   font-family: "Inter", "Segoe UI", system-ui, sans-serif;
 }
 
@@ -58,6 +59,55 @@ body {
 
 .hud-metric--wide {
   flex: 1 1 160px;
+}
+
+.danger-blink {
+  position: relative;
+  isolation: isolate;
+  --danger-blink-intensity: 0;
+  --danger-blink-color: rgba(239, 68, 68, 1);
+  --danger-blink-glow-radius: clamp(18px, 6vw, 40px);
+}
+
+.danger-blink::after {
+  content: "";
+  position: absolute;
+  inset: calc(var(--danger-blink-glow-radius) * -0.45);
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(circle, var(--danger-blink-color) 0%, transparent 70%);
+  opacity: calc(var(--danger-blink-intensity) * 0.85);
+  animation: danger-blink var(--danger-blink-duration) ease-in-out infinite;
+}
+
+@keyframes danger-blink {
+  0%,
+  100% {
+    opacity: calc(var(--danger-blink-intensity) * 0.2);
+  }
+  50% {
+    opacity: calc(var(--danger-blink-intensity) * 1);
+  }
+}
+
+.danger-blink--none {
+  --danger-blink-color: rgba(59, 130, 246, 0);
+}
+
+.danger-blink--low {
+  --danger-blink-color: rgba(250, 204, 21, 0.9);
+}
+
+.danger-blink--medium {
+  --danger-blink-color: rgba(249, 115, 22, 0.92);
+}
+
+.danger-blink--high {
+  --danger-blink-color: rgba(239, 68, 68, 0.95);
+}
+
+.danger-blink--critical {
+  --danger-blink-color: rgba(220, 38, 38, 1);
 }
 
 .hud-label {
@@ -207,5 +257,10 @@ kbd {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+
+  .danger-blink::after {
+    animation: none !important;
+    opacity: calc(var(--danger-blink-intensity) * 0.55);
   }
 }


### PR DESCRIPTION
## Summary
- add a HUD DangerBlink component that listens for HUD_DANGER events and maps payload levels to visual states
- introduce CSS variables and reduced motion friendly styling to drive the danger blink effect
- cover the component with unit tests to confirm string and numeric danger levels update classes

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e06190955c8328816a4e6f6a736d68