### PR TITLE
Add debounced ARIA announcer for score updates

### DIFF
--- a/src/components/AriaAnnouncer.test.ts
+++ b/src/components/AriaAnnouncer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { AriaAnnouncer } from "./AriaAnnouncer";
+
+describe("AriaAnnouncer", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("creates a polite live region", () => {
+    const announcer = new AriaAnnouncer();
+    expect(announcer.element.getAttribute("aria-live")).toBe("polite");
+    expect(announcer.element.getAttribute("role")).toBe("status");
+    expect(announcer.element.getAttribute("aria-atomic")).toBe("true");
+  });
+
+  it("debounces announcements to once per second", () => {
+    const announcer = new AriaAnnouncer();
+
+    announcer.announceScore(1);
+    expect(announcer.element.textContent).toBe("");
+
+    vi.advanceTimersByTime(999);
+    expect(announcer.element.textContent).toBe("");
+
+    vi.advanceTimersByTime(1);
+    expect(announcer.element.textContent).toBe("Score 1");
+
+    announcer.announceScore(2);
+    vi.advanceTimersByTime(500);
+
+    announcer.announceScore(3);
+    expect(announcer.element.textContent).toBe("Score 1");
+
+    vi.advanceTimersByTime(500);
+    expect(announcer.element.textContent).toBe("Score 3");
+  });
+
+  it("deduplicates identical score updates", () => {
+    const announcer = new AriaAnnouncer();
+
+    announcer.announceScore(10);
+    vi.advanceTimersByTime(1000);
+    expect(announcer.element.textContent).toBe("Score 10");
+
+    announcer.announceScore(10);
+    vi.advanceTimersByTime(1000);
+    expect(announcer.element.textContent).toBe("Score 10");
+
+    announcer.announceScore(11);
+    announcer.announceScore(11);
+    vi.advanceTimersByTime(1000);
+    expect(announcer.element.textContent).toBe("Score 11");
+  });
+});

--- a/src/components/AriaAnnouncer.ts
+++ b/src/components/AriaAnnouncer.ts
@@ -1,0 +1,91 @@
+const visuallyHiddenStyles = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: "0",
+  margin: "-1px",
+  overflow: "hidden",
+  clip: "rect(0 0 0 0)",
+  whiteSpace: "nowrap",
+  border: "0",
+} as const;
+
+export type AriaAnnouncerOptions = {
+  /**
+   * Duration in milliseconds to debounce announcements. Defaults to 1000ms.
+   */
+  debounceMs?: number;
+  /**
+   * Formatter applied to the score before announcing. Defaults to
+   * `Score <value>`.
+   */
+  formatMessage?: (score: number) => string;
+};
+
+export class AriaAnnouncer {
+  readonly element: HTMLDivElement;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private pendingScore: number | null = null;
+  private lastAnnouncedScore: number | null = null;
+  private readonly debounceMs: number;
+  private readonly formatMessage: (score: number) => string;
+
+  constructor({ debounceMs = 1000, formatMessage }: AriaAnnouncerOptions = {}) {
+    this.debounceMs = debounceMs;
+    this.formatMessage = formatMessage ?? ((score) => `Score ${score}`);
+
+    this.element = document.createElement("div");
+    this.element.setAttribute("aria-live", "polite");
+    this.element.setAttribute("role", "status");
+    this.element.setAttribute("aria-atomic", "true");
+
+    Object.assign(this.element.style, visuallyHiddenStyles);
+
+    // Ensure the live region is part of the accessibility tree.
+    document.body.appendChild(this.element);
+  }
+
+  announceScore(score: number) {
+    if (this.lastAnnouncedScore === score || this.pendingScore === score) {
+      return;
+    }
+
+    this.pendingScore = score;
+
+    if (this.timer) {
+      return;
+    }
+
+    this.timer = setTimeout(() => {
+      const scoreToAnnounce = this.pendingScore;
+      this.pendingScore = null;
+      this.timer = null;
+
+      if (scoreToAnnounce === null) {
+        return;
+      }
+
+      if (scoreToAnnounce === this.lastAnnouncedScore) {
+        return;
+      }
+
+      this.element.textContent = this.formatMessage(scoreToAnnounce);
+      this.lastAnnouncedScore = scoreToAnnounce;
+    }, this.debounceMs);
+  }
+
+  clear() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.pendingScore = null;
+  }
+
+  destroy() {
+    this.clear();
+    this.element.remove();
+  }
+}
+
+export default AriaAnnouncer;


### PR DESCRIPTION
## Summary
- add a reusable ARIA live region announcer that debounces score updates to once per second
- ensure polite live-region semantics and skip duplicate score announcements
- cover the new behaviour with Vitest, including debounce timing checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e061a2bf748328b8de28cacea82b88