### PR TITLE
Add medal shelf HUD component with layout-stability tests

### DIFF
--- a/src/hud/__tests__/MedalShelf.test.ts
+++ b/src/hud/__tests__/MedalShelf.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { MedalShelf } from "../components/MedalShelf";
+import { DEFAULT_MEDALS, type HudState, type MedalId } from "../state";
+
+function createState(medals: readonly MedalId[] = []): HudState {
+  return { earnedMedals: medals };
+}
+
+function getSlots(shelf: MedalShelf) {
+  return Array.from(shelf.element.querySelectorAll<HTMLElement>(".medal-shelf__slot"));
+}
+
+describe("MedalShelf", () => {
+  it("renders the full complement of medal slots", () => {
+    const shelf = new MedalShelf();
+
+    const slots = getSlots(shelf);
+    expect(slots).toHaveLength(DEFAULT_MEDALS.length);
+    expect(shelf.element.getAttribute("role")).toBe("list");
+
+    slots.forEach((slot, index) => {
+      expect(slot.dataset.medal).toBe(DEFAULT_MEDALS[index]?.id);
+      expect(slot.dataset.earned).toBe("false");
+    });
+  });
+
+  it("only toggles attributes when medals are earned, avoiding layout shifts", () => {
+    const shelf = new MedalShelf();
+    const originalSlots = getSlots(shelf);
+
+    // Capture node references and markup so we can ensure structural stability.
+    const originalNodes = [...originalSlots];
+    const originalIcons = originalSlots.map((slot) =>
+      slot.querySelector<HTMLElement>(".medal-shelf__icon")
+    );
+    const originalLabels = originalSlots.map((slot) =>
+      slot.querySelector<HTMLElement>(".medal-shelf__sr-label")
+    );
+
+    shelf.update(createState(["bronze", "silver"]));
+    shelf.update(createState(["bronze", "silver", "gold"]));
+
+    const updatedSlots = getSlots(shelf);
+    expect(updatedSlots).toHaveLength(originalSlots.length);
+
+    updatedSlots.forEach((slot, index) => {
+      expect(slot).toBe(originalNodes[index]);
+      const icon = slot.querySelector(".medal-shelf__icon");
+      const label = slot.querySelector(".medal-shelf__sr-label");
+
+      expect(icon).toBe(originalIcons[index]);
+      expect(label).toBe(originalLabels[index]);
+    });
+  });
+
+  it("reflects medal status through accessibility attributes", () => {
+    const shelf = new MedalShelf();
+
+    shelf.update(createState(["gold"]));
+
+    const slots = getSlots(shelf);
+    const goldSlot = slots.find((slot) => slot.dataset.medal === "gold");
+    const bronzeSlot = slots.find((slot) => slot.dataset.medal === "bronze");
+
+    expect(goldSlot?.dataset.earned).toBe("true");
+    expect(goldSlot?.getAttribute("aria-label")).toBe("Gold medal earned");
+
+    expect(bronzeSlot?.dataset.earned).toBe("false");
+    expect(bronzeSlot?.getAttribute("aria-label")).toBe("Bronze medal locked");
+  });
+});

--- a/src/hud/components/MedalShelf.ts
+++ b/src/hud/components/MedalShelf.ts
@@ -1,0 +1,126 @@
+import {
+  DEFAULT_MEDALS,
+  type HudState,
+  type MedalDefinition,
+  type MedalId,
+  toMedalSet,
+} from "../state";
+import "../styles/medal-shelf.css";
+
+function resolveRoot(root?: HTMLElement | string): HTMLElement {
+  if (!root) {
+    return document.createElement("div");
+  }
+
+  if (typeof root === "string") {
+    const element = document.querySelector(root);
+    if (!element) {
+      throw new Error(`MedalShelf root selector \"${root}\" did not match an element.`);
+    }
+    if (!(element instanceof HTMLElement)) {
+      throw new Error("MedalShelf root selector must resolve to an HTMLElement.");
+    }
+    return element;
+  }
+
+  return root;
+}
+
+function buildSlot(definition: MedalDefinition): {
+  slot: HTMLElement;
+  srLabel: HTMLSpanElement;
+} {
+  const slot = document.createElement("div");
+  slot.className = "medal-shelf__slot";
+  slot.dataset.medal = definition.id;
+  slot.dataset.earned = "false";
+  slot.setAttribute("role", "listitem");
+  slot.setAttribute("aria-label", `${definition.label} locked`);
+
+  const icon = document.createElement("span");
+  icon.className = "medal-shelf__icon";
+  icon.textContent = definition.icon;
+  icon.setAttribute("aria-hidden", "true");
+
+  const srLabel = document.createElement("span");
+  srLabel.className = "medal-shelf__sr-label";
+  srLabel.textContent = `${definition.label} locked`;
+
+  slot.append(icon, srLabel);
+
+  return { slot, srLabel };
+}
+
+export interface MedalShelfOptions {
+  /**
+   * Optional root element (or selector) to hydrate. When omitted the shelf will
+   * create a new <div> container.
+   */
+  readonly root?: HTMLElement | string;
+  /**
+   * Overrides for the available medal definitions. Useful for testing or
+   * themed experiences.
+   */
+  readonly medals?: readonly MedalDefinition[];
+  /**
+   * When provided, the element receives an aria-label describing the shelf.
+   * Defaults to "Earned medals".
+   */
+  readonly label?: string;
+}
+
+export class MedalShelf {
+  readonly #root: HTMLElement;
+  readonly #definitions: readonly MedalDefinition[];
+  readonly #slots: Map<MedalId, HTMLElement> = new Map();
+  readonly #srLabels: Map<MedalId, HTMLSpanElement> = new Map();
+
+  constructor(options: MedalShelfOptions = {}) {
+    this.#root = resolveRoot(options.root);
+    this.#definitions = options.medals ?? DEFAULT_MEDALS;
+
+    this.#root.classList.add("medal-shelf");
+    this.#root.setAttribute("role", "list");
+    this.#root.setAttribute("aria-label", options.label ?? "Earned medals");
+
+    const fragment = document.createDocumentFragment();
+    for (const definition of this.#definitions) {
+      const { slot, srLabel } = buildSlot(definition);
+      fragment.append(slot);
+      this.#slots.set(definition.id, slot);
+      this.#srLabels.set(definition.id, srLabel);
+    }
+
+    this.#root.replaceChildren(fragment);
+  }
+
+  get element(): HTMLElement {
+    return this.#root;
+  }
+
+  update(state: HudState | undefined): void {
+    const medals = toMedalSet(state?.earnedMedals);
+
+    for (const definition of this.#definitions) {
+      const slot = this.#slots.get(definition.id);
+      if (!slot) continue;
+
+      const srLabel = this.#srLabels.get(definition.id);
+      const isEarned = medals.has(definition.id);
+      const earnedState = isEarned ? "true" : "false";
+
+      if (slot.dataset.earned !== earnedState) {
+        slot.dataset.earned = earnedState;
+      }
+
+      const statusText = `${definition.label} ${isEarned ? "earned" : "locked"}`;
+      if (slot.getAttribute("aria-label") !== statusText) {
+        slot.setAttribute("aria-label", statusText);
+      }
+
+      if (srLabel && srLabel.textContent !== statusText) {
+        srLabel.textContent = statusText;
+      }
+    }
+  }
+}

--- a/src/hud/state.ts
+++ b/src/hud/state.ts
@@ -1,0 +1,37 @@
+export type MedalId = "bronze" | "silver" | "gold" | "platinum";
+
+export interface HudState {
+  /**
+   * Collection of medals earned by the player. The component accepts either an
+   * array or a set for ergonomics when interfacing with immutable state
+   * containers.
+   */
+  readonly earnedMedals?: ReadonlySet<MedalId> | readonly MedalId[];
+}
+
+export interface MedalDefinition {
+  readonly id: MedalId;
+  readonly label: string;
+  readonly icon: string;
+}
+
+export const DEFAULT_MEDALS: readonly MedalDefinition[] = [
+  { id: "bronze", label: "Bronze medal", icon: "🥉" },
+  { id: "silver", label: "Silver medal", icon: "🥈" },
+  { id: "gold", label: "Gold medal", icon: "🥇" },
+  { id: "platinum", label: "Platinum trophy", icon: "🏆" },
+];
+
+export function toMedalSet(
+  medals: HudState["earnedMedals"]
+): ReadonlySet<MedalId> {
+  if (!medals) {
+    return new Set();
+  }
+
+  if (medals instanceof Set) {
+    return medals;
+  }
+
+  return new Set(medals);
+}

--- a/src/hud/styles/medal-shelf.css
+++ b/src/hud/styles/medal-shelf.css
@@ -1,0 +1,50 @@
+.medal-shelf {
+  --medal-slot-size: clamp(2.25rem, 8vw, 3rem);
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--medal-slot-size);
+  gap: clamp(0.5rem, 2vw, 0.875rem);
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0;
+}
+
+.medal-shelf__slot {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: var(--medal-slot-size);
+  height: var(--medal-slot-size);
+  border-radius: 999px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.15), rgba(0, 0, 0, 0.2));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  transition: transform 160ms ease, opacity 160ms ease, filter 160ms ease;
+}
+
+.medal-shelf__icon {
+  font-size: clamp(1.25rem, 4vw, 1.8rem);
+  line-height: 1;
+}
+
+.medal-shelf__slot[data-earned="true"] {
+  opacity: 1;
+  transform: scale(1.08);
+  filter: drop-shadow(0 0.35rem 0.55rem rgba(0, 0, 0, 0.35));
+}
+
+.medal-shelf__slot[data-earned="false"] {
+  opacity: 0.35;
+  filter: grayscale(0.85) contrast(0.8);
+}
+
+.medal-shelf__sr-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add HUD state helpers and default medal definitions
- implement a MedalShelf component that renders a stable row of medal slots with grid styling
- cover medal shelf updates with tests that assert DOM stability and accessibility metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e06196fa5c83289d398cacf014e217