### PR TITLE
feat: add responsive HUD layout to HudRoot

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <main class="game-layout">
+    <main class="game-layout" data-hud-root>
       <header class="hud-panel" aria-label="Game dashboard">
         <div class="hud-metric" aria-live="polite">
           <span class="hud-label">Score</span>

--- a/src/hud/HudRoot.js
+++ b/src/hud/HudRoot.js
@@ -1,0 +1,52 @@
+import "./styles/layout.css";
+
+const DEFAULT_SELECTORS = {
+  root: "[data-hud-root]",
+  panel: ".hud-panel",
+  stage: ".game-stage",
+  footer: ".game-footer",
+  score: "#scoreValue",
+  best: "#bestValue",
+  message: "#gameMessage",
+  overlay: "#gameOverlay",
+  startButton: "#startButton",
+  speedBar: "#speedFill",
+  speedProgress: "#speedProgress",
+};
+
+function resolveElement(selector, context = document) {
+  if (!selector) return null;
+  if (selector instanceof Element) return selector;
+  return context.querySelector(selector);
+}
+
+export class HudRoot {
+  constructor(selectors = {}) {
+    this.selectors = { ...DEFAULT_SELECTORS, ...selectors };
+    this.root = resolveElement(this.selectors.root);
+
+    if (!this.root) {
+      throw new Error("HUD root element not found");
+    }
+
+    this.root.classList.add("hud-root");
+
+    this.panel = resolveElement(this.selectors.panel, this.root);
+    this.stage = resolveElement(this.selectors.stage, this.root);
+    this.footer = resolveElement(this.selectors.footer, this.root);
+
+    this.elements = {
+      score: resolveElement(this.selectors.score, this.root),
+      best: resolveElement(this.selectors.best, this.root),
+      message: resolveElement(this.selectors.message, this.root),
+      overlay: resolveElement(this.selectors.overlay, this.root),
+      startButton: resolveElement(this.selectors.startButton, this.root),
+      speedBar: resolveElement(this.selectors.speedBar, this.root),
+      speedProgress: resolveElement(this.selectors.speedProgress, this.root),
+    };
+  }
+
+  getElements() {
+    return { ...this.elements };
+  }
+}

--- a/src/hud/styles/layout.css
+++ b/src/hud/styles/layout.css
@@ -1,0 +1,96 @@
+.hud-root {
+  --hud-max-width: clamp(320px, 94vw, 1240px);
+  --hud-gap: clamp(16px, 4vw, 32px);
+  --hud-panel-column: clamp(140px, 32vw, 220px);
+  --hud-stage-padding: clamp(12px, 5vw, 28px);
+  margin: 0 auto;
+  width: var(--hud-max-width);
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "panel"
+    "stage"
+    "footer";
+  gap: var(--hud-gap);
+}
+
+.hud-root .hud-panel {
+  grid-area: panel;
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(var(--hud-panel-column), 1fr)
+  );
+  align-items: stretch;
+  justify-content: stretch;
+  gap: clamp(12px, 3vw, 20px);
+}
+
+.hud-root .hud-metric {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.hud-root .game-stage {
+  grid-area: stage;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--hud-stage-padding);
+}
+
+.hud-root .game-stage #gameCanvas {
+  width: clamp(280px, 68vw, 640px);
+  max-width: 100%;
+  aspect-ratio: 420 / 640;
+  max-height: clamp(320px, 76vh, 720px);
+}
+
+.hud-root .game-footer {
+  grid-area: footer;
+  text-align: center;
+  padding: clamp(12px, 3vw, 20px);
+}
+
+@media (min-width: 600px) {
+  .hud-root {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "panel panel"
+      "stage stage"
+      "footer footer";
+  }
+
+  .hud-root .hud-panel {
+    grid-template-columns: repeat(
+      auto-fit,
+      minmax(clamp(150px, 22vw, 240px), 1fr)
+    );
+  }
+}
+
+@media (min-width: 1024px) {
+  .hud-root {
+    grid-template-columns:
+      minmax(clamp(260px, 28vw, 360px), 1fr)
+      minmax(clamp(360px, 56vw, 780px), 2fr);
+    grid-template-areas:
+      "panel stage"
+      "footer stage";
+    align-items: start;
+  }
+
+  .hud-root .hud-panel {
+    align-content: start;
+  }
+
+  .hud-root .game-stage {
+    justify-content: center;
+    padding: clamp(16px, 3vw, 40px);
+  }
+
+  .hud-root .game-stage #gameCanvas {
+    width: clamp(340px, 48vw, 720px);
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import {
   startGame,
   handleCanvasClick,
 } from "./game/systems/index.js";
+import { HudRoot } from "./hud/HudRoot.js";
 
 function bindInput(canvas) {
   const pressAction = (event) => {
@@ -75,17 +76,11 @@ function init() {
   canvas.setAttribute("aria-label", "Flappy Bird 3D playfield");
   canvas.setAttribute("tabindex", "0");
 
+  const hudRoot = new HudRoot();
+
   const state = createGameState(canvas);
   initializeGameLoop(state, {
-    hudElements: {
-      score: "#scoreValue",
-      best: "#bestValue",
-      message: "#gameMessage",
-      startButton: "#startButton",
-      overlay: "#gameOverlay",
-      speedBar: "#speedFill",
-      speedProgress: "#speedProgress",
-    },
+    hudElements: hudRoot.getElements(),
   });
 
   bindInput(canvas);


### PR DESCRIPTION
## Summary
- add a scoped HUD layout stylesheet with grid and flex breakpoints that use clamp-based sizing
- introduce a HudRoot helper that imports the layout styles and returns resolved HUD elements
- mark the HUD root in the markup and initialize the game loop with HudRoot-managed elements

## Testing
- npm run lint *(fails: existing TypeScript parsing issues in legacy files)*
- Playwright viewport sweep of layout playground at widths 320px–1920px

------
https://chatgpt.com/codex/tasks/task_e_68e0618948748328819cbd4e48daa934