### PR TITLE
Fix Medal import source in rendering index

### DIFF
--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,15 +1,16 @@
 import { createGameOverTitle } from "../hud/components/GameOverTitle.ts";
 import { MedalBanner } from "../hud/components/MedalBanner.ts";
-import { hudAdapter, Medal } from "../hud/adapter.ts";
+import { hudAdapter } from "../hud/adapter.ts";
 
-export { hudAdapter, Medal } from "../hud/adapter.ts";
+export { hudAdapter } from "../hud/adapter.ts";
+export { Medal } from "../hud/logic/medals.ts";
 import { PerfectIndicator } from "../hud/components/PerfectIndicator.ts";
 import { createHapticsAdapter } from "../hud/util/haptics.ts";
 import {
   emitBestRibbonEvent,
   ensureBestRibbon,
 } from "../hud/components/BestRibbon.ts";
-import { getMedalForScore, Medal } from "../hud/logic/medals";
+import { getMedalForScore, Medal } from "../hud/logic/medals.ts";
 import { FinalScore } from "../hud/components/FinalScore.ts";
 import { HudRoot } from "../hud/HudRoot.ts";
 import { PauseMenu } from "../hud/components/PauseMenu.ts";


### PR DESCRIPTION
## Summary
- import `Medal` exclusively from the HUD logic module while keeping `hudAdapter` sourced from its adapter file
- update the rendering barrel exports to forward `hudAdapter` and re-export `Medal` from the logic module

## Testing
- npm run lint *(fails: existing ESLint configuration cannot parse many TypeScript files in the project and reports numerous parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e06848f98c8328a95b3fa29e0d5c8e