### PR TITLE
Add safe area-aware spacing tokens for layout

### DIFF
--- a/src/hud/styles/root.css
+++ b/src/hud/styles/root.css
@@ -1,3 +1,5 @@
+@import "../../../styles/tokens.css";
+
 #hud-root {
   position: absolute;
   inset: 0;
@@ -23,7 +25,10 @@
   width: min(100vw, var(--hud-max-width));
   min-width: var(--hud-min-width);
   gap: var(--hud-gap);
-  padding: var(--hud-padding);
+  padding-block-start: var(--hud-padding-block-start);
+  padding-block-end: var(--hud-padding-block-end);
+  padding-inline-start: var(--hud-padding-inline-start);
+  padding-inline-end: var(--hud-padding-inline-end);
   box-sizing: border-box;
   pointer-events: none;
   margin: 0 auto;

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,5 @@
+@import "./styles/tokens.css";
+
 :root {
   color-scheme: light;
   --hud-bg: rgba(255, 255, 255, 0.75);
@@ -24,7 +26,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding-block-start: var(--layout-body-padding-block-start);
+  padding-block-end: var(--layout-body-padding-block-end);
+  padding-inline-start: var(--layout-body-padding-inline-start);
+  padding-inline-end: var(--layout-body-padding-inline-end);
   color: var(--hud-text);
 }
 
@@ -96,7 +101,7 @@ body {
   justify-content: center;
   background: rgba(255, 255, 255, 0.65);
   border-radius: 24px;
-  padding: clamp(12px, 5vw, 32px);
+  padding: var(--layout-stage-padding);
   box-shadow: 0 30px 60px rgba(15, 23, 42, 0.18);
 }
 
@@ -183,16 +188,14 @@ kbd {
 }
 
 @media (max-width: 768px) {
-  body {
-    padding: 16px;
+  :root {
+    --layout-body-padding-block: 16px;
+    --layout-body-padding-inline: 16px;
+    --layout-stage-padding: clamp(8px, 8vw, 24px);
   }
 
   .game-layout {
     grid-template-columns: 1fr;
-  }
-
-  .game-stage {
-    padding: clamp(8px, 8vw, 24px);
   }
 
   #gameCanvas {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,0 +1,27 @@
+:root {
+  --layout-safe-area-top: env(safe-area-inset-top, 0px);
+  --layout-safe-area-right: env(safe-area-inset-right, 0px);
+  --layout-safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --layout-safe-area-left: env(safe-area-inset-left, 0px);
+
+  --layout-body-padding-block: clamp(24px, 6vw, 80px);
+  --layout-body-padding-inline: clamp(24px, 6vw, 80px);
+  --layout-body-padding-block-start: calc(
+    var(--layout-body-padding-block, 0px) + var(--layout-safe-area-top)
+  );
+  --layout-body-padding-block-end: calc(
+    var(--layout-body-padding-block, 0px) + var(--layout-safe-area-bottom)
+  );
+  --layout-body-padding-inline-start: calc(
+    var(--layout-body-padding-inline, 0px) + var(--layout-safe-area-left)
+  );
+  --layout-body-padding-inline-end: calc(
+    var(--layout-body-padding-inline, 0px) + var(--layout-safe-area-right)
+  );
+
+  --layout-stage-padding: clamp(12px, 5vw, 32px);
+  --hud-padding-block-start: calc(var(--hud-padding, 0px) + var(--layout-safe-area-top));
+  --hud-padding-block-end: calc(var(--hud-padding, 0px) + var(--layout-safe-area-bottom));
+  --hud-padding-inline-start: calc(var(--hud-padding, 0px) + var(--layout-safe-area-left));
+  --hud-padding-inline-end: calc(var(--hud-padding, 0px) + var(--layout-safe-area-right));
+}


### PR DESCRIPTION
## Summary
- add shared layout spacing tokens that include env(safe-area-inset-*) fallbacks for page padding
- update the HUD container and main layout styles to consume the new safe-area-aware tokens

## Testing
- npm run build
- Verified HUD layout playground with simulated safe-area insets on mobile and desktop viewports

------
https://chatgpt.com/codex/tasks/task_e_68e0618a18248328aaedc6dc9738c0d6