### PR TITLE
Deduplicate HUD locale fallback constant

### DIFF
--- a/src/hud/hud-i18n.ts
+++ b/src/hud/hud-i18n.ts
@@ -99,17 +99,17 @@ const DICTIONARIES: Record<string, HudDictionary> = {
   fr: FRENCH_DICTIONARY,
 };
 
-const DEFAULT_LOCALE = 'en';
+const DICTIONARY_DEFAULT_LOCALE = DEFAULT_LOCALE;
 const LOCALE_SEPARATOR_REGEX = /[-_]/;
 
 const normalizeLocale = (locale?: string): string => {
   if (!locale) {
-    return DEFAULT_LOCALE;
+    return DICTIONARY_DEFAULT_LOCALE;
   }
 
   const primarySubtag = locale.toLowerCase().split(LOCALE_SEPARATOR_REGEX)[0];
 
-  return primarySubtag || DEFAULT_LOCALE;
+  return primarySubtag || DICTIONARY_DEFAULT_LOCALE;
 };
 
 const getHudDictionary = (locale?: string): HudDictionary => {


### PR DESCRIPTION
## Summary
- reuse the HUD i18n default locale constant for both hint and dictionary translations to avoid redeclaration errors

## Testing
- npm run build
- npm run test
- npm run lint *(fails: ESLint config cannot parse existing TypeScript sources)*
- npm run typecheck *(fails: pre-existing TypeScript errors in HUD and rendering modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e0686f72548328a37130f9c23d1d8d