### PR TITLE
Add HUD retry button component with cooldown and tests

### DIFF
--- a/src/hud/bus.ts
+++ b/src/hud/bus.ts
@@ -1,0 +1,39 @@
+export const HUD_RETRY = "HUD_RETRY" as const;
+
+export type HudEvent = typeof HUD_RETRY;
+
+export type HudEventHandler = () => void;
+
+class HudEventBus {
+  #listeners: Map<HudEvent, Set<HudEventHandler>> = new Map();
+
+  subscribe(event: HudEvent, handler: HudEventHandler): () => void {
+    const handlers = this.#listeners.get(event) ?? new Set();
+    handlers.add(handler);
+    this.#listeners.set(event, handlers);
+
+    return () => {
+      handlers.delete(handler);
+      if (handlers.size === 0) {
+        this.#listeners.delete(event);
+      }
+    };
+  }
+
+  publish(event: HudEvent): void {
+    const handlers = this.#listeners.get(event);
+    if (!handlers) {
+      return;
+    }
+
+    for (const handler of handlers) {
+      handler();
+    }
+  }
+
+  clear(): void {
+    this.#listeners.clear();
+  }
+}
+
+export const hudEventBus = new HudEventBus();

--- a/src/hud/components/RetryButton.test.ts
+++ b/src/hud/components/RetryButton.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { RetryButton } from "./RetryButton";
+import { HUD_RETRY, hudEventBus } from "../bus";
+
+describe("RetryButton", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    hudEventBus.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    hudEventBus.clear();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("disables itself for the cooldown duration after activation", () => {
+    const button = new RetryButton({ targetDocument: document });
+    document.body.appendChild(button.element);
+
+    const listener = vi.fn();
+    const unsubscribe = hudEventBus.subscribe(HUD_RETRY, listener);
+
+    button.element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(button.element.disabled).toBe(true);
+    expect(button.element.getAttribute("aria-disabled")).toBe("true");
+
+    vi.advanceTimersByTime(399);
+    expect(button.element.disabled).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(button.element.disabled).toBe(false);
+    expect(button.element.hasAttribute("aria-disabled")).toBe(false);
+
+    unsubscribe();
+    button.destroy();
+  });
+
+  it("prevents repeated retry events while on cooldown", () => {
+    const button = new RetryButton({ targetDocument: document, cooldownMs: 400 });
+    document.body.appendChild(button.element);
+
+    const listener = vi.fn();
+    const unsubscribe = hudEventBus.subscribe(HUD_RETRY, listener);
+
+    button.element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    button.element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(400);
+
+    button.element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    button.destroy();
+  });
+});

--- a/src/hud/components/RetryButton.ts
+++ b/src/hud/components/RetryButton.ts
@@ -1,0 +1,132 @@
+import { HUD_RETRY, hudEventBus } from "../bus";
+import "../styles/retry-button.css";
+
+export interface RetryButtonOptions {
+  /**
+   * Custom label for the button. Defaults to "Retry".
+   */
+  label?: string;
+  /**
+   * Accessible description announced to assistive technology.
+   */
+  ariaLabel?: string;
+  /**
+   * Duration of the disabled cooldown in milliseconds.
+   */
+  cooldownMs?: number;
+  /**
+   * Document instance used to create the button. Primarily useful for tests.
+   */
+  targetDocument?: Document;
+}
+
+const DEFAULT_COOLDOWN = 400;
+const ACTIVATION_KEYS = new Set(["Enter", "Space"]);
+
+type TimerView = Pick<typeof globalThis, "setTimeout" | "clearTimeout">;
+
+export class RetryButton {
+  readonly element: HTMLButtonElement;
+  private readonly cooldownMs: number;
+  private readonly view: TimerView;
+  private cooldownTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private isKeyboardActivation = false;
+
+  constructor(options: RetryButtonOptions = {}) {
+    const {
+      label = "Retry",
+      ariaLabel = "Retry the game",
+      cooldownMs = DEFAULT_COOLDOWN,
+      targetDocument = typeof document !== "undefined" ? document : undefined,
+    } = options;
+
+    if (!targetDocument) {
+      throw new Error("RetryButton requires a document to render");
+    }
+
+    const view = targetDocument.defaultView ?? globalThis;
+
+    this.cooldownMs = cooldownMs;
+    this.view = view as TimerView;
+    this.element = targetDocument.createElement("button");
+    this.element.type = "button";
+    this.element.classList.add("retry-button");
+    this.element.textContent = label;
+    this.element.setAttribute("aria-label", ariaLabel);
+
+    this.element.addEventListener("click", this.handleClick);
+    this.element.addEventListener("keydown", this.handleKeyDown);
+    this.element.addEventListener("keyup", this.handleKeyUp);
+  }
+
+  private readonly handleClick = (event: MouseEvent) => {
+    event.preventDefault();
+    this.activate();
+  };
+
+  private readonly handleKeyDown = (event: KeyboardEvent) => {
+    if (event.repeat) return;
+    if (!ACTIVATION_KEYS.has(event.code)) return;
+
+    this.isKeyboardActivation = true;
+    event.preventDefault();
+  };
+
+  private readonly handleKeyUp = (event: KeyboardEvent) => {
+    if (!this.isKeyboardActivation) return;
+    if (!ACTIVATION_KEYS.has(event.code)) return;
+
+    this.isKeyboardActivation = false;
+    event.preventDefault();
+    this.activate();
+  };
+
+  private activate(): void {
+    if (this.element.disabled) {
+      return;
+    }
+
+    hudEventBus.publish(HUD_RETRY);
+    this.startCooldown();
+  }
+
+  private startCooldown(): void {
+    this.element.disabled = true;
+    this.element.setAttribute("aria-disabled", "true");
+
+    if (this.cooldownTimer !== null) {
+      this.view.clearTimeout(this.cooldownTimer);
+    }
+
+    this.cooldownTimer = this.view.setTimeout(() => {
+      this.element.disabled = false;
+      this.element.removeAttribute("aria-disabled");
+      this.cooldownTimer = null;
+    }, this.cooldownMs);
+  }
+
+  destroy(): void {
+    this.element.removeEventListener("click", this.handleClick);
+    this.element.removeEventListener("keydown", this.handleKeyDown);
+    this.element.removeEventListener("keyup", this.handleKeyUp);
+    if (this.cooldownTimer !== null) {
+      this.view.clearTimeout(this.cooldownTimer);
+      this.cooldownTimer = null;
+    }
+  }
+}
+
+export function renderRetryButton(
+  container: Element,
+  options: RetryButtonOptions = {}
+): RetryButton {
+  const button = new RetryButton({
+    ...options,
+    targetDocument:
+      options.targetDocument ?? container.ownerDocument ?? document,
+  });
+  container.appendChild(button.element);
+  return button;
+}
+
+export { HUD_RETRY } from "../bus";

--- a/src/hud/styles/retry-button.css
+++ b/src/hud/styles/retry-button.css
@@ -1,0 +1,34 @@
+.retry-button {
+  appearance: none;
+  border: none;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #ffaf00, #ff6b00);
+  color: #1b1b1b;
+  font-weight: 600;
+  padding: 0.75rem 1.75rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.retry-button:disabled,
+.retry-button[aria-disabled="true"] {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.retry-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.25);
+}
+
+.retry-button:active:not(:disabled) {
+  transform: translateY(1px);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.2);
+}
+
+.retry-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.9);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px rgba(255, 111, 0, 0.45);
+}


### PR DESCRIPTION
## Summary
- add a HUD event bus and retry button component that emits `HUD_RETRY`, handles keyboard input, and enforces a 400ms cooldown
- include focus-visible styling for the retry button
- cover the retry button cooldown behaviour with Vitest tests

## Testing
- npm run test
- npm run typecheck *(fails: existing errors in prng.test.ts and three renderer assets types)*

------
https://chatgpt.com/codex/tasks/task_e_68e0619d464c8328afc31570db305893