### PR TITLE
Ensure first input flaps when starting a new round

### DIFF
--- a/src/game/systems/loop.js
+++ b/src/game/systems/loop.js
@@ -231,7 +231,14 @@ export function handleCanvasClick() {
   ensureState();
 
   if (state.awaitingStart || state.gameOver) {
+    const wasStartingRound = state.awaitingStart || state.gameOver;
     startGame();
+    if (wasStartingRound && state.isRunning && state.bird) {
+      state.bird.jump();
+      if (renderer) {
+        renderer.pulseBird();
+      }
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- trigger the bird to flap when a new round starts via the start button or keyboard so the game begins immediately
- keep the renderer pulse feedback in sync with the automatic opening flap

## Testing
- `npm run lint` *(fails: repository ESLint config does not parse the project's TypeScript sources and reports existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e0690f46208328b1443da6f6057c65