### PR TITLE
Add HUD medal logic and event emissions

### DIFF
--- a/src/hud/logic/__tests__/medals.test.ts
+++ b/src/hud/logic/__tests__/medals.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { getMedalForScore, Medal } from "../medals";
+
+describe("getMedalForScore", () => {
+  const cases: Array<{ score: number; medal: Medal }> = [
+    { score: -10, medal: Medal.None },
+    { score: 0, medal: Medal.None },
+    { score: 9, medal: Medal.None },
+    { score: 10, medal: Medal.Bronze },
+    { score: 15, medal: Medal.Bronze },
+    { score: 19, medal: Medal.Bronze },
+    { score: 20, medal: Medal.Silver },
+    { score: 25, medal: Medal.Silver },
+    { score: 29, medal: Medal.Silver },
+    { score: 30, medal: Medal.Gold },
+    { score: 35, medal: Medal.Gold },
+    { score: 39, medal: Medal.Gold },
+    { score: 40, medal: Medal.Platinum },
+    { score: 100, medal: Medal.Platinum },
+  ];
+
+  for (const { score, medal } of cases) {
+    it(`returns ${medal} for a score of ${score}`, () => {
+      expect(getMedalForScore(score)).toBe(medal);
+    });
+  }
+
+  it("treats fractional scores by flooring them", () => {
+    expect(getMedalForScore(29.9)).toBe(Medal.Silver);
+    expect(getMedalForScore(30.2)).toBe(Medal.Gold);
+  });
+
+  it("returns none for non-finite values", () => {
+    expect(getMedalForScore(Number.POSITIVE_INFINITY)).toBe(Medal.None);
+    expect(getMedalForScore(Number.NEGATIVE_INFINITY)).toBe(Medal.None);
+    expect(getMedalForScore(Number.NaN)).toBe(Medal.None);
+  });
+
+  it("is pure and does not retain state between invocations", () => {
+    expect(getMedalForScore(10)).toBe(Medal.Bronze);
+    expect(getMedalForScore(0)).toBe(Medal.None);
+    expect(getMedalForScore(10)).toBe(Medal.Bronze);
+  });
+});

--- a/src/hud/logic/medals.ts
+++ b/src/hud/logic/medals.ts
@@ -1,0 +1,40 @@
+export enum Medal {
+  None = "none",
+  Bronze = "bronze",
+  Silver = "silver",
+  Gold = "gold",
+  Platinum = "platinum",
+}
+
+export const medalThresholds = Object.freeze({
+  [Medal.Bronze]: 10,
+  [Medal.Silver]: 20,
+  [Medal.Gold]: 30,
+  [Medal.Platinum]: 40,
+});
+
+export function getMedalForScore(score: number): Medal {
+  if (!Number.isFinite(score)) {
+    return Medal.None;
+  }
+
+  const normalizedScore = Math.floor(score);
+
+  if (normalizedScore >= medalThresholds[Medal.Platinum]) {
+    return Medal.Platinum;
+  }
+
+  if (normalizedScore >= medalThresholds[Medal.Gold]) {
+    return Medal.Gold;
+  }
+
+  if (normalizedScore >= medalThresholds[Medal.Silver]) {
+    return Medal.Silver;
+  }
+
+  if (normalizedScore >= medalThresholds[Medal.Bronze]) {
+    return Medal.Bronze;
+  }
+
+  return Medal.None;
+}

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,3 +1,5 @@
+import { getMedalForScore, Medal } from "../hud/logic/medals";
+
 const noop = () => {};
 
 function resolveElement(element) {
@@ -50,9 +52,27 @@ export function createHudController(elements = {}) {
     startButton.blur();
   });
 
+  let currentMedal = Medal.None;
+  const medalListeners = new Set();
+
+  const notifyMedalChange = (medal) => {
+    medalListeners.forEach((listener) => {
+      try {
+        listener(medal);
+      } catch (error) {
+        console.error("HUD medal listener error", error);
+      }
+    });
+  };
+
   return {
     setScore(value) {
       safeText(scoreEl, value);
+      const medal = getMedalForScore(Number(value));
+      if (medal !== currentMedal) {
+        currentMedal = medal;
+        notifyMedalChange(currentMedal);
+      }
     },
     setBest(value) {
       safeText(bestEl, value);
@@ -76,6 +96,18 @@ export function createHudController(elements = {}) {
     },
     onRestart(handler = noop) {
       startButton?.addEventListener("click", handler);
+    },
+    onMedalChange(handler = noop) {
+      if (typeof handler !== "function") {
+        return noop;
+      }
+      medalListeners.add(handler);
+      return () => {
+        medalListeners.delete(handler);
+      };
+    },
+    getCurrentMedal() {
+      return currentMedal;
     },
   };
 }


### PR DESCRIPTION
## Summary
- add a Medal enum and score-to-medal mapping helper for the HUD
- cover the medal mapper with exhaustive unit tests for 100% branch coverage
- integrate the medal mapper with the HUD controller and emit medal change events

## Testing
- npm run test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e061948c3483288dde2ec75c83f6f7