### PR TITLE
Add styled HUD final score component with formatting tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
 node_modules/
+coverage/
 public/assets/models/bird.glb
 public/assets/textures/bird_atlas.png

--- a/src/game/systems/loop.js
+++ b/src/game/systems/loop.js
@@ -47,10 +47,13 @@ function refreshHud() {
 
 function syncHighScore() {
   ensureState();
+  let didImprove = false;
   if (state.score > state.bestScore) {
     state.bestScore = state.score;
     persistBestScore(state.bestScore);
+    didImprove = true;
   }
+  return didImprove;
 }
 
 function showIntro() {
@@ -120,10 +123,10 @@ function endRound() {
   state.isRunning = false;
   state.gameOver = true;
   state.awaitingStart = true;
-  syncHighScore();
+  const isNewRecord = syncHighScore();
   refreshHud();
   if (hud) {
-    hud.showGameOver(state.score, state.bestScore);
+    hud.showGameOver(state.score, state.bestScore, { isNewRecord });
   }
   if (renderer) {
     renderer.markGameOver();

--- a/src/hud/components/FinalScore.ts
+++ b/src/hud/components/FinalScore.ts
@@ -1,0 +1,116 @@
+import { formatScore } from "../formatScore";
+import "../styles/final-score.css";
+
+export interface FinalScoreUpdateOptions {
+  /**
+   * When true, the component will show the celebratory badge indicating the
+   * player achieved a new personal best.
+   */
+  isRecord?: boolean;
+}
+
+export interface FinalScoreOptions {
+  /**
+   * Optional heading text displayed at the top of the score summary.
+   */
+  heading?: string;
+}
+
+interface MetricElements {
+  container: HTMLDivElement;
+  value: HTMLSpanElement;
+}
+
+export class FinalScore {
+  private readonly root: HTMLElement;
+  private readonly scoreValue: HTMLSpanElement;
+  private readonly bestValue: HTMLSpanElement;
+  private readonly badge: HTMLSpanElement;
+
+  constructor(options: FinalScoreOptions = {}) {
+    this.root = document.createElement("section");
+    this.root.className = "final-score";
+    this.root.hidden = true;
+    this.root.setAttribute("role", "status");
+    this.root.setAttribute("aria-live", "polite");
+
+    const title = document.createElement("h2");
+    title.className = "final-score__title";
+    title.textContent = options.heading ?? "Final score";
+    this.root.appendChild(title);
+
+    const metrics = document.createElement("div");
+    metrics.className = "final-score__metrics";
+
+    const scoreMetric = this.createMetric("Score");
+    this.scoreValue = scoreMetric.value;
+    metrics.appendChild(scoreMetric.container);
+
+    const bestMetric = this.createMetric("Best");
+    this.bestValue = bestMetric.value;
+    metrics.appendChild(bestMetric.container);
+
+    this.root.appendChild(metrics);
+
+    this.badge = document.createElement("span");
+    this.badge.className = "final-score__badge";
+    this.badge.textContent = "New personal best!";
+    this.badge.setAttribute("role", "note");
+    this.badge.hidden = true;
+    this.root.appendChild(this.badge);
+  }
+
+  private createMetric(label: string): MetricElements {
+    const container = document.createElement("div");
+    container.className = "final-score__metric";
+
+    const labelEl = document.createElement("span");
+    labelEl.className = "final-score__label";
+    labelEl.textContent = label;
+    container.appendChild(labelEl);
+
+    const value = document.createElement("span");
+    value.className = "final-score__value";
+    value.textContent = "0";
+    container.appendChild(value);
+
+    return { container, value };
+  }
+
+  /**
+   * Returns the DOM element representing the component. Useful for unit tests
+   * and direct DOM integration.
+   */
+  get element(): HTMLElement {
+    return this.root;
+  }
+
+  /**
+   * Appends the component to the given container. When a reference node is
+   * supplied, the component is inserted before it to preserve overlay layout.
+   */
+  attach(container: Element, before?: Element | null): void {
+    if (before) {
+      container.insertBefore(this.root, before);
+    } else {
+      container.appendChild(this.root);
+    }
+  }
+
+  setScores(score: number, best: number, options: FinalScoreUpdateOptions = {}): void {
+    this.scoreValue.textContent = formatScore(score);
+    this.bestValue.textContent = formatScore(best);
+
+    const isRecord = options.isRecord ?? (score > 0 && score >= best);
+    this.badge.hidden = !isRecord;
+    this.root.classList.toggle("final-score--record", isRecord);
+  }
+
+  show(): void {
+    this.root.hidden = false;
+  }
+
+  hide(): void {
+    this.root.hidden = true;
+  }
+}

--- a/src/hud/components/__tests__/FinalScore.test.ts
+++ b/src/hud/components/__tests__/FinalScore.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { FinalScore } from "../FinalScore";
+import { formatScore } from "../../formatScore";
+
+describe("formatScore", () => {
+  it("adds thousands separators for large scores", () => {
+    expect(formatScore(1234567)).toMatchInlineSnapshot('"1,234,567"');
+  });
+
+  it("clamps negative and non-finite values to zero", () => {
+    expect(formatScore(-42)).toMatchInlineSnapshot('"0"');
+    expect(formatScore(Number.NaN)).toMatchInlineSnapshot('"0"');
+    expect(formatScore(Number.POSITIVE_INFINITY)).toMatchInlineSnapshot('"0"');
+  });
+});
+
+describe("FinalScore", () => {
+  it("renders formatted metrics", () => {
+    const view = new FinalScore();
+    view.setScores(987654, 1234567);
+    view.show();
+
+    expect(view.element.outerHTML).toMatchInlineSnapshot(`
+      "<section class=\"final-score\" role=\"status\" aria-live=\"polite\"><h2 class=\"final-score__title\">Final score</h2><div class=\"final-score__metrics\"><div class=\"final-score__metric\"><span class=\"final-score__label\">Score</span><span class=\"final-score__value\">987,654</span></div><div class=\"final-score__metric\"><span class=\"final-score__label\">Best</span><span class=\"final-score__value\">1,234,567</span></div></div><span class=\"final-score__badge\" role=\"note\" hidden=\"\">New personal best!</span></section>"
+    `);
+  });
+
+  it("highlights new personal bests", () => {
+    const view = new FinalScore();
+    view.setScores(2222, 2222, { isRecord: true });
+    view.show();
+
+    expect(view.element.outerHTML).toMatchInlineSnapshot(`
+      "<section class=\"final-score final-score--record\" role=\"status\" aria-live=\"polite\"><h2 class=\"final-score__title\">Final score</h2><div class=\"final-score__metrics\"><div class=\"final-score__metric\"><span class=\"final-score__label\">Score</span><span class=\"final-score__value\">2,222</span></div><div class=\"final-score__metric\"><span class=\"final-score__label\">Best</span><span class=\"final-score__value\">2,222</span></div></div><span class=\"final-score__badge\" role=\"note\">New personal best!</span></section>"
+    `);
+  });
+});

--- a/src/hud/formatScore.ts
+++ b/src/hud/formatScore.ts
@@ -1,0 +1,18 @@
+const MAX_SAFE = Number.MAX_SAFE_INTEGER;
+
+function sanitizeScore(raw: number): number {
+  if (!Number.isFinite(raw)) {
+    return 0;
+  }
+
+  if (raw <= 0) {
+    return 0;
+  }
+
+  return Math.min(Math.floor(raw), MAX_SAFE);
+}
+
+export function formatScore(score: number): string {
+  const safeScore = sanitizeScore(score);
+  return safeScore.toLocaleString("en-US");
+}

--- a/src/hud/styles/final-score.css
+++ b/src/hud/styles/final-score.css
@@ -1,0 +1,91 @@
+.final-score {
+  width: min(360px, 100%);
+  margin-inline: auto;
+  padding: 1.25rem 1.5rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.78), rgba(15, 23, 42, 0.62));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow:
+    0 24px 48px rgba(15, 23, 42, 0.35),
+    0 0 0 1px rgba(15, 23, 42, 0.4);
+  color: #f8fafc;
+  text-align: center;
+}
+
+.final-score[hidden] {
+  display: none;
+}
+
+.final-score__title {
+  margin: 0;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.final-score__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.final-score__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.final-score__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(248, 250, 252, 0.72);
+}
+
+.final-score__value {
+  font-size: clamp(1.85rem, 4.5vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #ffffff;
+  text-shadow:
+    0 0 2px rgba(0, 0, 0, 0.55),
+    0 0 6px rgba(0, 0, 0, 0.45),
+    0 0 16px rgba(0, 0, 0, 0.35);
+  -webkit-text-stroke: 1px rgba(0, 0, 0, 0.35);
+}
+
+.final-score__badge {
+  margin-top: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+  background: linear-gradient(90deg, rgba(253, 224, 71, 0.28), rgba(250, 204, 21, 0.45));
+  color: #fefce8;
+  text-shadow: 0 0 12px rgba(15, 23, 42, 0.65);
+  box-shadow:
+    inset 0 0 0 1px rgba(253, 224, 71, 0.45),
+    0 10px 22px rgba(253, 224, 71, 0.3);
+}
+
+.final-score__badge[hidden] {
+  display: none;
+}
+
+.final-score--record {
+  border-color: rgba(253, 224, 71, 0.65);
+  box-shadow:
+    0 28px 60px rgba(253, 224, 71, 0.28),
+    0 0 0 1px rgba(253, 224, 71, 0.38);
+}
+
+.final-score--record .final-score__value {
+  color: #fef08a;
+}

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,3 +1,5 @@
+import { FinalScore } from "../hud/components/FinalScore.ts";
+
 const noop = () => {};
 
 function resolveElement(element) {
@@ -20,6 +22,12 @@ export function createHudController(elements = {}) {
   const startButton = resolveElement(elements.startButton ?? "#startButton");
   const speedBar = resolveElement(elements.speedBar ?? "#speedFill");
   const speedProgress = resolveElement(elements.speedProgress ?? "#speedProgress");
+  const finalScore = overlay ? new FinalScore() : null;
+
+  if (overlay && finalScore) {
+    finalScore.attach(overlay, startButton);
+    finalScore.hide();
+  }
 
   const safeText = (target, value) => {
     if (!target) return;
@@ -61,15 +69,29 @@ export function createHudController(elements = {}) {
     showIntro() {
       toggle(overlay, true);
       showMessage("Tap, click, or press Space to start");
+      finalScore?.hide();
+      if (startButton) {
+        startButton.textContent = "Play";
+      }
       toggle(startButton, true);
     },
     showRunning() {
       toggle(overlay, false);
+      finalScore?.hide();
     },
-    showGameOver(score, best) {
+    showGameOver(score, best, options = {}) {
       toggle(overlay, true);
-      showMessage(`Game over! Score: ${score} · Best: ${best}`);
+      showMessage("Game over! Tap or press Space to try again");
+      const isRecord =
+        typeof options.isNewRecord === "boolean"
+          ? options.isNewRecord
+          : score > 0 && score === best;
+      finalScore?.setScores(score, best, { isRecord });
+      finalScore?.show();
       toggle(startButton, true);
+      if (startButton) {
+        startButton.textContent = "Play again";
+      }
     },
     onStart(handler = noop) {
       startButton?.addEventListener("click", handler);


### PR DESCRIPTION
## Summary
- add a reusable FinalScore HUD component backed by a formatScore helper and high-contrast styles
- integrate the component into the HUD controller with improved high-score detection messaging
- add snapshot tests that verify score formatting and record highlighting

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0619bda04832899d9e4f522fc2d1d