### PR TITLE
feat(hud): add localized hints component

### DIFF
--- a/src/hud/components/Hints.test.ts
+++ b/src/hud/components/Hints.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getLocalizedHints, HINT_KEYS, translate } from '../hud-i18n';
+import { createHints } from './Hints';
+
+describe('HUD hints component', () => {
+  it('renders localized strings for the provided locale', () => {
+    const controller = createHints({ locale: 'es' });
+    const { element } = controller;
+
+    const heading = element.querySelector('h2');
+    expect(heading?.textContent).toBe(translate('es', 'hud.hints.title'));
+
+    const renderedHints = Array.from(element.querySelectorAll('li')).map((item) => item.textContent);
+    const expectedHints = getLocalizedHints('es').hints;
+
+    expect(renderedHints).toEqual(expectedHints);
+  });
+
+  it('ensures all defined hint keys resolve in every locale', () => {
+    const locales = ['en', 'es', 'fr'] as const;
+
+    for (const locale of locales) {
+      for (const key of HINT_KEYS) {
+        expect(translate(locale, key)).toMatch(/\w/);
+      }
+    }
+  });
+
+  it('respects the hints toggle visibility state', () => {
+    const controller = createHints({ hintsEnabled: false });
+
+    expect(controller.element.hidden).toBe(true);
+
+    controller.setHintsEnabled(true);
+    expect(controller.element.hidden).toBe(false);
+
+    controller.setHintsEnabled(false);
+    expect(controller.element.hidden).toBe(true);
+  });
+
+  it('hides itself when the user prefers reduced motion', () => {
+    const listeners: Array<(event: MediaQueryListEvent) => void> = [];
+    const mediaQueryList = {
+      matches: true,
+      addEventListener: (_: 'change', listener: (event: MediaQueryListEvent) => void) => {
+        listeners.push(listener);
+      },
+      removeEventListener: vi.fn(),
+    };
+
+    const matchMedia = vi.fn().mockReturnValue(mediaQueryList);
+
+    const controller = createHints({ matchMedia });
+
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+    expect(controller.element.hidden).toBe(true);
+
+    mediaQueryList.matches = false;
+    listeners.forEach((listener) =>
+      listener({ matches: false } as unknown as MediaQueryListEvent),
+    );
+
+    expect(controller.element.hidden).toBe(false);
+
+    controller.destroy();
+    expect(mediaQueryList.removeEventListener).toHaveBeenCalled();
+  });
+});

--- a/src/hud/components/Hints.ts
+++ b/src/hud/components/Hints.ts
@@ -1,0 +1,142 @@
+import { getLocalizedHints } from '../hud-i18n';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+type MediaQueryListLike = Pick<MediaQueryList, 'matches'> & {
+  addEventListener?: (type: 'change', listener: (event: MediaQueryListEvent) => void) => void;
+  removeEventListener?: (type: 'change', listener: (event: MediaQueryListEvent) => void) => void;
+  addListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+  removeListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+};
+
+export interface HintsOptions {
+  locale?: string | null;
+  document?: Document;
+  matchMedia?: (query: string) => MediaQueryListLike;
+  hintsEnabled?: boolean;
+}
+
+export interface HintsController {
+  element: HTMLElement;
+  setLocale: (locale: string | null) => void;
+  setHintsEnabled: (enabled: boolean) => void;
+  destroy: () => void;
+}
+
+function ensureDocument(doc?: Document): Document {
+  if (doc) {
+    return doc;
+  }
+
+  if (typeof document !== 'undefined') {
+    return document;
+  }
+
+  throw new Error('Hints component requires a document to render into.');
+}
+
+function setupMediaQuery(
+  matchMedia: ((query: string) => MediaQueryListLike) | undefined,
+  onChange: (matches: boolean) => void,
+): { list: MediaQueryListLike | null; teardown: () => void } {
+  if (!matchMedia) {
+    return { list: null, teardown: () => {} };
+  }
+
+  const list = matchMedia(REDUCED_MOTION_QUERY);
+  const handler = (event: MediaQueryListEvent) => {
+    onChange(event.matches);
+  };
+
+  if (list.addEventListener) {
+    list.addEventListener('change', handler);
+    return {
+      list,
+      teardown: () => {
+        list.removeEventListener?.('change', handler);
+      },
+    };
+  }
+
+  if (list.addListener) {
+    list.addListener(handler);
+    return {
+      list,
+      teardown: () => {
+        list.removeListener?.(handler);
+      },
+    };
+  }
+
+  return { list, teardown: () => {} };
+}
+
+export function createHints(options: HintsOptions = {}): HintsController {
+  const doc = ensureDocument(options.document);
+  const root = doc.createElement('section');
+  root.className = 'hud-hints';
+  root.setAttribute('role', 'note');
+
+  const heading = doc.createElement('h2');
+  heading.className = 'hud-hints__title';
+  const list = doc.createElement('ul');
+  list.className = 'hud-hints__list';
+
+  root.append(heading, list);
+
+  let currentLocale: string | null | undefined = options.locale ?? null;
+  let hintsEnabled = options.hintsEnabled ?? true;
+  let reducedMotion = false;
+
+  const renderHints = () => {
+    const { title, hints } = getLocalizedHints(currentLocale);
+    heading.textContent = title;
+
+    list.replaceChildren(
+      ...hints.map((hint) => {
+        const item = doc.createElement('li');
+        item.className = 'hud-hints__item';
+        item.textContent = hint;
+        return item;
+      }),
+    );
+  };
+
+  const applyVisibility = () => {
+    const shouldHide = reducedMotion || !hintsEnabled;
+    root.hidden = shouldHide;
+    root.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
+  };
+
+  const defaultMatchMedia =
+    options.matchMedia ?? (doc.defaultView?.matchMedia?.bind(doc.defaultView) as
+      | ((query: string) => MediaQueryListLike)
+      | undefined);
+
+  const { list: mediaQueryList, teardown } = setupMediaQuery(defaultMatchMedia, (matches) => {
+    reducedMotion = matches;
+    applyVisibility();
+  });
+
+  reducedMotion = Boolean(mediaQueryList?.matches);
+
+  renderHints();
+  applyVisibility();
+
+  return {
+    element: root,
+    setLocale(locale: string | null) {
+      currentLocale = locale;
+      renderHints();
+    },
+    setHintsEnabled(enabled: boolean) {
+      hintsEnabled = enabled;
+      applyVisibility();
+    },
+    destroy() {
+      teardown();
+    },
+  };
+}
+
+export default createHints;

--- a/src/hud/hud-i18n.ts
+++ b/src/hud/hud-i18n.ts
@@ -1,0 +1,80 @@
+const HUD_MESSAGES = {
+  en: {
+    'hud.hints.title': 'Flight academy',
+    'hud.hints.tap': 'Tap, click, or press Space to flap your wings.',
+    'hud.hints.restart': 'Press R or tap the Play button to restart after a crash.',
+    'hud.hints.speed': 'Keep an eye on the speed meter—pipes move faster as you survive.',
+    'hud.hints.focus': 'Stay centered between pipes to give yourself room for quick corrections.',
+  },
+  es: {
+    'hud.hints.title': 'Academia de vuelo',
+    'hud.hints.tap': 'Toca, haz clic o presiona la barra espaciadora para aletear.',
+    'hud.hints.restart': 'Presiona R o toca el botón de Jugar para reiniciar después de un choque.',
+    'hud.hints.speed': 'Mira el medidor de velocidad: los tubos se aceleran mientras sobrevives.',
+    'hud.hints.focus': 'Mantén el ave centrada entre los tubos para reaccionar con más margen.',
+  },
+  fr: {
+    'hud.hints.title': 'Académie du vol',
+    'hud.hints.tap': 'Touchez, cliquez ou appuyez sur Espace pour battre des ailes.',
+    'hud.hints.restart': 'Appuyez sur R ou sur le bouton Jouer pour recommencer après un crash.',
+    'hud.hints.speed': 'Surveillez le compteur de vitesse : les tuyaux accélèrent au fil du temps.',
+    'hud.hints.focus': 'Restez au centre entre les tuyaux pour garder une marge de manœuvre.',
+  },
+} as const;
+
+export const HINT_KEYS = [
+  'hud.hints.tap',
+  'hud.hints.restart',
+  'hud.hints.speed',
+  'hud.hints.focus',
+] as const;
+
+export type HintKey = (typeof HINT_KEYS)[number];
+export type HudLocale = keyof typeof HUD_MESSAGES;
+
+const DEFAULT_LOCALE: HudLocale = 'en';
+
+const SUPPORTED_LOCALES = Object.keys(HUD_MESSAGES) as HudLocale[];
+
+export function resolveLocale(input?: string | null): HudLocale {
+  if (!input) {
+    return DEFAULT_LOCALE;
+  }
+
+  const normalized = input.toLowerCase();
+  if (SUPPORTED_LOCALES.includes(normalized as HudLocale)) {
+    return normalized as HudLocale;
+  }
+
+  const [languageCode] = normalized.split('-');
+  if (SUPPORTED_LOCALES.includes(languageCode as HudLocale)) {
+    return languageCode as HudLocale;
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+export type HudMessageKey = HintKey | 'hud.hints.title';
+
+export function translate(locale: string | undefined, key: HudMessageKey): string {
+  const resolved = resolveLocale(locale);
+  const messages = HUD_MESSAGES[resolved];
+  const fallback = HUD_MESSAGES[DEFAULT_LOCALE];
+  return messages[key] ?? fallback[key];
+}
+
+export interface LocalizedHints {
+  title: string;
+  hints: string[];
+}
+
+export function getLocalizedHints(locale?: string | null): LocalizedHints {
+  return {
+    title: translate(locale ?? undefined, 'hud.hints.title'),
+    hints: HINT_KEYS.map((key) => translate(locale ?? undefined, key)),
+  };
+}
+
+export function getAvailableLocales(): HudLocale[] {
+  return [...SUPPORTED_LOCALES];
+}


### PR DESCRIPTION
## Summary
- add a HUD hints component that renders localized messaging and hides for reduced-motion preferences
- provide shared HUD hint translations for English, Spanish, and French
- cover localization resolution and visibility toggles with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e061a0f7148328a870f9305928e996