### PR TITLE
Add HUD audio toggle control with persistence

### DIFF
--- a/src/hud/components/AudioToggle.test.ts
+++ b/src/hud/components/AudioToggle.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAudioToggle } from "./AudioToggle";
+import {
+  HUD_EVENT_AUDIO_TOGGLED,
+  type HudAudioToggleDetail,
+} from "../events";
+import {
+  getHudPreference,
+  resetHudPreferences,
+  setHudPreference,
+} from "../hud-store";
+
+declare global {
+  interface DocumentEventMap {
+    [HUD_EVENT_AUDIO_TOGGLED]: CustomEvent<HudAudioToggleDetail>;
+  }
+}
+
+describe("AudioToggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetHudPreferences();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("persists the toggled state via the HUD store", () => {
+    const control = createAudioToggle();
+    document.body.append(control.element);
+
+    expect(getHudPreference("audioEnabled")).toBe(true);
+
+    control.element.click();
+
+    expect(getHudPreference("audioEnabled")).toBe(false);
+
+    const stored = localStorage.getItem("flappy-hud-preferences");
+    expect(stored).toContain("audioEnabled");
+    expect(stored).toContain("false");
+  });
+
+  it("emits HUD audio toggle events with the latest state", () => {
+    setHudPreference("audioEnabled", false);
+    const target = new EventTarget();
+    const factory = vi.fn(() => ({}) as AudioContext);
+    const control = createAudioToggle({
+      eventTarget: target,
+      audioContextFactory: factory,
+    });
+
+    const handler = vi.fn();
+    target.addEventListener(HUD_EVENT_AUDIO_TOGGLED, (event) => {
+      handler((event as CustomEvent<HudAudioToggleDetail>).detail);
+    });
+
+    expect(factory).not.toHaveBeenCalled();
+
+    control.element.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenLastCalledWith({
+      enabled: true,
+      audioContext: expect.any(Object),
+    });
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    control.element.click();
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenLastCalledWith({
+      enabled: false,
+      audioContext: null,
+    });
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hud/components/AudioToggle.ts
+++ b/src/hud/components/AudioToggle.ts
@@ -1,0 +1,126 @@
+import {
+  getHudPreference,
+  setHudPreference,
+  subscribeToHudPreferences,
+} from "../hud-store";
+import {
+  HUD_EVENT_AUDIO_TOGGLED,
+  type HudAudioToggleDetail,
+} from "../events";
+
+export interface AudioToggleLabels {
+  on: string;
+  off: string;
+}
+
+export interface AudioToggleOptions {
+  /** Target that receives HUD audio toggle events. Defaults to `document`. */
+  eventTarget?: EventTarget;
+  /**
+   * Optional callback used to lazily create an {@link AudioContext} the first time audio is enabled.
+   * When omitted, the component emits toggle events without an attached context.
+   */
+  audioContextFactory?: () => AudioContext;
+  /** Override the accessible labels rendered by the control. */
+  labels?: AudioToggleLabels;
+}
+
+export interface AudioToggleControl {
+  readonly element: HTMLButtonElement;
+  destroy(): void;
+  setEnabled(enabled: boolean): void;
+}
+
+const DEFAULT_LABELS: AudioToggleLabels = {
+  on: "Audio cues on",
+  off: "Audio cues off",
+};
+
+function createEvent(detail: HudAudioToggleDetail): CustomEvent<HudAudioToggleDetail> {
+  return new CustomEvent<HudAudioToggleDetail>(HUD_EVENT_AUDIO_TOGGLED, {
+    detail,
+  });
+}
+
+export function createAudioToggle(
+  options: AudioToggleOptions = {},
+): AudioToggleControl {
+  const { eventTarget = document, labels = DEFAULT_LABELS } = options;
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.classList.add("hud-audio-toggle");
+  button.setAttribute("role", "switch");
+  button.setAttribute("aria-live", "polite");
+
+  let enabled = getHudPreference("audioEnabled");
+  let audioContext: AudioContext | null = null;
+
+  const ensureAudioContext = (): AudioContext | null => {
+    if (!enabled) {
+      return null;
+    }
+
+    if (!audioContext && options.audioContextFactory) {
+      audioContext = options.audioContextFactory();
+    }
+
+    return audioContext;
+  };
+
+  const render = () => {
+    const label = enabled ? labels.on : labels.off;
+    button.textContent = label;
+    button.setAttribute("aria-label", label);
+    button.setAttribute("aria-checked", String(enabled));
+    button.dataset.state = enabled ? "on" : "off";
+  };
+
+  const dispatch = () => {
+    const detail: HudAudioToggleDetail = {
+      enabled,
+      audioContext: enabled ? ensureAudioContext() : null,
+    };
+    eventTarget.dispatchEvent(createEvent(detail));
+  };
+
+  const applyEnabled = (next: boolean) => {
+    if (enabled === next) {
+      return;
+    }
+
+    enabled = next;
+    render();
+    setHudPreference("audioEnabled", enabled);
+    dispatch();
+  };
+
+  const handleClick = () => {
+    applyEnabled(!enabled);
+  };
+
+  button.addEventListener("click", handleClick);
+
+  const unsubscribe = subscribeToHudPreferences((preferences) => {
+    if (preferences.audioEnabled === enabled) {
+      return;
+    }
+
+    enabled = preferences.audioEnabled;
+    render();
+  });
+
+  render();
+
+  return {
+    element: button,
+    destroy() {
+      button.removeEventListener("click", handleClick);
+      unsubscribe();
+    },
+    setEnabled(next) {
+      applyEnabled(next);
+    },
+  };
+}
+

--- a/src/hud/events.ts
+++ b/src/hud/events.ts
@@ -1,0 +1,6 @@
+export const HUD_EVENT_AUDIO_TOGGLED = "hud:audio-toggled";
+
+export interface HudAudioToggleDetail {
+  enabled: boolean;
+  audioContext: AudioContext | null;
+}

--- a/src/hud/hud-store.ts
+++ b/src/hud/hud-store.ts
@@ -1,0 +1,133 @@
+export type HudPreferenceKey = "audioEnabled";
+
+export interface HudPreferences {
+  audioEnabled: boolean;
+}
+
+const STORAGE_KEY = "flappy-hud-preferences";
+const DEFAULT_PREFERENCES: HudPreferences = {
+  audioEnabled: true,
+};
+
+let cachedPreferences: HudPreferences | null = null;
+const listeners = new Set<(prefs: HudPreferences) => void>();
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch (error) {
+    return null;
+  }
+}
+
+function loadFromStorage(): HudPreferences {
+  const storage = getStorage();
+  if (!storage) {
+    return { ...DEFAULT_PREFERENCES };
+  }
+
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { ...DEFAULT_PREFERENCES };
+    }
+
+    const parsed = JSON.parse(raw) as Partial<HudPreferences> | null;
+    if (!parsed || typeof parsed !== "object") {
+      return { ...DEFAULT_PREFERENCES };
+    }
+
+    return {
+      ...DEFAULT_PREFERENCES,
+      ...parsed,
+    };
+  } catch (error) {
+    return { ...DEFAULT_PREFERENCES };
+  }
+}
+
+function persistPreferences(preferences: HudPreferences): void {
+  const storage = getStorage();
+  if (!storage) {
+    cachedPreferences = { ...preferences };
+    return;
+  }
+
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  } catch (error) {
+    // Ignore storage failures to keep the HUD responsive even when storage is unavailable.
+  }
+
+  cachedPreferences = { ...preferences };
+}
+
+function getCachedPreferences(): HudPreferences {
+  if (!cachedPreferences) {
+    cachedPreferences = loadFromStorage();
+  }
+
+  return cachedPreferences;
+}
+
+function notifyListeners(preferences: HudPreferences): void {
+  listeners.forEach((listener) => {
+    listener({ ...preferences });
+  });
+}
+
+export function getHudPreferences(): HudPreferences {
+  return { ...getCachedPreferences() };
+}
+
+export function getHudPreference<K extends HudPreferenceKey>(
+  key: K,
+): HudPreferences[K] {
+  const preferences = getCachedPreferences();
+  return preferences[key];
+}
+
+export function setHudPreference<K extends HudPreferenceKey>(
+  key: K,
+  value: HudPreferences[K],
+): HudPreferences {
+  const current = getCachedPreferences();
+  if (current[key] === value) {
+    return { ...current };
+  }
+
+  const next: HudPreferences = {
+    ...current,
+    [key]: value,
+  };
+
+  persistPreferences(next);
+  notifyListeners(next);
+  return { ...next };
+}
+
+export function subscribeToHudPreferences(
+  listener: (preferences: HudPreferences) => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetHudPreferences(): HudPreferences {
+  const defaults = { ...DEFAULT_PREFERENCES };
+  cachedPreferences = defaults;
+  const storage = getStorage();
+  try {
+    storage?.removeItem(STORAGE_KEY);
+  } catch (error) {
+    // Ignore failures when clearing storage.
+  }
+  notifyListeners(defaults);
+  return { ...defaults };
+}


### PR DESCRIPTION
## Summary
- add a reusable HUD audio toggle control that publishes enable/disable events
- persist audio preferences through a new HUD store backed by localStorage
- cover the new behavior with tests for persistence and event emission

## Testing
- npm run test
- npm run typecheck *(fails: existing TypeScript errors in legacy rendering and test files)*

------
https://chatgpt.com/codex/tasks/task_e_68e061920b1c8328b2494b68b4f68715