### PR TITLE
Enhance HUD score contrast

### DIFF
--- a/src/hud/Score.ts
+++ b/src/hud/Score.ts
@@ -1,0 +1,35 @@
+import "./styles/score-contrast.css";
+
+type ScoreValue = number | string;
+
+type ResolvableElement = string | HTMLElement | null | undefined;
+
+export class Score {
+  private readonly element: HTMLElement | null;
+
+  constructor(target: ResolvableElement) {
+    this.element = Score.resolve(target);
+    this.element?.classList.add("hud-score-contrast");
+  }
+
+  set(value: ScoreValue): void {
+    if (!this.element) return;
+    this.element.textContent = typeof value === "number" ? value.toString() : value;
+  }
+
+  get node(): HTMLElement | null {
+    return this.element;
+  }
+
+  private static resolve(target: ResolvableElement): HTMLElement | null {
+    if (!target) {
+      return null;
+    }
+
+    if (typeof target === "string") {
+      return document.querySelector<HTMLElement>(target);
+    }
+
+    return target;
+  }
+}

--- a/src/hud/styles/score-contrast.css
+++ b/src/hud/styles/score-contrast.css
@@ -1,0 +1,10 @@
+@import "./tokens.css";
+
+.hud-score-contrast {
+  text-shadow:
+    var(--hud-score-shadow-secondary),
+    var(--hud-score-shadow-primary),
+    var(--hud-score-shadow-highlight);
+  -webkit-text-stroke: var(--hud-score-outline-width) var(--hud-score-outline-color);
+  paint-order: stroke fill;
+}

--- a/src/hud/styles/tokens.css
+++ b/src/hud/styles/tokens.css
@@ -1,0 +1,7 @@
+:root {
+  --hud-score-outline-width: 1.5px;
+  --hud-score-outline-color: rgba(15, 23, 42, 0.92);
+  --hud-score-shadow-primary: 0 4px 10px rgba(15, 23, 42, 0.55);
+  --hud-score-shadow-secondary: 0 0 2px rgba(15, 23, 42, 0.85);
+  --hud-score-shadow-highlight: 0 0 6px rgba(255, 255, 255, 0.45);
+}

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,3 +1,5 @@
+import { Score as ScoreDisplay } from "../hud/Score.ts";
+
 const noop = () => {};
 
 function resolveElement(element) {
@@ -14,6 +16,7 @@ function resolveElement(element) {
 
 export function createHudController(elements = {}) {
   const scoreEl = resolveElement(elements.score ?? "#scoreValue");
+  const scoreDisplay = scoreEl ? new ScoreDisplay(scoreEl) : null;
   const bestEl = resolveElement(elements.best ?? "#bestValue");
   const messageEl = resolveElement(elements.message ?? "#gameMessage");
   const overlay = resolveElement(elements.overlay ?? "#gameOverlay");
@@ -52,6 +55,11 @@ export function createHudController(elements = {}) {
 
   return {
     setScore(value) {
+      if (scoreDisplay) {
+        scoreDisplay.set(value);
+        return;
+      }
+
       safeText(scoreEl, value);
     },
     setBest(value) {


### PR DESCRIPTION
## Summary
- add HUD score contrast tokens and styles for a high-contrast score readout
- apply the new score styling class from Score.ts via the HUD controller

## Testing
- npm run test
- npm run typecheck *(fails: existing missing types for three.js modules and implicit any in legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e0618749c88328ab97969fec16af17