### PR TITLE
Add HUD best score component with delta display

### DIFF
--- a/src/hud/components/BestScore.test.ts
+++ b/src/hud/components/BestScore.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { BestScore } from "./BestScore";
+
+describe("BestScore", () => {
+  it("renders a placeholder before the first score is available", () => {
+    const container = document.createElement("div");
+
+    const component = new BestScore({ element: container, document });
+
+    expect(component.element.textContent?.trim()).toBe("Best —");
+    const delta = component.element.querySelector<HTMLElement>(".best-score__delta");
+    expect(delta?.getAttribute("hidden")).toBe("true");
+  });
+
+  it("formats the delta when the best score improves", () => {
+    const container = document.createElement("div");
+    const component = new BestScore({ element: container, document });
+
+    component.update(42);
+    component.update(45);
+
+    expect(component.element.textContent?.trim()).toBe("Best 45 (+3)");
+    const delta = component.element.querySelector<HTMLElement>(".best-score__delta");
+    expect(delta?.textContent).toBe(" (+3)");
+  });
+});

--- a/src/hud/components/BestScore.ts
+++ b/src/hud/components/BestScore.ts
@@ -1,0 +1,152 @@
+import "../styles/best-score.css";
+
+export interface BestScoreOptions {
+  /**
+   * Target element that will host the component. When omitted, a fresh
+   * container element will be created.
+   */
+  element?: HTMLElement | string | null;
+  /**
+   * Accessible document reference. Defaults to the global document which is
+   * available in the browser and within the jsdom test environment.
+   */
+  document?: Document;
+  /**
+   * Custom label shown before the score value. Defaults to "Best".
+   */
+  label?: string;
+  /**
+   * Placeholder shown while no best score is available.
+   */
+  placeholder?: string;
+  /**
+   * Seed value for the best score, typically restored from persisted state.
+   */
+  initialBest?: number | null;
+  /**
+   * Optional formatter for score values.
+   */
+  formatValue?: (value: number) => string;
+}
+
+/**
+ * Normalizes numbers coming from game state or storage. The HUD only presents
+ * non-negative integers and gracefully falls back to `null` when the input is
+ * not finite.
+ */
+function normalizeScore(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const clamped = Math.max(0, value);
+  return Math.round(clamped);
+}
+
+function resolveElement(
+  element: HTMLElement | string | null | undefined,
+  doc: Document
+): HTMLElement {
+  if (!element) {
+    return doc.createElement("div");
+  }
+
+  if (typeof element === "string") {
+    const target = doc.querySelector<HTMLElement>(element);
+    if (!target) {
+      throw new Error(`BestScore: element selector \"${element}\" did not match any nodes`);
+    }
+    return target;
+  }
+
+  return element;
+}
+
+const DEFAULT_LABEL = "Best";
+const DEFAULT_PLACEHOLDER = "—";
+
+/**
+ * Displays the best score achieved in the current session and the delta versus
+ * the previous record when available (for example: "Best 42 (+3)").
+ */
+export class BestScore {
+  readonly element: HTMLElement;
+
+  private readonly valueEl: HTMLElement;
+  private readonly deltaEl: HTMLElement;
+  private readonly labelEl: HTMLElement;
+  private readonly placeholder: string;
+  private readonly formatValue: (value: number) => string;
+  private lastBest: number | null;
+
+  constructor(options: BestScoreOptions = {}) {
+    const doc = options.document ?? globalThis.document;
+    if (!doc) {
+      throw new Error("BestScore: a document instance is required");
+    }
+
+    this.element = resolveElement(options.element, doc);
+    this.element.classList.add("best-score");
+    this.element.setAttribute("role", "group");
+    this.element.setAttribute("aria-live", "polite");
+
+    this.placeholder = options.placeholder ?? DEFAULT_PLACEHOLDER;
+    this.formatValue = options.formatValue ?? ((value) => String(value));
+    this.lastBest = normalizeScore(options.initialBest ?? null);
+
+    this.labelEl = doc.createElement("span");
+    this.labelEl.className = "best-score__label";
+    this.labelEl.textContent = options.label ?? DEFAULT_LABEL;
+
+    this.valueEl = doc.createElement("span");
+    this.valueEl.className = "best-score__value";
+
+    this.deltaEl = doc.createElement("span");
+    this.deltaEl.className = "best-score__delta";
+    this.deltaEl.setAttribute("aria-hidden", "true");
+
+    this.element.replaceChildren(
+      this.labelEl,
+      doc.createTextNode(" "),
+      this.valueEl,
+      this.deltaEl
+    );
+
+    this.render(this.lastBest, null);
+  }
+
+  /**
+   * Updates the component with a new best score value.
+   */
+  update(nextBest: number | null | undefined): void {
+    const normalized = normalizeScore(nextBest);
+
+    if (normalized === null) {
+      this.lastBest = null;
+      this.render(null, null);
+      return;
+    }
+
+    const previous = this.lastBest;
+    const delta = previous !== null && normalized > previous ? normalized - previous : null;
+
+    this.render(normalized, delta);
+    this.lastBest = normalized;
+  }
+
+  private render(best: number | null, delta: number | null): void {
+    if (best === null) {
+      this.valueEl.textContent = this.placeholder;
+    } else {
+      this.valueEl.textContent = this.formatValue(best);
+    }
+
+    if (delta !== null && delta > 0) {
+      this.deltaEl.textContent = ` (+${this.formatValue(delta)})`;
+      this.deltaEl.removeAttribute("hidden");
+    } else {
+      this.deltaEl.textContent = "";
+      this.deltaEl.setAttribute("hidden", "true");
+    }
+  }
+}

--- a/src/hud/styles/best-score.css
+++ b/src/hud/styles/best-score.css
@@ -1,0 +1,35 @@
+.best-score {
+  display: inline-flex;
+  align-items: baseline;
+  font-weight: 600;
+  color: var(--hud-text, #0b1f33);
+}
+
+.best-score__label {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.72;
+}
+
+.best-score__value {
+  font-size: 1.5rem;
+  margin-left: 0.35rem;
+}
+
+.best-score__delta {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #16a34a;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.best-score__delta[hidden] {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .best-score__delta {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated BestScore HUD component that normalizes inputs and renders the score plus any positive delta
- style the component to align with the HUD palette and ensure the delta animates in when visible
- cover initial placeholder handling and delta formatting with new unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0619cd0d48328a8c538cadbc22007