### PR TITLE
Add HUD game over panel component with focus handling

### DIFF
--- a/src/hud/components/GameOverPanel.test.ts
+++ b/src/hud/components/GameOverPanel.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HUD_GAME_OVER, HUD_RUNNING } from '../constants';
+import { GameOverPanel } from './GameOverPanel';
+
+describe('GameOverPanel', () => {
+  let root: HTMLElement;
+  let title: HTMLElement;
+  let finalScore: HTMLElement;
+  let bestScore: HTMLElement;
+  let medalShelf: HTMLElement;
+  let buttons: HTMLElement;
+  let playAgain: HTMLButtonElement;
+  let quitButton: HTMLButtonElement;
+  let outsideButton: HTMLButtonElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="hudRoot" class="is-hidden" aria-hidden="true"></div>
+      <h2 id="gameOverTitle">Game Over</h2>
+      <output id="finalScore">0</output>
+      <output id="bestScore">0</output>
+      <div id="medalShelf"></div>
+      <div id="actionButtons">
+        <button id="playAgain" type="button">Play again</button>
+        <button id="quitButton" type="button">Quit</button>
+      </div>
+      <button id="outsideFocus" type="button">Outside</button>
+    `;
+
+    root = document.getElementById('hudRoot') as HTMLElement;
+    title = document.getElementById('gameOverTitle') as HTMLElement;
+    finalScore = document.getElementById('finalScore') as HTMLElement;
+    bestScore = document.getElementById('bestScore') as HTMLElement;
+    medalShelf = document.getElementById('medalShelf') as HTMLElement;
+    buttons = document.getElementById('actionButtons') as HTMLElement;
+    playAgain = document.getElementById('playAgain') as HTMLButtonElement;
+    quitButton = document.getElementById('quitButton') as HTMLButtonElement;
+    outsideButton = document.getElementById('outsideFocus') as HTMLButtonElement;
+  });
+
+  function createPanel(onDismiss?: () => void) {
+    return new GameOverPanel(
+      {
+        root,
+        title,
+        finalScore,
+        bestScore,
+        medalShelf,
+        buttons,
+      },
+      { onDismiss }
+    );
+  }
+
+  it('portals subcomponents into the HUD root when HUD_GAME_OVER is active', () => {
+    const panel = createPanel();
+    panel.sync(HUD_GAME_OVER, { score: 42, best: 128, medal: 'gold' });
+
+    expect(root.contains(title)).toBe(true);
+    expect(root.contains(finalScore)).toBe(true);
+    expect(root.contains(bestScore)).toBe(true);
+    expect(root.contains(medalShelf)).toBe(true);
+    expect(root.contains(buttons)).toBe(true);
+
+    expect(finalScore.textContent).toBe('42');
+    expect(bestScore.textContent).toBe('128');
+    expect(medalShelf.getAttribute('data-medal')).toBe('gold');
+    expect(root.classList.contains('is-hidden')).toBe(false);
+    expect(root.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('restores subcomponents when the panel is dismissed via a new HUD state', () => {
+    const panel = createPanel();
+    panel.sync(HUD_GAME_OVER, { score: 5, best: 10 });
+
+    expect(root.contains(title)).toBe(true);
+
+    panel.sync(HUD_RUNNING);
+
+    expect(root.contains(title)).toBe(false);
+    expect(document.body.contains(title)).toBe(true);
+    expect(document.body.contains(finalScore)).toBe(true);
+    expect(document.body.contains(bestScore)).toBe(true);
+    expect(document.body.contains(medalShelf)).toBe(true);
+    expect(document.body.contains(buttons)).toBe(true);
+    expect(root.classList.contains('is-hidden')).toBe(true);
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('invokes the dismiss callback when Escape is pressed and restores focus', () => {
+    const onDismiss = vi.fn();
+    const panel = createPanel(onDismiss);
+
+    outsideButton.focus();
+    expect(document.activeElement).toBe(outsideButton);
+
+    panel.sync(HUD_GAME_OVER, { score: 17, best: 30 });
+    expect(document.activeElement).toBe(playAgain);
+
+    const escapeEvent = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+    });
+    document.dispatchEvent(escapeEvent);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(outsideButton);
+    expect(root.contains(title)).toBe(false);
+  });
+
+  it('traps focus within the panel when Tab or Shift+Tab are pressed', () => {
+    const panel = createPanel();
+    panel.sync(HUD_GAME_OVER, { score: 1, best: 2 });
+
+    expect(document.activeElement).toBe(playAgain);
+
+    playAgain.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
+    );
+    expect(document.activeElement).toBe(quitButton);
+
+    quitButton.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true })
+    );
+    expect(document.activeElement).toBe(playAgain);
+
+    playAgain.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, shiftKey: true })
+    );
+    expect(document.activeElement).toBe(quitButton);
+  });
+});

--- a/src/hud/components/GameOverPanel.ts
+++ b/src/hud/components/GameOverPanel.ts
@@ -1,0 +1,327 @@
+import { HUD_GAME_OVER, type HudState } from '../constants';
+
+type ElementTarget = string | HTMLElement;
+
+export interface GameOverPanelElements {
+  root: ElementTarget;
+  title: ElementTarget;
+  finalScore: ElementTarget;
+  bestScore: ElementTarget;
+  medalShelf: ElementTarget;
+  buttons: ElementTarget;
+}
+
+export interface GameOverPanelOptions {
+  document?: Document;
+  onDismiss?: () => void;
+}
+
+export interface GameOverPayload {
+  score?: number | string;
+  best?: number | string;
+  medal?: string | null;
+}
+
+interface PortalRecord {
+  name: string;
+  element: HTMLElement;
+  placeholder: Comment | null;
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled]):not([tabindex="-1"])',
+  'textarea:not([disabled]):not([tabindex="-1"])',
+  'input:not([disabled]):not([tabindex="-1"])',
+  'select:not([disabled]):not([tabindex="-1"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function isHTMLElement(value: unknown, doc: Document): value is HTMLElement {
+  if (!value) {
+    return false;
+  }
+  const view = doc.defaultView ?? (globalThis as typeof globalThis | undefined);
+  if (view && 'HTMLElement' in view) {
+    return value instanceof (view as typeof window).HTMLElement;
+  }
+  return value instanceof HTMLElement;
+}
+
+function resolveElement(target: ElementTarget, doc: Document, name: string): HTMLElement {
+  if (typeof target === 'string') {
+    const found = doc.querySelector<HTMLElement>(target);
+    if (!found) {
+      throw new Error(`GameOverPanel: Unable to find ${name} element using selector "${target}".`);
+    }
+    return found;
+  }
+
+  if (isHTMLElement(target, doc)) {
+    return target;
+  }
+
+  throw new Error(`GameOverPanel: Invalid ${name} element.`);
+}
+
+function toText(value: number | string | undefined): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return typeof value === 'number' ? String(value) : value;
+}
+
+export class GameOverPanel {
+  private readonly doc: Document;
+
+  private readonly root: HTMLElement;
+
+  private readonly panel: HTMLElement;
+
+  private readonly portalItems: PortalRecord[];
+
+  private readonly finalScoreEl: HTMLElement;
+
+  private readonly bestScoreEl: HTMLElement;
+
+  private readonly medalShelfEl: HTMLElement;
+
+  private readonly buttonsEl: HTMLElement;
+
+  private readonly onDismiss?: () => void;
+
+  private isActive = false;
+
+  private previouslyFocused: HTMLElement | null = null;
+
+  private readonly keydownListener: (event: KeyboardEvent) => void;
+
+  constructor(elements: GameOverPanelElements, options: GameOverPanelOptions = {}) {
+    const doc = options.document ?? globalThis.document;
+    if (!doc) {
+      throw new Error('GameOverPanel requires a document instance.');
+    }
+
+    this.doc = doc;
+    this.root = resolveElement(elements.root, doc, 'root');
+    const titleEl = resolveElement(elements.title, doc, 'title');
+    this.finalScoreEl = resolveElement(elements.finalScore, doc, 'finalScore');
+    this.bestScoreEl = resolveElement(elements.bestScore, doc, 'bestScore');
+    this.medalShelfEl = resolveElement(elements.medalShelf, doc, 'medalShelf');
+    this.buttonsEl = resolveElement(elements.buttons, doc, 'buttons');
+
+    this.panel = doc.createElement('div');
+    this.panel.className = 'hud-game-over-panel';
+    this.panel.setAttribute('role', 'dialog');
+    this.panel.setAttribute('aria-modal', 'true');
+    this.panel.setAttribute('aria-label', 'Game over summary');
+    this.panel.tabIndex = -1;
+
+    this.portalItems = [
+      { name: 'title', element: titleEl, placeholder: null },
+      { name: 'finalScore', element: this.finalScoreEl, placeholder: null },
+      { name: 'bestScore', element: this.bestScoreEl, placeholder: null },
+      { name: 'medalShelf', element: this.medalShelfEl, placeholder: null },
+      { name: 'buttons', element: this.buttonsEl, placeholder: null },
+    ];
+
+    this.onDismiss = options.onDismiss;
+    this.keydownListener = (event: KeyboardEvent) => this.handleKeydown(event);
+  }
+
+  sync(state: HudState, payload?: GameOverPayload): void {
+    if (state === HUD_GAME_OVER) {
+      this.show(payload);
+    } else {
+      this.hide();
+    }
+  }
+
+  destroy(): void {
+    this.hide();
+    for (const record of this.portalItems) {
+      if (record.placeholder?.parentNode) {
+        record.placeholder.parentNode.insertBefore(record.element, record.placeholder);
+        record.placeholder.remove();
+        record.placeholder = null;
+      }
+    }
+  }
+
+  private show(payload?: GameOverPayload): void {
+    if (this.isActive) {
+      this.updateContent(payload);
+      return;
+    }
+
+    this.ensurePortals();
+    if (!this.panel.isConnected) {
+      this.root.appendChild(this.panel);
+    }
+
+    for (const record of this.portalItems) {
+      this.panel.appendChild(record.element);
+    }
+
+    this.root.classList.remove('is-hidden');
+    this.root.removeAttribute('aria-hidden');
+
+    this.updateContent(payload);
+
+    this.previouslyFocused = this.doc.activeElement as HTMLElement | null;
+    this.doc.addEventListener('keydown', this.keydownListener, true);
+    this.isActive = true;
+    this.focusInitialElement();
+  }
+
+  private hide(): void {
+    if (!this.isActive) {
+      return;
+    }
+
+    this.doc.removeEventListener('keydown', this.keydownListener, true);
+    this.restorePortals();
+    if (this.panel.parentNode) {
+      this.panel.parentNode.removeChild(this.panel);
+    }
+
+    if (this.root.childElementCount === 0) {
+      this.root.setAttribute('aria-hidden', 'true');
+      this.root.classList.add('is-hidden');
+    }
+
+    if (this.previouslyFocused && typeof this.previouslyFocused.focus === 'function') {
+      try {
+        this.previouslyFocused.focus();
+      } catch (error) {
+        // Swallow focus errors to avoid breaking dismissal.
+      }
+    }
+
+    this.previouslyFocused = null;
+    this.isActive = false;
+  }
+
+  private dismiss(): void {
+    if (!this.isActive) {
+      return;
+    }
+    this.hide();
+    this.onDismiss?.();
+  }
+
+  private ensurePortals(): void {
+    for (const record of this.portalItems) {
+      if (record.placeholder || !record.element.parentNode) {
+        continue;
+      }
+      const placeholder = this.doc.createComment(`portal:${record.name}`);
+      record.element.parentNode.insertBefore(placeholder, record.element);
+      record.placeholder = placeholder;
+    }
+  }
+
+  private restorePortals(): void {
+    for (const record of this.portalItems) {
+      if (record.placeholder?.parentNode) {
+        record.placeholder.parentNode.insertBefore(record.element, record.placeholder);
+      }
+    }
+  }
+
+  private updateContent(payload?: GameOverPayload): void {
+    if (!payload) {
+      return;
+    }
+    if (payload.score !== undefined) {
+      this.finalScoreEl.textContent = toText(payload.score);
+    }
+    if (payload.best !== undefined) {
+      this.bestScoreEl.textContent = toText(payload.best);
+    }
+    if ('medal' in payload) {
+      if (payload.medal) {
+        this.medalShelfEl.setAttribute('data-medal', payload.medal);
+      } else {
+        this.medalShelfEl.removeAttribute('data-medal');
+      }
+    }
+  }
+
+  private focusInitialElement(): void {
+    const focusables = this.getFocusableElements();
+    const target = focusables[0] ?? this.panel;
+    target.focus();
+  }
+
+  private getFocusableElements(): HTMLElement[] {
+    if (!this.isActive) {
+      return [];
+    }
+
+    const candidates = Array.from(
+      this.panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+    );
+
+    const focusables = candidates.filter((element) => {
+      if (element.getAttribute('aria-hidden') === 'true') {
+        return false;
+      }
+      if (element.hasAttribute('disabled')) {
+        return false;
+      }
+      if (element.tabIndex < 0) {
+        return false;
+      }
+      return true;
+    });
+
+    if (focusables.length === 0 && this.panel.tabIndex >= 0) {
+      focusables.push(this.panel);
+    }
+
+    return focusables;
+  }
+
+  private handleKeydown(event: KeyboardEvent): void {
+    if (!this.isActive) {
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.dismiss();
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusables = this.getFocusableElements();
+    if (focusables.length === 0) {
+      event.preventDefault();
+      this.panel.focus();
+      return;
+    }
+
+    const activeElement = this.doc.activeElement as HTMLElement | null;
+    let currentIndex = activeElement ? focusables.indexOf(activeElement) : -1;
+    if (currentIndex === -1) {
+      currentIndex = event.shiftKey ? 0 : focusables.length - 1;
+    }
+
+    let nextIndex = currentIndex + (event.shiftKey ? -1 : 1);
+    if (nextIndex < 0) {
+      nextIndex = focusables.length - 1;
+    }
+    if (nextIndex >= focusables.length) {
+      nextIndex = 0;
+    }
+
+    event.preventDefault();
+    focusables[nextIndex].focus();
+  }
+}
+
+export default GameOverPanel;

--- a/src/hud/constants.ts
+++ b/src/hud/constants.ts
@@ -1,0 +1,8 @@
+export const HUD_INTRO = 'HUD_INTRO';
+export const HUD_RUNNING = 'HUD_RUNNING';
+export const HUD_GAME_OVER = 'HUD_GAME_OVER';
+
+export type HudState =
+  | typeof HUD_INTRO
+  | typeof HUD_RUNNING
+  | typeof HUD_GAME_OVER;


### PR DESCRIPTION
## Summary
- add HUD state constants for intro, running, and game over views
- implement a GameOverPanel controller that portals HUD subcomponents, updates scores, and manages focus dismissal behavior
- cover the new panel with integration tests verifying HUD_GAME_OVER rendering, dismissal, and focus trapping

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0619eb674832892635748971e09c0