### PR TITLE
Add session stats HUD panel triggered by game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <canvas id="gameCanvas" aria-describedby="gameMessage"></canvas>
         <div id="gameOverlay" class="game-overlay" aria-live="assertive">
           <p id="gameMessage" class="game-message">Tap or press Space to start</p>
+          <div id="sessionStats" class="session-stats" hidden></div>
           <button id="startButton" type="button" class="game-button">Play</button>
         </div>
       </section>

--- a/src/game/systems/loop.js
+++ b/src/game/systems/loop.js
@@ -2,6 +2,7 @@ import { Bird, Pipe } from "../entities/index.js";
 import { CONFIG, resetGameState, persistBestScore } from "./state.js";
 import { createThreeRenderer } from "../../rendering/three/renderer.js";
 import { createHudController } from "../../rendering/index.js";
+import { HUD_GAME_OVER } from "../../hud/components/SessionStats.ts";
 
 let state = null;
 let renderer = null;
@@ -95,6 +96,9 @@ function prepareRound() {
   ensureRenderer();
 
   resetGameState(state);
+  state.sessionStats.attempts += 1;
+  state.sessionStats.lastScore = 0;
+  state.sessionStats.lastDurationMs = 0;
   state.bird = new Bird(80, state.playfieldHeight / 2, {
     width: 38,
     height: 26,
@@ -122,8 +126,34 @@ function endRound() {
   state.awaitingStart = true;
   syncHighScore();
   refreshHud();
+  state.sessionStats.lastScore = state.score;
+  state.sessionStats.lastDurationMs = state.roundDurationMs;
+  state.sessionStats.totalScore += state.score;
+  state.sessionStats.totalDurationMs += state.roundDurationMs;
+  state.sessionStats.bestScore = Math.max(
+    state.sessionStats.bestScore,
+    state.score
+  );
   if (hud) {
     hud.showGameOver(state.score, state.bestScore);
+  }
+  if (typeof window !== "undefined") {
+    const attempts = state.sessionStats.attempts;
+    window.dispatchEvent(
+      new CustomEvent(HUD_GAME_OVER, {
+        detail: {
+          attempts,
+          averageScore:
+            attempts > 0 ? state.sessionStats.totalScore / attempts : 0,
+          averageDurationMs:
+            attempts > 0 ? state.sessionStats.totalDurationMs / attempts : 0,
+          lastScore: state.sessionStats.lastScore,
+          lastDurationMs: state.sessionStats.lastDurationMs,
+          sessionBest: state.sessionStats.bestScore,
+          bestScore: state.bestScore,
+        },
+      })
+    );
   }
   if (renderer) {
     renderer.markGameOver();
@@ -142,6 +172,7 @@ function update(timestamp) {
   const deltaMs = Math.min(now - state.lastTimestamp, 1000 / 15);
   state.lastTimestamp = now;
   const delta = deltaMs / (1000 / 60);
+  state.roundDurationMs += deltaMs;
 
   state.spawnTimer += deltaMs;
   if (state.spawnTimer >= CONFIG.pipeIntervalMs) {

--- a/src/game/systems/state.js
+++ b/src/game/systems/state.js
@@ -41,6 +41,15 @@ export function createGameState(canvas, prng = createDeterministicPrng()) {
     lastTimestamp: null,
     spawnTimer: 0,
     ui: null,
+    roundDurationMs: 0,
+    sessionStats: {
+      attempts: 0,
+      totalScore: 0,
+      totalDurationMs: 0,
+      lastScore: 0,
+      lastDurationMs: 0,
+      bestScore: 0,
+    },
   };
 }
 
@@ -58,6 +67,7 @@ export function resetGameState(state) {
   state.animationFrameId = null;
   state.spawnTimer = 0;
   state.lastTimestamp = null;
+  state.roundDurationMs = 0;
   if (state.prng && typeof state.prng.reset === "function") {
     state.prng.reset();
   }

--- a/src/hud/components/SessionStats.test.ts
+++ b/src/hud/components/SessionStats.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import {
+  HUD_GAME_OVER,
+  initSessionStats,
+  type SessionStatsDetail,
+} from "./SessionStats";
+
+const baseDetail: SessionStatsDetail = {
+  attempts: 3,
+  averageScore: 6,
+  averageDurationMs: 12345,
+  lastScore: 4,
+  lastDurationMs: 10234,
+  sessionBest: 10,
+  bestScore: 12,
+};
+
+describe("SessionStatsPanel", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    document.body.innerHTML = '<div id="sessionStats"></div>';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  function dispatch(detail: SessionStatsDetail = baseDetail) {
+    window.dispatchEvent(new CustomEvent(HUD_GAME_OVER, { detail }));
+  }
+
+  it("renders stats when a HUD_GAME_OVER event is emitted", () => {
+    initSessionStats();
+    dispatch();
+
+    const attempts = document.querySelector(
+      '[data-stat="attempts"] .session-stats__value'
+    );
+    const averageScore = document.querySelector(
+      '[data-stat="averageScore"] .session-stats__value'
+    );
+    const lastDuration = document.querySelector(
+      '[data-stat="lastDurationMs"] .session-stats__value'
+    );
+
+    expect(attempts?.textContent).toBe("3 plays");
+    expect(averageScore?.textContent).toBe("6");
+    expect(lastDuration?.textContent).toBe("10s");
+  });
+
+  it("supports toggling via pointer and keyboard interactions", () => {
+    initSessionStats();
+    dispatch();
+
+    const toggle = document.querySelector<HTMLButtonElement>(
+      ".session-stats__toggle"
+    );
+    const panel = document.querySelector<HTMLDivElement>(
+      ".session-stats__panel"
+    );
+
+    expect(toggle).toBeTruthy();
+    expect(panel?.hidden).toBe(false);
+
+    toggle?.click();
+    expect(panel?.hidden).toBe(true);
+    expect(document.activeElement).toBe(toggle);
+
+    toggle?.click();
+    expect(panel?.hidden).toBe(false);
+    expect(document.activeElement).toBe(panel);
+
+    panel?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(panel?.hidden).toBe(true);
+    expect(document.activeElement).toBe(toggle);
+  });
+});

--- a/src/hud/components/SessionStats.ts
+++ b/src/hud/components/SessionStats.ts
@@ -1,0 +1,290 @@
+import "../styles/session-stats.css";
+
+export const HUD_GAME_OVER = "HUD_GAME_OVER" as const;
+
+export interface SessionStatsDetail {
+  attempts: number;
+  averageScore: number;
+  averageDurationMs: number;
+  lastScore: number;
+  lastDurationMs: number;
+  sessionBest: number;
+  bestScore: number;
+}
+
+interface SessionStatsOptions {
+  root?: HTMLElement | string | null;
+  toggleLabel?: string;
+  expandedLabel?: string;
+}
+
+type StatKey =
+  | "attempts"
+  | "averageScore"
+  | "sessionBest"
+  | "lastScore"
+  | "averageDurationMs"
+  | "lastDurationMs"
+  | "bestScore";
+
+const STAT_CONFIG: Array<{
+  key: StatKey;
+  label: string;
+  format(detail: SessionStatsDetail): string;
+}> = [
+  {
+    key: "attempts",
+    label: "Attempts",
+    format: (detail) => formatCount(detail.attempts, "play"),
+  },
+  {
+    key: "averageScore",
+    label: "Average score",
+    format: (detail) => formatNumber(detail.averageScore),
+  },
+  {
+    key: "sessionBest",
+    label: "Session best",
+    format: (detail) => formatNumber(detail.sessionBest),
+  },
+  {
+    key: "lastScore",
+    label: "Last score",
+    format: (detail) => formatNumber(detail.lastScore),
+  },
+  {
+    key: "averageDurationMs",
+    label: "Avg survival",
+    format: (detail) => formatDuration(detail.averageDurationMs),
+  },
+  {
+    key: "lastDurationMs",
+    label: "Last survival",
+    format: (detail) => formatDuration(detail.lastDurationMs),
+  },
+  {
+    key: "bestScore",
+    label: "All-time best",
+    format: (detail) => formatNumber(detail.bestScore),
+  },
+];
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value) || Number.isNaN(value)) {
+    return "—";
+  }
+  const formatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: value % 1 === 0 ? 0 : 1,
+  });
+  return formatter.format(value);
+}
+
+function formatCount(count: number, noun: string): string {
+  if (!Number.isFinite(count) || count <= 0) {
+    return `No ${noun}s yet`;
+  }
+  const formatter = new Intl.NumberFormat();
+  const label = count === 1 ? noun : `${noun}s`;
+  return `${formatter.format(count)} ${label}`;
+}
+
+function formatDuration(milliseconds: number): string {
+  if (!Number.isFinite(milliseconds) || milliseconds <= 0) {
+    return "—";
+  }
+  const seconds = milliseconds / 1000;
+  if (seconds < 10) {
+    return `${seconds.toFixed(1)}s`;
+  }
+  if (seconds < 120) {
+    return `${Math.round(seconds)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remaining = Math.round(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${minutes}:${remaining} min`;
+}
+
+function resolveRoot(root?: HTMLElement | string | null): HTMLElement | null {
+  if (!root) {
+    return document.querySelector<HTMLElement>("#sessionStats");
+  }
+  if (typeof root === "string") {
+    return document.querySelector<HTMLElement>(root);
+  }
+  return root;
+}
+
+export class SessionStatsPanel {
+  private readonly root: HTMLElement | null;
+
+  private readonly toggle: HTMLButtonElement;
+
+  private readonly panel: HTMLDivElement;
+
+  private readonly list: HTMLDListElement;
+
+  private expanded = false;
+
+  private hasData = false;
+
+  constructor(options: SessionStatsOptions = {}) {
+    this.root = resolveRoot(options.root ?? null);
+    this.toggle = document.createElement("button");
+    this.panel = document.createElement("div");
+    this.list = document.createElement("dl");
+
+    if (!this.root) {
+      return;
+    }
+
+    const toggleLabel = options.toggleLabel ?? "Show session stats";
+    const expandedLabel = options.expandedLabel ?? "Hide session stats";
+    const panelId = `${this.root.id || "session-stats"}-panel`;
+
+    this.root.classList.add("session-stats");
+    this.root.setAttribute("data-state", "idle");
+    this.root.hidden = true;
+
+    this.toggle.className = "session-stats__toggle";
+    this.toggle.type = "button";
+    this.toggle.textContent = toggleLabel;
+    this.toggle.setAttribute("aria-expanded", "false");
+    this.toggle.setAttribute("aria-controls", panelId);
+    this.toggle.disabled = true;
+
+    this.panel.className = "session-stats__panel";
+    this.panel.id = panelId;
+    this.panel.hidden = true;
+    this.panel.setAttribute("role", "group");
+    this.panel.setAttribute("tabindex", "-1");
+
+    const heading = document.createElement("h2");
+    heading.className = "session-stats__title";
+    heading.textContent = "Session stats";
+
+    this.list.className = "session-stats__list";
+
+    this.panel.append(heading, this.list);
+    this.root.append(this.toggle, this.panel);
+
+    const updateToggleLabel = () => {
+      this.toggle.textContent = this.expanded ? expandedLabel : toggleLabel;
+    };
+
+    const collapsePanel = () => {
+      this.expanded = false;
+      this.panel.hidden = true;
+      this.toggle.setAttribute("aria-expanded", "false");
+      this.root?.setAttribute("data-state", this.hasData ? "ready" : "idle");
+      updateToggleLabel();
+    };
+
+    const expandPanel = (shouldFocus = true) => {
+      if (!this.hasData) return;
+      this.expanded = true;
+      this.panel.hidden = false;
+      this.toggle.setAttribute("aria-expanded", "true");
+      this.root?.setAttribute("data-state", "open");
+      updateToggleLabel();
+      if (shouldFocus) {
+        requestAnimationFrame(() => this.panel.focus());
+      }
+    };
+
+    const togglePanel = () => {
+      if (this.expanded) {
+        collapsePanel();
+        requestAnimationFrame(() => this.toggle.focus());
+      } else {
+        expandPanel();
+      }
+    };
+
+    this.toggle.addEventListener("click", togglePanel);
+    this.toggle.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowDown" && !this.expanded) {
+        event.preventDefault();
+        expandPanel();
+      }
+    });
+
+    this.panel.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        collapsePanel();
+        requestAnimationFrame(() => this.toggle.focus());
+      }
+    });
+
+    window.addEventListener(HUD_GAME_OVER, (event: Event) => {
+      const customEvent = event as CustomEvent<SessionStatsDetail>;
+      const firstUpdate = !this.hasData;
+      this.applyStats(customEvent.detail);
+      if (firstUpdate && !this.expanded) {
+        expandPanel(false);
+      }
+    });
+
+    // expose for internal reuse
+    this.expand = expandPanel;
+    this.collapse = collapsePanel;
+    this.updateToggleLabel = updateToggleLabel;
+  }
+
+  // Methods assigned within constructor
+  private expand: (shouldFocus?: boolean) => void = () => {};
+
+  private collapse: () => void = () => {};
+
+  private updateToggleLabel: () => void = () => {};
+
+  applyStats(detail?: SessionStatsDetail) {
+    if (!this.root || !detail) return;
+
+    if (!this.hasData) {
+      this.root.hidden = false;
+      this.toggle.disabled = false;
+      this.hasData = true;
+      this.root.setAttribute("data-state", "ready");
+      this.updateToggleLabel();
+    }
+
+    this.list.textContent = "";
+
+    for (const stat of STAT_CONFIG) {
+      const wrapper = document.createElement("div");
+      wrapper.className = "session-stats__item";
+      wrapper.dataset.stat = stat.key;
+
+      const term = document.createElement("dt");
+      term.className = "session-stats__label";
+      term.textContent = stat.label;
+
+      const description = document.createElement("dd");
+      description.className = "session-stats__value";
+      description.textContent = stat.format(detail);
+
+      wrapper.append(term, description);
+      this.list.append(wrapper);
+    }
+
+    this.root.dispatchEvent(
+      new CustomEvent("sessionstatsupdate", {
+        bubbles: true,
+        detail,
+      })
+    );
+
+    if (this.expanded) {
+      requestAnimationFrame(() => this.panel.focus());
+    }
+  }
+}
+
+export function initSessionStats(options?: SessionStatsOptions): SessionStatsPanel {
+  return new SessionStatsPanel(options);
+}
+
+export default SessionStatsPanel;

--- a/src/hud/styles/session-stats.css
+++ b/src/hud/styles/session-stats.css
@@ -1,0 +1,106 @@
+.session-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-block: 0.75rem 0;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background-color: rgba(17, 17, 26, 0.82);
+  background: color-mix(
+    in srgb,
+    var(--hud-panel-bg, rgba(17, 17, 26, 0.75)) 85%,
+    #1e1e2c 15%
+  );
+  color: inherit;
+}
+
+.session-stats[data-state="idle"] {
+  display: none;
+}
+
+.session-stats__toggle {
+  align-self: flex-start;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background-color: rgba(12, 12, 18, 0.35);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background-color 160ms ease, border-color 160ms ease;
+}
+
+.session-stats__toggle:focus-visible {
+  outline: 2px solid #6dd0ff;
+  outline-offset: 2px;
+}
+
+.session-stats__toggle:hover,
+.session-stats__toggle:focus-visible {
+  background-color: rgba(24, 24, 36, 0.75);
+  border-color: rgba(255, 255, 255, 0.6);
+}
+
+.session-stats__toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.session-stats__panel {
+  background-color: rgba(12, 12, 18, 0.75);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.35);
+  outline: none;
+}
+
+.session-stats__title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.session-stats__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.session-stats__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.session-stats__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.72;
+}
+
+.session-stats__value {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+@media (max-width: 480px) {
+  .session-stats {
+    padding: 0.5rem;
+  }
+
+  .session-stats__panel {
+    padding: 0.5rem;
+  }
+
+  .session-stats__title {
+    font-size: 0.9rem;
+  }
+
+  .session-stats__value {
+    font-size: 0.95rem;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import {
   startGame,
   handleCanvasClick,
 } from "./game/systems/index.js";
+import { initSessionStats } from "./hud/components/SessionStats.ts";
 
 function bindInput(canvas) {
   const pressAction = (event) => {
@@ -87,6 +88,8 @@ function init() {
       speedProgress: "#speedProgress",
     },
   });
+
+  initSessionStats();
 
   bindInput(canvas);
   resizeCanvas(canvas);


### PR DESCRIPTION
## Summary
- add a HUD session statistics panel component that listens for the `HUD_GAME_OVER` event
- track per-session attempts, averages, and durations in the game state and dispatch HUD updates on game over
- style the session stats panel and add focused interaction tests

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0619816448328a71c1bce52748162