### PR TITLE
Add pause menu HUD component

### DIFF
--- a/src/hud/HudRoot.ts
+++ b/src/hud/HudRoot.ts
@@ -1,0 +1,83 @@
+export type HudLayerName = string;
+
+export interface HudRootOptions {
+  host?: HTMLElement | string | null;
+  layers?: HudLayerName[];
+}
+
+function resolveHost(host?: HTMLElement | string | null): HTMLElement | null {
+  if (!host) {
+    return document.body;
+  }
+
+  if (typeof host === "string") {
+    return document.querySelector(host);
+  }
+
+  return host;
+}
+
+/**
+ * The HUD root manages DOM layering for overlays and modal components. It keeps
+ * a small registry of layers and ensures components can be mounted into the
+ * appropriate container without interfering with the rest of the layout.
+ */
+export class HudRoot {
+  private readonly host: HTMLElement;
+
+  private readonly root: HTMLDivElement;
+
+  private readonly layers = new Map<HudLayerName, HTMLDivElement>();
+
+  constructor(options: HudRootOptions = {}) {
+    const host = resolveHost(options.host);
+    if (!host) {
+      throw new Error("Unable to initialize HUD root: host element was not found.");
+    }
+
+    this.host = host;
+    this.root = document.createElement("div");
+    this.root.className = "hud-root";
+    this.host.appendChild(this.root);
+
+    const initialLayers = options.layers ?? ["base", "modal"];
+    initialLayers.forEach((layerName) => {
+      this.ensureLayer(layerName);
+    });
+  }
+
+  /** Returns the DOM element associated with the provided layer name. */
+  getLayer(name: HudLayerName): HTMLDivElement {
+    return this.ensureLayer(name);
+  }
+
+  /** Appends an element to the requested layer, creating it if needed. */
+  mount(element: HTMLElement, layerName: HudLayerName = "base") {
+    const layer = this.ensureLayer(layerName);
+    if (element.parentElement !== layer) {
+      layer.appendChild(element);
+    }
+  }
+
+  /** Removes the root and any layers from the DOM. */
+  destroy() {
+    this.layers.clear();
+    if (this.root.parentElement) {
+      this.root.parentElement.removeChild(this.root);
+    }
+  }
+
+  private ensureLayer(name: HudLayerName): HTMLDivElement {
+    const existing = this.layers.get(name);
+    if (existing) {
+      return existing;
+    }
+
+    const layer = document.createElement("div");
+    layer.className = `hud-layer hud-layer--${name}`;
+    layer.dataset.hudLayer = name;
+    this.layers.set(name, layer);
+    this.root.appendChild(layer);
+    return layer;
+  }
+}

--- a/src/hud/components/PauseMenu.test.ts
+++ b/src/hud/components/PauseMenu.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { PauseMenu, PauseMenuEvent } from "./PauseMenu";
+
+describe("PauseMenu", () => {
+  const dispatchTab = (target: HTMLElement, options: { shiftKey?: boolean } = {}) => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Tab",
+      code: "Tab",
+      bubbles: true,
+      cancelable: true,
+      shiftKey: options.shiftKey ?? false,
+    });
+    const origin =
+      document.activeElement instanceof HTMLElement ? document.activeElement : target;
+    origin.dispatchEvent(event);
+  };
+
+  it("traps focus within its buttons when tabbing forward and backward", () => {
+    const menu = new PauseMenu();
+    document.body.append(menu.element);
+
+    menu.open();
+
+    const resumeButton = menu.element.querySelector(
+      '[data-pause-menu-button="resume"]'
+    ) as HTMLButtonElement | null;
+    const muteButton = menu.element.querySelector(
+      '[data-pause-menu-button="mute"]'
+    ) as HTMLButtonElement | null;
+    const quitButton = menu.element.querySelector(
+      '[data-pause-menu-button="quit"]'
+    ) as HTMLButtonElement | null;
+
+    expect(document.activeElement).toBe(resumeButton);
+
+    dispatchTab(menu.element);
+    expect(document.activeElement).toBe(muteButton);
+
+    dispatchTab(menu.element);
+    expect(document.activeElement).toBe(quitButton);
+
+    dispatchTab(menu.element);
+    expect(document.activeElement).toBe(resumeButton);
+
+    dispatchTab(menu.element, { shiftKey: true });
+    expect(document.activeElement).toBe(quitButton);
+  });
+
+  it("publishes events for button actions", () => {
+    const events: string[] = [];
+    const menu = new PauseMenu();
+    document.body.append(menu.element);
+
+    menu.addEventListener(PauseMenuEvent.Resume, () => events.push("resume"));
+    menu.addEventListener(PauseMenuEvent.ToggleMute, (event) => {
+      events.push(event.detail?.muted ? "muted" : "unmuted");
+    });
+    menu.addEventListener(PauseMenuEvent.Quit, () => events.push("quit"));
+
+    menu.open();
+
+    const resumeButton = menu.element.querySelector(
+      '[data-pause-menu-button="resume"]'
+    ) as HTMLButtonElement | null;
+    const muteButton = menu.element.querySelector(
+      '[data-pause-menu-button="mute"]'
+    ) as HTMLButtonElement | null;
+    const quitButton = menu.element.querySelector(
+      '[data-pause-menu-button="quit"]'
+    ) as HTMLButtonElement | null;
+
+    resumeButton?.click();
+    muteButton?.click();
+    muteButton?.click();
+    quitButton?.click();
+
+    expect(events).toEqual(["resume", "muted", "unmuted", "quit"]);
+  });
+});

--- a/src/hud/components/PauseMenu.ts
+++ b/src/hud/components/PauseMenu.ts
@@ -1,0 +1,243 @@
+export const PauseMenuEvent = {
+  Open: "pause-menu:open",
+  Close: "pause-menu:close",
+  Resume: "pause-menu:resume",
+  ToggleMute: "pause-menu:toggle-mute",
+  Quit: "pause-menu:quit",
+} as const;
+
+export type PauseMenuEventName = (typeof PauseMenuEvent)[keyof typeof PauseMenuEvent];
+
+export interface PauseMenuOptions {
+  initialMuted?: boolean;
+  label?: string;
+  eventTarget?: EventTarget;
+}
+
+export interface PauseMenuToggleDetail {
+  muted: boolean;
+}
+
+export interface PauseMenuEventDetailMap {
+  [PauseMenuEvent.Open]: undefined;
+  [PauseMenuEvent.Close]: undefined;
+  [PauseMenuEvent.Resume]: undefined;
+  [PauseMenuEvent.Quit]: undefined;
+  [PauseMenuEvent.ToggleMute]: PauseMenuToggleDetail;
+}
+
+type PauseMenuEventListener<K extends PauseMenuEventName> = (
+  event: CustomEvent<PauseMenuEventDetailMap[K]>
+) => void;
+
+const buttonOrder = ["resume", "mute", "quit"] as const;
+type PauseMenuButtonId = (typeof buttonOrder)[number];
+
+function isFocusable(element: Element | null | undefined): element is HTMLElement {
+  return !!element && element instanceof HTMLElement && !element.hasAttribute("disabled");
+}
+
+export class PauseMenu {
+  readonly element: HTMLDivElement;
+
+  private readonly eventTarget: EventTarget;
+
+  private readonly buttons: Record<PauseMenuButtonId, HTMLButtonElement>;
+
+  private previouslyFocused: HTMLElement | null = null;
+
+  private isOpen = false;
+
+  private muted: boolean;
+
+  constructor(options: PauseMenuOptions = {}) {
+    this.eventTarget = options.eventTarget ?? new EventTarget();
+    this.muted = Boolean(options.initialMuted);
+
+    this.element = document.createElement("div");
+    this.element.className = "pause-menu";
+    this.element.setAttribute("role", "dialog");
+    this.element.setAttribute("aria-modal", "true");
+    this.element.setAttribute("aria-label", options.label ?? "Game paused");
+    this.element.hidden = true;
+    this.element.setAttribute("aria-hidden", "true");
+
+    const heading = document.createElement("h2");
+    heading.className = "pause-menu__title";
+    heading.textContent = options.label ?? "Paused";
+
+    const description = document.createElement("p");
+    description.className = "pause-menu__description";
+    description.textContent = "Take a breather or adjust your settings.";
+
+    const actions = document.createElement("div");
+    actions.className = "pause-menu__actions";
+
+    this.buttons = {
+      resume: this.createButton("Resume", "resume"),
+      mute: this.createButton("Mute", "mute"),
+      quit: this.createButton("Quit", "quit"),
+    };
+
+    actions.append(
+      this.buttons.resume,
+      this.buttons.mute,
+      this.buttons.quit
+    );
+
+    this.element.append(heading, description, actions);
+
+    this.updateMuteButton();
+
+    this.element.addEventListener("keydown", (event) => this.handleKeydown(event));
+  }
+
+  /** Adds an event listener for menu events. */
+  addEventListener<K extends PauseMenuEventName>(
+    type: K,
+    listener: PauseMenuEventListener<K>
+  ) {
+    this.eventTarget.addEventListener(type, listener as EventListener);
+  }
+
+  /** Removes a previously registered event listener. */
+  removeEventListener<K extends PauseMenuEventName>(
+    type: K,
+    listener: PauseMenuEventListener<K>
+  ) {
+    this.eventTarget.removeEventListener(type, listener as EventListener);
+  }
+
+  /** Opens the pause menu and traps focus within its buttons. */
+  open() {
+    if (this.isOpen) return;
+    this.isOpen = true;
+    this.previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    this.element.hidden = false;
+    this.element.setAttribute("aria-hidden", "false");
+    this.focusFirstButton();
+    this.publish(PauseMenuEvent.Open);
+  }
+
+  /** Closes the pause menu and restores focus to the previously focused element. */
+  close() {
+    if (!this.isOpen) return;
+    this.isOpen = false;
+    this.element.hidden = true;
+    this.element.setAttribute("aria-hidden", "true");
+
+    if (isFocusable(this.previouslyFocused) && document.contains(this.previouslyFocused)) {
+      this.previouslyFocused.focus();
+    }
+
+    this.publish(PauseMenuEvent.Close);
+  }
+
+  /** Updates the mute toggle state. */
+  setMuted(nextMuted: boolean) {
+    this.muted = Boolean(nextMuted);
+    this.updateMuteButton();
+  }
+
+  /** Returns whether the pause menu is currently open. */
+  isVisible() {
+    return this.isOpen;
+  }
+
+  /** Removes the menu element from the DOM. */
+  destroy() {
+    this.close();
+    if (this.element.parentElement) {
+      this.element.parentElement.removeChild(this.element);
+    }
+  }
+
+  private createButton(label: string, id: PauseMenuButtonId): HTMLButtonElement {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "game-button pause-menu__button";
+    button.dataset.pauseMenuButton = id;
+    button.textContent = label;
+    button.addEventListener("click", () => this.handleButtonActivate(id));
+    return button;
+  }
+
+  private handleButtonActivate(id: PauseMenuButtonId) {
+    switch (id) {
+      case "resume":
+        this.publish(PauseMenuEvent.Resume);
+        this.close();
+        break;
+      case "mute":
+        this.muted = !this.muted;
+        this.updateMuteButton();
+        this.publish(PauseMenuEvent.ToggleMute, { muted: this.muted });
+        break;
+      case "quit":
+        this.publish(PauseMenuEvent.Quit);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private focusFirstButton() {
+    const first = this.buttons.resume;
+    if (isFocusable(first)) {
+      first.focus();
+    }
+  }
+
+  private getFocusableButtons(): HTMLButtonElement[] {
+    return buttonOrder
+      .map((id) => this.buttons[id])
+      .filter((button) => isFocusable(button));
+  }
+
+  private handleKeydown(event: KeyboardEvent) {
+    if (!this.isOpen) return;
+
+    if (event.key === "Tab") {
+      const focusable = this.getFocusableButtons();
+      if (!focusable.length) {
+        return;
+      }
+
+      const currentIndex = focusable.indexOf(document.activeElement as HTMLButtonElement);
+      let nextIndex = currentIndex;
+
+      if (event.shiftKey) {
+        nextIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
+      } else {
+        nextIndex = currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+      }
+
+      event.preventDefault();
+      focusable[nextIndex]?.focus();
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      this.publish(PauseMenuEvent.Resume);
+      this.close();
+    }
+  }
+
+  private updateMuteButton() {
+    const muteButton = this.buttons.mute;
+    muteButton.setAttribute("aria-pressed", this.muted ? "true" : "false");
+    muteButton.textContent = this.muted ? "Unmute" : "Mute";
+  }
+
+  private publish<K extends PauseMenuEventName>(
+    type: K,
+    detail?: PauseMenuEventDetailMap[K]
+  ) {
+    const event = new CustomEvent(type, {
+      bubbles: false,
+      cancelable: false,
+      detail,
+    });
+    this.eventTarget.dispatchEvent(event);
+  }
+}

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,3 +1,6 @@
+import { HudRoot } from "../hud/HudRoot.ts";
+import { PauseMenu } from "../hud/components/PauseMenu.ts";
+
 const noop = () => {};
 
 function resolveElement(element) {
@@ -20,6 +23,11 @@ export function createHudController(elements = {}) {
   const startButton = resolveElement(elements.startButton ?? "#startButton");
   const speedBar = resolveElement(elements.speedBar ?? "#speedFill");
   const speedProgress = resolveElement(elements.speedProgress ?? "#speedProgress");
+
+  const hudRootHost = overlay?.parentElement ?? document.body;
+  const hudRoot = new HudRoot({ host: hudRootHost });
+  const pauseMenu = new PauseMenu();
+  hudRoot.mount(pauseMenu.element, "modal");
 
   const safeText = (target, value) => {
     if (!target) return;
@@ -77,5 +85,7 @@ export function createHudController(elements = {}) {
     onRestart(handler = noop) {
       startButton?.addEventListener("click", handler);
     },
+    pauseMenu,
+    hudRoot,
   };
 }

--- a/styles.css
+++ b/styles.css
@@ -137,6 +137,70 @@ body {
   pointer-events: none;
 }
 
+.hud-root {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 20;
+}
+
+.hud-layer {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.hud-layer--modal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pause-menu {
+  pointer-events: auto;
+  min-width: min(320px, 90%);
+  max-width: min(440px, 90%);
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  border-radius: 24px;
+  padding: 28px clamp(24px, 5vw, 36px);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.pause-menu[hidden] {
+  display: none;
+}
+
+.pause-menu__title {
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  margin: 0;
+}
+
+.pause-menu__description {
+  margin: 0;
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.pause-menu__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pause-menu__button {
+  width: 100%;
+  justify-content: center;
+}
+
+.pause-menu__button[aria-pressed="true"] {
+  background: rgba(37, 99, 235, 0.45);
+}
+
 .game-message {
   font-size: clamp(1.25rem, 2vw, 1.75rem);
   margin: 0;


### PR DESCRIPTION
## Summary
- add HUD root layering helper and pause menu component that dispatches HUD events instead of touching game systems directly
- wire the pause menu into the HUD controller and style it with accessible focus trapping and modal visuals
- cover keyboard navigation and event publishing behaviours with new Vitest coverage

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e061a0172c8328a85bb9880e7ea8d2