### PR TITLE
Add throttled score pop animation for HUD updates

### DIFF
--- a/src/hud/components/Score.test.ts
+++ b/src/hud/components/Score.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SCORE_POP_CLASS,
+  Score,
+  dispatchScoreEvent,
+} from './Score';
+
+describe('HUD Score component', () => {
+  it('toggles the pop class for each score event while updating the text', () => {
+    vi.useFakeTimers();
+
+    const element = document.createElement('span');
+    const score = new Score({
+      element,
+      throttleMs: 100,
+      popDurationMs: 60,
+    });
+
+    try {
+      dispatchScoreEvent(element, 1);
+      expect(element.textContent).toBe('1');
+      expect(element.classList.contains(SCORE_POP_CLASS)).toBe(true);
+
+      dispatchScoreEvent(element, 2);
+      dispatchScoreEvent(element, 3);
+      expect(element.textContent).toBe('3');
+
+      // First animation completes and removes the class
+      vi.advanceTimersByTime(60);
+      expect(element.classList.contains(SCORE_POP_CLASS)).toBe(false);
+
+      // After the throttle window the queued event animates again
+      vi.advanceTimersByTime(40);
+      expect(element.classList.contains(SCORE_POP_CLASS)).toBe(true);
+
+      // Second animation completes and removes the class again
+      vi.advanceTimersByTime(60);
+      expect(element.classList.contains(SCORE_POP_CLASS)).toBe(false);
+
+      // Final queued event should animate after another throttle window
+      vi.advanceTimersByTime(40);
+      expect(element.classList.contains(SCORE_POP_CLASS)).toBe(true);
+
+      vi.advanceTimersByTime(60);
+      expect(element.classList.contains(SCORE_POP_CLASS)).toBe(false);
+    } finally {
+      score.dispose();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/hud/components/Score.ts
+++ b/src/hud/components/Score.ts
@@ -1,0 +1,181 @@
+import '../styles/score-pop.css';
+
+export const SCORE_EVENT = 'hud:score';
+export const SCORE_POP_CLASS = 'is-score-pop';
+const DEFAULT_THROTTLE_MS = 180;
+const DEFAULT_POP_DURATION_MS = 220;
+
+export interface ScoreEventDetail {
+  value: number;
+}
+
+export type ScoreEvent = CustomEvent<ScoreEventDetail>;
+
+export interface ScoreOptions {
+  element: HTMLElement;
+  eventTarget?: EventTarget;
+  eventName?: string;
+  throttleMs?: number;
+  popDurationMs?: number;
+  popClassName?: string;
+  formatValue?: (value: number) => string;
+}
+
+export interface ScoreSetOptions {
+  animate?: boolean;
+  force?: boolean;
+}
+
+export function createScoreEvent(value: number): ScoreEvent {
+  return new CustomEvent<ScoreEventDetail>(SCORE_EVENT, {
+    detail: { value },
+  });
+}
+
+export function dispatchScoreEvent(target: EventTarget, value: number): boolean {
+  return target.dispatchEvent(createScoreEvent(value));
+}
+
+export class Score {
+  private readonly element: HTMLElement;
+
+  private readonly eventTarget: EventTarget;
+
+  private readonly eventName: string;
+
+  private readonly popClassName: string;
+
+  private readonly throttleMs: number;
+
+  private readonly popDurationMs: number;
+
+  private readonly formatValue: (value: number) => string;
+
+  private currentValue: number | null = null;
+
+  private pendingPops = 0;
+
+  private processingQueue = false;
+
+  private throttleTimer: number | null = null;
+
+  private removalTimer: number | null = null;
+
+  constructor(options: ScoreOptions) {
+    if (!options?.element) {
+      throw new Error('Score HUD requires an element to control');
+    }
+
+    this.element = options.element;
+    this.eventTarget = options.eventTarget ?? options.element;
+    this.eventName = options.eventName ?? SCORE_EVENT;
+    this.popClassName = options.popClassName ?? SCORE_POP_CLASS;
+    this.throttleMs = Math.max(0, options.throttleMs ?? DEFAULT_THROTTLE_MS);
+    this.popDurationMs = Math.max(0, options.popDurationMs ?? DEFAULT_POP_DURATION_MS);
+    this.formatValue = options.formatValue ?? ((value: number) => String(value));
+
+    this.eventTarget.addEventListener(this.eventName, this.handleScoreEvent as EventListener);
+  }
+
+  public dispose(): void {
+    this.eventTarget.removeEventListener(
+      this.eventName,
+      this.handleScoreEvent as EventListener
+    );
+    if (this.throttleTimer !== null) {
+      clearTimeout(this.throttleTimer);
+      this.throttleTimer = null;
+    }
+    if (this.removalTimer !== null) {
+      clearTimeout(this.removalTimer);
+      this.removalTimer = null;
+    }
+    this.pendingPops = 0;
+    this.processingQueue = false;
+  }
+
+  public setValue(value: number, options: ScoreSetOptions = {}): void {
+    const animate = options.animate ?? true;
+    const force = options.force ?? false;
+    this.updateDisplay(value, { animate, force });
+  }
+
+  private handleScoreEvent = (event: Event): void => {
+    if (!(event instanceof CustomEvent)) {
+      return;
+    }
+
+    const detail = event.detail as Partial<ScoreEventDetail> | null;
+    const value = detail?.value;
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      return;
+    }
+
+    this.updateDisplay(value, { animate: true, force: false });
+  };
+
+  private updateDisplay(
+    value: number,
+    options: { animate: boolean; force: boolean }
+  ): void {
+    const { animate, force } = options;
+    const previous = this.currentValue;
+    this.currentValue = value;
+    this.element.textContent = this.formatValue(value);
+
+    if (!animate) {
+      return;
+    }
+
+    if (force || previous === null || value > previous) {
+      this.enqueuePop();
+    }
+  }
+
+  private enqueuePop(): void {
+    this.pendingPops += 1;
+    if (!this.processingQueue) {
+      this.processingQueue = true;
+      this.processQueue();
+    }
+  }
+
+  private processQueue(): void {
+    if (this.pendingPops === 0) {
+      this.processingQueue = false;
+      return;
+    }
+
+    this.pendingPops -= 1;
+    this.triggerPop();
+
+    if (this.throttleMs === 0) {
+      this.processQueue();
+      return;
+    }
+
+    this.throttleTimer = window.setTimeout(() => {
+      this.throttleTimer = null;
+      this.processQueue();
+    }, this.throttleMs);
+  }
+
+  private triggerPop(): void {
+    if (this.removalTimer !== null) {
+      clearTimeout(this.removalTimer);
+      this.removalTimer = null;
+    }
+
+    this.element.classList.remove(this.popClassName);
+    // Force layout so the browser registers the class re-addition.
+    void this.element.offsetWidth;
+    this.element.classList.add(this.popClassName);
+
+    if (this.popDurationMs > 0) {
+      this.removalTimer = window.setTimeout(() => {
+        this.element.classList.remove(this.popClassName);
+        this.removalTimer = null;
+      }, this.popDurationMs);
+    }
+  }
+}

--- a/src/hud/styles/score-pop.css
+++ b/src/hud/styles/score-pop.css
@@ -1,0 +1,42 @@
+@keyframes score-pop {
+  0% {
+    transform: scale(1);
+    text-shadow: none;
+  }
+
+  40% {
+    transform: scale(1.2);
+    text-shadow: 0 0.2em 0.4em rgba(0, 0, 0, 0.35);
+  }
+
+  100% {
+    transform: scale(1);
+    text-shadow: none;
+  }
+}
+
+@keyframes score-pop-reduced {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.75;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+.hud-value.is-score-pop {
+  animation: score-pop 220ms cubic-bezier(0.17, 0.89, 0.32, 1.28);
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hud-value.is-score-pop {
+    animation: score-pop-reduced 220ms ease-out;
+    transform: none;
+  }
+}

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,3 +1,5 @@
+import { Score } from "../hud/components/Score.ts";
+
 const noop = () => {};
 
 function resolveElement(element) {
@@ -14,6 +16,14 @@ function resolveElement(element) {
 
 export function createHudController(elements = {}) {
   const scoreEl = resolveElement(elements.score ?? "#scoreValue");
+  const scoreHud =
+    scoreEl instanceof HTMLElement ? new Score({ element: scoreEl }) : null;
+  if (scoreHud && scoreEl instanceof HTMLElement) {
+    const initialText = scoreEl.textContent ?? "";
+    const parsedInitial = Number.parseInt(initialText, 10);
+    const initialValue = Number.isNaN(parsedInitial) ? 0 : parsedInitial;
+    scoreHud.setValue(initialValue, { animate: false });
+  }
   const bestEl = resolveElement(elements.best ?? "#bestValue");
   const messageEl = resolveElement(elements.message ?? "#gameMessage");
   const overlay = resolveElement(elements.overlay ?? "#gameOverlay");
@@ -52,7 +62,11 @@ export function createHudController(elements = {}) {
 
   return {
     setScore(value) {
-      safeText(scoreEl, value);
+      if (scoreHud) {
+        scoreHud.setValue(value);
+      } else {
+        safeText(scoreEl, value);
+      }
     },
     setBest(value) {
       safeText(bestEl, value);


### PR DESCRIPTION
## Summary
- introduce a TypeScript HUD score component that listens for ScoreEvent updates, throttles repeated animations, and exposes helpers for dispatching events
- add a score pop animation stylesheet with reduced-motion friendly keyframes and wire the component into the existing HUD controller
- cover the new behavior with Vitest to ensure the pop class toggles for every queued score event

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e06188500483289ecac2093f1c27bf