### PR TITLE
Add pause badge HUD component and styles

### DIFF
--- a/src/hud/components/PauseBadge.test.ts
+++ b/src/hud/components/PauseBadge.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { HUD_GAME_OVER, HUD_PAUSE } from "../events";
+import { PauseBadge } from "./PauseBadge";
+
+describe("PauseBadge", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<header class="hud-panel"></header>';
+  });
+
+  it("is hidden by default", () => {
+    const badge = new PauseBadge();
+    expect(badge.element.classList.contains("is-hidden")).toBe(true);
+    expect(badge.element.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("shows when paused and hides when resumed", () => {
+    const badge = new PauseBadge();
+
+    window.dispatchEvent(new CustomEvent(HUD_PAUSE, { detail: { paused: true } }));
+    expect(badge.element.classList.contains("is-hidden")).toBe(false);
+    expect(badge.element.getAttribute("aria-hidden")).toBe("false");
+
+    window.dispatchEvent(new CustomEvent(HUD_PAUSE, { detail: { paused: false } }));
+    expect(badge.element.classList.contains("is-hidden")).toBe(true);
+    expect(badge.element.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("hides automatically when the game is over", () => {
+    const badge = new PauseBadge();
+
+    window.dispatchEvent(new CustomEvent(HUD_PAUSE, { detail: { paused: true } }));
+    expect(badge.element.classList.contains("is-hidden")).toBe(false);
+
+    window.dispatchEvent(new CustomEvent(HUD_PAUSE, { detail: { paused: true, gameOver: true } }));
+    expect(badge.element.classList.contains("is-hidden")).toBe(true);
+
+    window.dispatchEvent(new CustomEvent(HUD_PAUSE, { detail: { paused: true } }));
+    expect(badge.element.classList.contains("is-hidden")).toBe(false);
+
+    window.dispatchEvent(new CustomEvent(HUD_GAME_OVER));
+    expect(badge.element.classList.contains("is-hidden")).toBe(true);
+  });
+
+  it("normalises alternative game over states", () => {
+    const badge = new PauseBadge();
+
+    window.dispatchEvent(
+      new CustomEvent(HUD_PAUSE, { detail: { paused: true, state: "game-over" } })
+    );
+    expect(badge.element.classList.contains("is-hidden")).toBe(true);
+
+    window.dispatchEvent(
+      new CustomEvent(HUD_PAUSE, { detail: { paused: true, state: "running" } })
+    );
+    expect(badge.element.classList.contains("is-hidden")).toBe(false);
+  });
+});

--- a/src/hud/components/PauseBadge.ts
+++ b/src/hud/components/PauseBadge.ts
@@ -1,0 +1,181 @@
+import { HUD_GAME_OVER, HUD_PAUSE, HudPauseEvent, HudPauseEventDetail } from "../events";
+import "../styles/pause-badge.css";
+
+type ElementOrSelector = string | HTMLElement | null | undefined;
+
+export interface PauseBadgeOptions {
+  /**
+   * Event target to listen to for HUD events. Defaults to {@link window}.
+   */
+  target?: EventTarget | null;
+  /**
+   * Optional container that the badge should be appended to when it needs to
+   * create its own element.
+   */
+  container?: ElementOrSelector;
+  /**
+   * Optional element or selector that represents an existing badge element.
+   */
+  element?: ElementOrSelector;
+  /**
+   * Text to render inside the badge. Defaults to "Paused".
+   */
+  label?: string;
+}
+
+function resolveElement(source: ElementOrSelector): HTMLElement | null {
+  if (!source) {
+    return null;
+  }
+
+  if (typeof source === "string") {
+    return document.querySelector<HTMLElement>(source);
+  }
+
+  return source;
+}
+
+function createBadge(label: string): HTMLElement {
+  const badge = document.createElement("span");
+  badge.className = "hud-pause-badge is-hidden";
+  badge.textContent = label;
+  badge.setAttribute("role", "status");
+  badge.setAttribute("aria-live", "polite");
+  badge.setAttribute("aria-hidden", "true");
+  return badge;
+}
+
+function addTargetListener(
+  target: EventTarget | null | undefined,
+  type: string,
+  listener: EventListenerOrEventListenerObject
+): () => void {
+  if (!target) {
+    return () => {};
+  }
+
+  target.addEventListener(type, listener);
+  return () => target.removeEventListener(type, listener);
+}
+
+function normaliseState(detail: HudPauseEventDetail | undefined): {
+  paused: boolean;
+  gameOver: boolean;
+  hasGameOver: boolean;
+} {
+  if (!detail) {
+    return { paused: false, gameOver: false, hasGameOver: false };
+  }
+
+  const paused = Boolean(detail.paused);
+
+  let hasGameOver = typeof detail.gameOver === "boolean";
+  let gameOver = hasGameOver ? Boolean(detail.gameOver) : false;
+
+  const state = typeof detail.state === "string" ? detail.state.toLowerCase() : "";
+  if (state) {
+    if (state === "game-over" || state === "game_over" || state === "gameover") {
+      gameOver = true;
+      hasGameOver = true;
+    } else if (state === "running" || state === "playing" || state === "resume") {
+      gameOver = false;
+      hasGameOver = true;
+    }
+  }
+
+  return { paused, gameOver, hasGameOver };
+}
+
+function isHudPauseEvent(event: Event): event is HudPauseEvent {
+  return "detail" in event;
+}
+
+export class PauseBadge {
+  public readonly element: HTMLElement;
+
+  private readonly target: EventTarget | null;
+  private readonly removeListeners: Array<() => void> = [];
+
+  private isPaused = false;
+  private isGameOver = false;
+
+  constructor(options: PauseBadgeOptions = {}) {
+    const {
+      element: elementOrSelector,
+      container: containerOrSelector,
+      label = "Paused",
+      target = window,
+    } = options;
+
+    this.target = target ?? null;
+
+    const existing = resolveElement(elementOrSelector);
+
+    if (existing) {
+      this.element = existing;
+      this.element.classList.add("hud-pause-badge");
+      if (!this.element.textContent) {
+        this.element.textContent = label;
+      }
+      if (!this.element.getAttribute("role")) {
+        this.element.setAttribute("role", "status");
+      }
+      if (!this.element.getAttribute("aria-live")) {
+        this.element.setAttribute("aria-live", "polite");
+      }
+    } else {
+      const container = resolveElement(containerOrSelector) ?? document.querySelector(".hud-panel");
+      this.element = createBadge(label);
+      (container ?? document.body).appendChild(this.element);
+    }
+
+    this.element.classList.add("hud-pause-badge");
+    this.hide();
+
+    this.removeListeners.push(
+      addTargetListener(this.target, HUD_PAUSE, (event) => this.onPauseEvent(event)),
+      addTargetListener(this.target, HUD_GAME_OVER, () => this.onGameOver())
+    );
+  }
+
+  private onPauseEvent(event: Event) {
+    if (!isHudPauseEvent(event)) {
+      return;
+    }
+
+    const { paused, gameOver, hasGameOver } = normaliseState(event.detail);
+    this.isPaused = paused;
+    if (hasGameOver || !paused) {
+      this.isGameOver = gameOver;
+    } else if (paused) {
+      this.isGameOver = false;
+    }
+    this.updateVisibility();
+  }
+
+  private onGameOver() {
+    this.isGameOver = true;
+    this.isPaused = false;
+    this.updateVisibility();
+  }
+
+  private updateVisibility() {
+    const shouldShow = this.isPaused && !this.isGameOver;
+    this.element.classList.toggle("is-hidden", !shouldShow);
+    this.element.classList.toggle("is-visible", shouldShow);
+    this.element.setAttribute("aria-hidden", shouldShow ? "false" : "true");
+  }
+
+  private hide() {
+    this.isPaused = false;
+    this.isGameOver = false;
+    this.updateVisibility();
+  }
+
+  public destroy() {
+    while (this.removeListeners.length > 0) {
+      const remove = this.removeListeners.pop();
+      remove?.();
+    }
+  }
+}

--- a/src/hud/events.ts
+++ b/src/hud/events.ts
@@ -1,0 +1,10 @@
+export const HUD_PAUSE = "hud:pause" as const;
+export const HUD_GAME_OVER = "hud:game-over" as const;
+
+export type HudPauseEventDetail = {
+  paused: boolean;
+  gameOver?: boolean;
+  state?: string;
+};
+
+export type HudPauseEvent = CustomEvent<HudPauseEventDetail>;

--- a/src/hud/styles/pause-badge.css
+++ b/src/hud/styles/pause-badge.css
@@ -1,0 +1,31 @@
+.hud-pause-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.18);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--hud-text, #0b1f33);
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.hud-pause-badge::before {
+  content: "\23F8";
+  font-size: 0.95rem;
+  line-height: 1;
+  opacity: 0.85;
+}
+
+.hud-pause-badge.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- add a PauseBadge HUD component that reacts to pause and game over events
- style the pause badge chip with a dedicated CSS module
- cover pause badge state transitions with vitest unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e0619f34088328a7877a995692b161