### PR TITLE
Fix HUD localization constants and rebuild HUD controller

### DIFF
--- a/src/hud/hud-i18n.ts
+++ b/src/hud/hud-i18n.ts
@@ -1,3 +1,5 @@
+const DEFAULT_LOCALE = 'en' as const;
+
 const HUD_MESSAGES = {
   en: {
     'hud.hints.title': 'Flight academy',
@@ -32,13 +34,13 @@ export const HINT_KEYS = [
 export type HintKey = (typeof HINT_KEYS)[number];
 export type HudLocale = keyof typeof HUD_MESSAGES;
 
-const DEFAULT_LOCALE: HudLocale = 'en';
+const DEFAULT_HINT_LOCALE: HudLocale = DEFAULT_LOCALE;
 
 const SUPPORTED_LOCALES = Object.keys(HUD_MESSAGES) as HudLocale[];
 
 export function resolveLocale(input?: string | null): HudLocale {
   if (!input) {
-    return DEFAULT_LOCALE;
+    return DEFAULT_HINT_LOCALE;
   }
 
   const normalized = input.toLowerCase();
@@ -51,7 +53,7 @@ export function resolveLocale(input?: string | null): HudLocale {
     return languageCode as HudLocale;
   }
 
-  return DEFAULT_LOCALE;
+  return DEFAULT_HINT_LOCALE;
 }
 
 export type HudMessageKey = HintKey | 'hud.hints.title';
@@ -59,7 +61,7 @@ export type HudMessageKey = HintKey | 'hud.hints.title';
 export function translate(locale: string | undefined, key: HudMessageKey): string {
   const resolved = resolveLocale(locale);
   const messages = HUD_MESSAGES[resolved];
-  const fallback = HUD_MESSAGES[DEFAULT_LOCALE];
+  const fallback = HUD_MESSAGES[DEFAULT_HINT_LOCALE];
   return messages[key] ?? fallback[key];
 }
 
@@ -88,18 +90,24 @@ export type HudStringKey = keyof typeof ENGLISH_DICTIONARY;
 
 type HudDictionary = Record<HudStringKey, string>;
 
+const SPANISH_DICTIONARY: HudDictionary = {
+  scoreLabel: 'Puntuación',
+  bestLabel: 'Mejor',
+  tapToStart: 'Toca para comenzar',
+};
+
 const FRENCH_DICTIONARY: HudDictionary = {
   scoreLabel: 'Score',
   bestLabel: 'Record',
   tapToStart: 'Touchez pour commencer',
 };
 
-const DICTIONARIES: Record<string, HudDictionary> = {
+const DICTIONARIES: Record<HudLocale, HudDictionary> = {
   en: ENGLISH_DICTIONARY,
+  es: SPANISH_DICTIONARY,
   fr: FRENCH_DICTIONARY,
 };
 
-const DEFAULT_LOCALE = 'en';
 const LOCALE_SEPARATOR_REGEX = /[-_]/;
 
 const normalizeLocale = (locale?: string): string => {

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,7 +1,6 @@
 import { createGameOverTitle } from "../hud/components/GameOverTitle.ts";
 import { MedalBanner } from "../hud/components/MedalBanner.ts";
 import { hudAdapter, Medal } from "../hud/adapter.ts";
-
 export { hudAdapter, Medal } from "../hud/adapter.ts";
 import { PerfectIndicator } from "../hud/components/PerfectIndicator.ts";
 import { createHapticsAdapter } from "../hud/util/haptics.ts";
@@ -9,66 +8,130 @@ import {
   emitBestRibbonEvent,
   ensureBestRibbon,
 } from "../hud/components/BestRibbon.ts";
-import { getMedalForScore, Medal } from "../hud/logic/medals";
+import { getMedalForScore } from "../hud/logic/medals.ts";
 import { FinalScore } from "../hud/components/FinalScore.ts";
 import { HudRoot } from "../hud/HudRoot.ts";
 import { PauseMenu } from "../hud/components/PauseMenu.ts";
 import { DimLayer } from "../hud/components/DimLayer.ts";
 
+const DEFAULT_SELECTORS = {
+  score: "#scoreValue",
+  best: "#bestValue",
+  message: "#gameMessage",
+  overlay: "#gameOverlay",
+  startButton: "#startButton",
+  speedBar: "#speedFill",
+  speedProgress: "#speedProgress",
+  perfectIndicator: "#perfectIndicator",
+};
+
 const noop = () => {};
 
-function resolveElement(element) {
-  if (!element) {
+function resolveElement(input, fallbackSelector) {
+  const candidate = input ?? fallbackSelector;
+  if (!candidate) {
     return null;
   }
 
-  if (typeof element === "string") {
-    return document.querySelector(element);
+  if (typeof candidate === "string") {
+    return document.querySelector(candidate);
   }
 
-  return element;
+  return candidate ?? null;
+}
+
+function toNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function safeText(target, value) {
+  if (!target) return;
+  target.textContent = String(value);
+}
+
+function toggleElement(target, shouldShow) {
+  if (!target) return;
+  target.classList.toggle("is-hidden", !shouldShow);
+  if ("hidden" in target) {
+    target.hidden = !shouldShow;
+  }
+}
+
+function clamp01(value) {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, value));
 }
 
 export function createHudController(elements = {}, options = {}) {
-  const scoreEl = resolveElement(elements.score ?? "#scoreValue");
-  const bestEl = resolveElement(elements.best ?? "#bestValue");
-  const messageEl = resolveElement(elements.message ?? "#gameMessage");
-  const overlay = resolveElement(elements.overlay ?? "#gameOverlay");
-  const startButton = resolveElement(elements.startButton ?? "#startButton");
-  const speedBar = resolveElement(elements.speedBar ?? "#speedFill");
-  const speedProgress = resolveElement(elements.speedProgress ?? "#speedProgress");
-  const overlayParent =
-    overlay?.parentElement instanceof HTMLElement ? overlay.parentElement : null;
-  const medalMount =
-    resolveElement(elements.medalBanner ?? null) ?? overlayParent ?? undefined;
-
-  new MedalBanner({
-    mount: medalMount,
-  });
-  const perfectIndicatorEl = resolveElement(
-    elements.perfectIndicator ?? "#perfectIndicator"
+  const scoreEl = resolveElement(elements.score, DEFAULT_SELECTORS.score);
+  const bestEl = resolveElement(elements.best, DEFAULT_SELECTORS.best);
+  const messageEl = resolveElement(elements.message, DEFAULT_SELECTORS.message);
+  const overlay = resolveElement(elements.overlay, DEFAULT_SELECTORS.overlay);
+  const startButton = resolveElement(elements.startButton, DEFAULT_SELECTORS.startButton);
+  const speedBar = resolveElement(elements.speedBar, DEFAULT_SELECTORS.speedBar);
+  const speedProgress = resolveElement(
+    elements.speedProgress,
+    DEFAULT_SELECTORS.speedProgress,
   );
+  const perfectIndicatorRoot = resolveElement(
+    elements.perfectIndicator,
+    DEFAULT_SELECTORS.perfectIndicator,
+  );
+  const medalEl = resolveElement(elements.medal, null);
+  const medalBannerMount = resolveElement(elements.medalBanner, null);
 
-  const toNumeric = (value, fallback = 0) => {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
-  const medalEl = resolveElement(elements.medal);
+  if (startButton instanceof HTMLButtonElement && !startButton.hasAttribute("type")) {
+    startButton.type = "button";
+  }
+
+  const overlayParent = overlay?.parentElement ?? null;
+  const medalBanner = new MedalBanner({
+    mount: medalBannerMount ?? overlayParent ?? undefined,
+  });
 
   const haptics = options.haptics ?? createHapticsAdapter();
   const supportsHaptics = Boolean(haptics?.supported);
-  let lastScore = 0;
-  let lastMedal = null;
-  const finalScore = overlay ? new FinalScore() : null;
 
+  const eventTarget = typeof EventTarget !== "undefined" ? new EventTarget() : null;
+
+  const addEventListener = (type, handler) => {
+    if (!eventTarget) return noop;
+    eventTarget.addEventListener(type, handler);
+    return () => eventTarget.removeEventListener(type, handler);
+  };
+
+  const removeEventListener = (type, handler) => {
+    eventTarget?.removeEventListener(type, handler);
+  };
+
+  const emitEvent = (type, detail) => {
+    if (!eventTarget) return;
+    eventTarget.dispatchEvent(new CustomEvent(type, { detail }));
+  };
+
+  const perfectIndicator =
+    perfectIndicatorRoot && eventTarget
+      ? new PerfectIndicator({
+          root: perfectIndicatorRoot,
+          adapter: {
+            on: (type, handler) => addEventListener(type, handler),
+            off: (type, handler) => removeEventListener(type, handler),
+          },
+        })
+      : null;
+
+  const finalScore = overlay ? new FinalScore() : null;
   if (overlay && finalScore) {
-    finalScore.attach(overlay, startButton);
+    finalScore.attach(overlay, startButton ?? null);
     finalScore.hide();
   }
+
   const dimLayer = overlay ? new DimLayer(overlay) : null;
 
-  const hudRootHost = overlay?.parentElement ?? document.body;
-  const hudRoot = new HudRoot({ host: hudRootHost });
+  const hudRoot = new HudRoot({ host: overlayParent ?? document.body });
   const pauseMenu = new PauseMenu();
   hudRoot.mount(pauseMenu.element, "modal");
 
@@ -81,70 +144,64 @@ export function createHudController(elements = {}, options = {}) {
     }
   }
 
-  const safeText = (target, value) => {
-    if (!target) return;
-    target.textContent = String(value);
+  ensureBestRibbon();
+
+  let lastScore = toNumber(scoreEl?.textContent ?? 0);
+  let currentScore = lastScore;
+  let currentBest = toNumber(bestEl?.textContent ?? 0);
+  let tieAnnouncedAt = 0;
+  let bestThreshold = currentBest;
+  let lastBeatScore = 0;
+  let currentMedal = Medal.None;
+  let lastMedalLabel = medalEl?.textContent ?? null;
+
+  const medalListeners = new Set();
+  const cleanupTasks = new Set();
+
+  const registerCleanup = (task) => {
+    cleanupTasks.add(task);
+    return () => {
+      cleanupTasks.delete(task);
+      task();
+    };
   };
 
-  const toggle = (target, shouldShow) => {
-    if (!target) return;
-    target.classList.toggle("is-hidden", !shouldShow);
-  };
-
-  const setSpeed = (ratio) => {
-    const clamped = Math.max(0, Math.min(1, Number.isFinite(ratio) ? ratio : 0));
-    if (speedBar) {
-      speedBar.style.width = `${clamped * 100}%`;
-    }
-    if (speedProgress) {
-      speedProgress.setAttribute("aria-valuenow", String(Math.round(clamped * 100)));
-    }
-  };
-
-  const eventTarget = typeof EventTarget !== "undefined" ? new EventTarget() : null;
-
-  const emitEvent = (type, detail) => {
-    if (!eventTarget) return;
-    eventTarget.dispatchEvent(new CustomEvent(type, { detail }));
-  };
-
-  const addEventListener = (type, handler) => {
-    if (!eventTarget) {
-      return noop;
-    }
-    eventTarget.addEventListener(type, handler);
-    return () => eventTarget.removeEventListener(type, handler);
-  };
-
-  const removeEventListener = (type, handler) => {
-    eventTarget?.removeEventListener(type, handler);
-  };
-
-  const perfectIndicator =
-    perfectIndicatorEl && eventTarget
-      ? new PerfectIndicator({
-          root: perfectIndicatorEl,
-          adapter: {
-            on: (type, handler) => addEventListener(type, handler),
-            off: (type, handler) => removeEventListener(type, handler),
-          },
-        })
-      : null;
-
-  let lastScore = toNumeric(scoreEl?.textContent ?? 0);
+  if (startButton) {
+    const blurOnActivate = () => {
+      if (typeof startButton.blur === "function") {
+        startButton.blur();
+      }
+    };
+    startButton.addEventListener("click", blurOnActivate);
+    registerCleanup(() => {
+      startButton.removeEventListener("click", blurOnActivate);
+    });
+  }
 
   const showMessage = (text) => {
     if (!messageEl) return;
     messageEl.textContent = text;
   };
 
-  ensureBestRibbon();
+  const updateMedalDisplay = (medal) => {
+    if (!medalEl) return;
+    medalEl.textContent = medal ?? "";
+    if (medal) {
+      medalEl.dataset.medal = medal;
+    } else {
+      delete medalEl.dataset.medal;
+    }
+  };
 
-  let currentScore = 0;
-  let currentBest = 0;
-  let tieAnnouncedAt = 0;
-  let bestThreshold = 0;
-  let lastBeatScore = 0;
+  const notifyMedalChange = (medal) => {
+    medalListeners.forEach((listener) => {
+      try {
+        listener(medal);
+      } catch (error) {
+        console.error("HUD medal listener error", error);
+      }
+    });
+  };
 
   const announceMilestone = () => {
     if (currentScore <= 0) {
@@ -174,135 +231,159 @@ export function createHudController(elements = {}, options = {}) {
     lastBeatScore = 0;
   };
 
-  startButton?.addEventListener("click", () => {
-    startButton.blur();
-  });
-
-  let currentMedal = Medal.None;
-  const medalListeners = new Set();
-
-  const notifyMedalChange = (medal) => {
-    medalListeners.forEach((listener) => {
-      try {
-        listener(medal);
-      } catch (error) {
-        console.error("HUD medal listener error", error);
-      }
-    });
+  const handleScoreHaptics = (value, delta) => {
+    if (!supportsHaptics || typeof haptics.scoreMilestone !== "function") {
+      return;
+    }
+    if (delta > 0) {
+      haptics.scoreMilestone(value);
+    }
   };
 
-  return {
+  const handleMedalHaptics = (medal) => {
+    if (!supportsHaptics || typeof haptics.medalEarned !== "function") {
+      return;
+    }
+    if (medal && medal !== Medal.None) {
+      haptics.medalEarned(medal);
+    }
+  };
+
+  const updateMedal = (medal) => {
+    if (medal === currentMedal) {
+      return;
+    }
+    currentMedal = medal;
+    updateMedalDisplay(medal === Medal.None ? "" : medal);
+    handleMedalHaptics(medal);
+    notifyMedalChange(medal);
+  };
+
+  const controller = {
     setScore(value) {
-      const numericValue = toNumeric(value, 0);
+      const numericValue = toNumber(value, 0);
+      const detail = {
+        value: numericValue,
+        previous: lastScore,
+        delta: numericValue - lastScore,
+      };
+
       safeText(scoreEl, numericValue);
-      if (numericValue !== lastScore) {
-        const detail = {
-          value: numericValue,
-          previous: lastScore,
-          delta: numericValue - lastScore,
-        };
+
+      if (detail.delta !== 0) {
         emitEvent("score:change", detail);
         if (detail.delta > 0) {
           emitEvent("score:increment", detail);
-        } else if (detail.delta < 0) {
+        } else {
           emitEvent("score:decrement", detail);
         }
-        lastScore = numericValue;
-      currentScore = Number(value) || 0;
-      safeText(scoreEl, value);
-      const numericValue = Number(value);
-      if (
-        supportsHaptics &&
-        Number.isFinite(numericValue) &&
-        numericValue > lastScore &&
-        typeof haptics.scoreMilestone === "function"
-      ) {
-        haptics.scoreMilestone(numericValue);
       }
-      if (Number.isFinite(numericValue)) {
-        lastScore = numericValue;
+
+      handleScoreHaptics(numericValue, detail.delta);
+
+      lastScore = numericValue;
+      currentScore = numericValue;
       announceMilestone();
-      const medal = getMedalForScore(Number(value));
-      if (medal !== currentMedal) {
-        currentMedal = medal;
-        notifyMedalChange(currentMedal);
-      }
+
+      const medal = getMedalForScore(numericValue);
+      updateMedal(medal);
     },
     setBest(value) {
-      currentBest = Number(value) || 0;
+      const numericValue = toNumber(value, 0);
+      safeText(bestEl, numericValue);
+      currentBest = numericValue;
       bestThreshold = Math.max(bestThreshold, currentBest);
-      safeText(bestEl, value);
       announceMilestone();
     },
-    setMedal(tier) {
-      if (medalEl) {
-        safeText(medalEl, tier ?? "");
+    setSpeed(ratio) {
+      const clamped = clamp01(ratio);
+      if (speedBar) {
+        speedBar.style.width = `${clamped * 100}%`;
       }
-      if (
-        supportsHaptics &&
-        tier &&
-        tier !== lastMedal &&
-        typeof haptics.medalEarned === "function"
-      ) {
-        haptics.medalEarned(tier);
+      if (speedProgress) {
+        speedProgress.setAttribute("aria-valuenow", String(Math.round(clamped * 100)));
       }
-      lastMedal = tier ?? null;
     },
-    setSpeed,
     showIntro() {
-      toggle(overlay, true);
-      gameOverTitle?.hide();
+      toggleElement(overlay, true);
       dimLayer?.setActive(true);
-      showMessage("Tap, click, or press Space to start");
+      gameOverTitle?.hide();
       finalScore?.hide();
+      showMessage("Tap, click, or press Space to start");
       if (startButton) {
         startButton.textContent = "Play";
+        toggleElement(startButton, true);
       }
-      toggle(startButton, true);
       resetMilestones();
     },
     showRunning() {
-      toggle(overlay, false);
-      gameOverTitle?.hide();
-      resetMilestones();
-      finalScore?.hide();
+      toggleElement(overlay, false);
       dimLayer?.setActive(false);
+      gameOverTitle?.hide();
+      finalScore?.hide();
+      resetMilestones();
     },
     showGameOver(score, best, options = {}) {
-      toggle(overlay, true);
-      gameOverTitle?.show();
-      showMessage(`Score: ${score} · Best: ${best}`);
-      showMessage("Game over! Tap or press Space to try again");
-      const isRecord =
-        typeof options.isNewRecord === "boolean"
-          ? options.isNewRecord
-          : score > 0 && score === best;
-      finalScore?.setScores(score, best, { isRecord });
-      finalScore?.show();
+      toggleElement(overlay, true);
       dimLayer?.setActive(true);
-      showMessage(`Game over! Score: ${score} · Best: ${best}`);
-      toggle(startButton, true);
+      gameOverTitle?.show();
+      showMessage("Game over! Tap or press Space to try again");
       if (startButton) {
         startButton.textContent = "Play again";
+        toggleElement(startButton, true);
       }
+      finalScore?.setScores(toNumber(score, 0), toNumber(best, 0), options);
+      finalScore?.show();
     },
     destroy() {
+      cleanupTasks.forEach((task) => {
+        task();
+      });
+      cleanupTasks.clear();
       perfectIndicator?.destroy();
+      medalBanner?.destroy?.();
+      pauseMenu.destroy();
+      hudRoot.destroy();
+      dimLayer?.dispose();
+      if (gameOverTitle && overlay?.contains(gameOverTitle.element)) {
+        overlay.removeChild(gameOverTitle.element);
+      }
     },
     onStart(handler = noop) {
-      startButton?.addEventListener("click", handler);
+      if (!startButton || typeof handler !== "function") {
+        return noop;
+      }
+      startButton.addEventListener("click", handler);
+      return registerCleanup(() => {
+        startButton.removeEventListener("click", handler);
+      });
     },
     onRestart(handler = noop) {
-      startButton?.addEventListener("click", handler);
+      if (!startButton || typeof handler !== "function") {
+        return noop;
+      }
+      startButton.addEventListener("click", handler);
+      return registerCleanup(() => {
+        startButton.removeEventListener("click", handler);
+      });
     },
     awardMedal(event) {
+      if (!event || !event.medal) {
+        hudAdapter.emitMedal({ medal: Medal.None });
+        updateMedal(Medal.None);
+        return;
+      }
       hudAdapter.emitMedal(event);
+      updateMedal(event.medal);
     },
     clearMedal() {
       hudAdapter.emitMedal({ medal: Medal.None });
+      updateMedal(Medal.None);
+    },
     events: {
       on: addEventListener,
       off: removeEventListener,
+    },
     onMedalChange(handler = noop) {
       if (typeof handler !== "function") {
         return noop;
@@ -314,11 +395,14 @@ export function createHudController(elements = {}, options = {}) {
     },
     getCurrentMedal() {
       return currentMedal;
-    pauseMenu,
-    hudRoot
-    }
-    dispose() {
-      dimLayer?.dispose();
     },
+    pauseMenu,
+    hudRoot,
   };
 
+  if (lastMedalLabel && !currentMedal) {
+    updateMedalDisplay(lastMedalLabel);
+  }
+
+  return controller;
+}


### PR DESCRIPTION
## Summary
- deduplicate the HUD locale constant, reuse it for hint translation fallback, and add a Spanish dictionary so the HUD strings cover supported locales
- rebuild the HUD controller module to valid modern JavaScript, wiring HUD elements, milestone events, haptics, medal updates, and cleanup logic so the overlay can render and reset correctly

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e066c3ddf48328b03b2f0c72ade18b