### PR TITLE
Add mount animation for score HUD

### DIFF
--- a/src/hud/components/ScoreAnim.test.ts
+++ b/src/hud/components/ScoreAnim.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SCORE_ANIM_CLASS,
+  SCORE_ANIM_ENTER_CLASS,
+  SCORE_ANIM_VISIBLE_CLASS,
+  applyScoreMountAnimation,
+} from "./ScoreAnim";
+
+describe("applyScoreMountAnimation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      ((callback: FrameRequestCallback) => {
+        return setTimeout(() => callback(Date.now()), 16) as unknown as number;
+      }) satisfies typeof requestAnimationFrame
+    );
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("applies base and enter classes immediately", () => {
+    const element = document.createElement("span");
+
+    applyScoreMountAnimation(element);
+
+    expect(element.classList.contains(SCORE_ANIM_CLASS)).toBe(true);
+    expect(element.classList.contains(SCORE_ANIM_ENTER_CLASS)).toBe(true);
+    expect(element.classList.contains(SCORE_ANIM_VISIBLE_CLASS)).toBe(false);
+  });
+
+  it("transitions to the visible state on the next frame", () => {
+    const element = document.createElement("span");
+
+    applyScoreMountAnimation(element);
+    vi.runAllTimers();
+
+    expect(element.classList.contains(SCORE_ANIM_ENTER_CLASS)).toBe(false);
+    expect(element.classList.contains(SCORE_ANIM_VISIBLE_CLASS)).toBe(true);
+  });
+
+  it("runs only once per target", () => {
+    const element = document.createElement("span");
+
+    applyScoreMountAnimation(element);
+    applyScoreMountAnimation(element);
+    vi.runAllTimers();
+
+    expect(element.getAttribute("data-score-anim")).toBe("true");
+    expect(element.classList.contains(SCORE_ANIM_VISIBLE_CLASS)).toBe(true);
+  });
+
+  it("ignores non-HTMLElement targets", () => {
+    const textNode = document.createTextNode("0");
+
+    // @ts-expect-error intentionally passing an invalid target to ensure it is ignored
+    applyScoreMountAnimation(textNode);
+
+    expect(textNode.parentElement).toBeNull();
+  });
+});

--- a/src/hud/components/ScoreAnim.ts
+++ b/src/hud/components/ScoreAnim.ts
@@ -1,0 +1,36 @@
+import "../styles/score-anim.css";
+
+export const SCORE_ANIM_CLASS = "score-anim";
+export const SCORE_ANIM_ENTER_CLASS = "score-anim--enter";
+export const SCORE_ANIM_VISIBLE_CLASS = "score-anim--entered";
+const SCORE_ANIM_APPLIED_ATTR = "data-score-anim";
+
+function scheduleFrame(callback: FrameRequestCallback) {
+  if (typeof globalThis.requestAnimationFrame === "function") {
+    return globalThis.requestAnimationFrame(callback);
+  }
+
+  globalThis.setTimeout(() => {
+    callback(Date.now());
+  }, 16);
+
+  return 0;
+}
+
+export function applyScoreMountAnimation(target: Element | null) {
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  if (target.hasAttribute(SCORE_ANIM_APPLIED_ATTR)) {
+    return;
+  }
+
+  target.setAttribute(SCORE_ANIM_APPLIED_ATTR, "true");
+  target.classList.add(SCORE_ANIM_CLASS, SCORE_ANIM_ENTER_CLASS);
+
+  scheduleFrame(() => {
+    target.classList.remove(SCORE_ANIM_ENTER_CLASS);
+    target.classList.add(SCORE_ANIM_VISIBLE_CLASS);
+  });
+}

--- a/src/hud/styles/score-anim.css
+++ b/src/hud/styles/score-anim.css
@@ -1,0 +1,31 @@
+.score-anim {
+  --score-anim-duration: 220ms;
+  --score-anim-ease: cubic-bezier(0.25, 0.8, 0.25, 1);
+  transform: scale(1);
+  opacity: 1;
+  transition: transform var(--score-anim-duration) var(--score-anim-ease),
+    opacity var(--score-anim-duration) var(--score-anim-ease);
+  transform-origin: center;
+  will-change: transform, opacity;
+}
+
+.score-anim.score-anim--enter {
+  transform: scale(0.75);
+  opacity: 0;
+}
+
+.score-anim.score-anim--entered {
+  transform: scale(1);
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .score-anim {
+    transition: none;
+  }
+
+  .score-anim.score-anim--enter {
+    transform: none;
+    opacity: 1;
+  }
+}

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,3 +1,5 @@
+import { applyScoreMountAnimation } from "../hud/components/ScoreAnim.ts";
+
 const noop = () => {};
 
 function resolveElement(element) {
@@ -20,6 +22,8 @@ export function createHudController(elements = {}) {
   const startButton = resolveElement(elements.startButton ?? "#startButton");
   const speedBar = resolveElement(elements.speedBar ?? "#speedFill");
   const speedProgress = resolveElement(elements.speedProgress ?? "#speedProgress");
+
+  applyScoreMountAnimation(scoreEl?.closest(".hud-metric") ?? scoreEl);
 
   const safeText = (target, value) => {
     if (!target) return;

--- a/src/rendering/index.test.ts
+++ b/src/rendering/index.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SCORE_ANIM_CLASS, SCORE_ANIM_ENTER_CLASS, SCORE_ANIM_VISIBLE_CLASS } from "../hud/components/ScoreAnim";
+import { createHudController } from "./index.js";
+
+describe("createHudController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      ((callback: FrameRequestCallback) => {
+        return setTimeout(() => callback(Date.now()), 16) as unknown as number;
+      }) satisfies typeof requestAnimationFrame
+    );
+
+    document.body.innerHTML = `
+      <div class="hud-panel">
+        <div class="hud-metric" aria-live="polite">
+          <span class="hud-label">Score</span>
+          <span id="scoreValue" class="hud-value">0</span>
+        </div>
+      </div>
+    `;
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("triggers the intro animation for the score metric", () => {
+    createHudController();
+
+    const metric = document.querySelector(".hud-metric");
+    expect(metric?.classList.contains(SCORE_ANIM_CLASS)).toBe(true);
+    expect(metric?.classList.contains(SCORE_ANIM_ENTER_CLASS)).toBe(true);
+
+    vi.runAllTimers();
+
+    expect(metric?.classList.contains(SCORE_ANIM_ENTER_CLASS)).toBe(false);
+    expect(metric?.classList.contains(SCORE_ANIM_VISIBLE_CLASS)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a ScoreAnim helper that applies the score intro animation and wire in dedicated CSS with reduced-motion support
- trigger the animation when the HUD is created so the score metric scales in on first mount
- cover the helper and HUD animation wiring with interaction-focused Vitest suites

## Testing
- npm run test
- npm run typecheck *(fails: existing TypeScript errors in prng tests and three module typings)*

------
https://chatgpt.com/codex/tasks/task_e_68e06187e710832880b78c69bcbf3868