### PR TITLE
Trigger opening flap on first input

### DIFF
--- a/src/game/systems/loop.js
+++ b/src/game/systems/loop.js
@@ -232,6 +232,10 @@ export function handleCanvasClick() {
 
   if (state.awaitingStart || state.gameOver) {
     startGame();
+    if (state.isRunning && state.bird) {
+      state.bird.jump();
+      renderer?.pulseBird?.();
+    }
     return;
   }
 
@@ -240,9 +244,7 @@ export function handleCanvasClick() {
   }
 
   state.bird.jump();
-  if (renderer) {
-    renderer.pulseBird();
-  }
+  renderer?.pulseBird?.();
 }
 
 export function teardownGameLoop() {

--- a/src/game/systems/loop.test.ts
+++ b/src/game/systems/loop.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGameState } from "./state.js";
+import {
+  handleCanvasClick,
+  initializeGameLoop,
+  teardownGameLoop,
+} from "./loop.js";
+import { createThreeRenderer } from "../../rendering/three/renderer.js";
+
+vi.mock("../../rendering/three/renderer.js", () => ({
+  createThreeRenderer: vi.fn(() => ({
+    render: vi.fn(),
+    pulseBird: vi.fn(),
+    markGameOver: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
+vi.mock("../../rendering/index.js", () => ({
+  createHudController: vi.fn(() => ({
+    setScore: vi.fn(),
+    setBest: vi.fn(),
+    setSpeed: vi.fn(),
+    showIntro: vi.fn(),
+    showRunning: vi.fn(),
+    showGameOver: vi.fn(),
+    destroy: vi.fn(),
+    awardMedal: vi.fn(),
+    clearMedal: vi.fn(),
+    onStart: vi.fn(),
+    onRestart: vi.fn(),
+    pauseMenu: { destroy: vi.fn() },
+    hudRoot: { destroy: vi.fn() },
+    events: { on: vi.fn(), off: vi.fn() },
+  })),
+}));
+
+describe("handleCanvasClick", () => {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.requestAnimationFrame = vi.fn(() => 1) as any;
+    globalThis.cancelAnimationFrame = vi.fn() as any;
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    teardownGameLoop();
+    document.body.innerHTML = "";
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  it("starts the round with an immediate flap on the first interaction", () => {
+    const canvas = document.createElement("canvas");
+    document.body.appendChild(canvas);
+    const gameState = createGameState(canvas) as any;
+
+    initializeGameLoop(gameState);
+
+    expect(gameState.awaitingStart).toBe(true);
+    handleCanvasClick();
+
+    expect(gameState.isRunning).toBe(true);
+    expect(gameState.awaitingStart).toBe(false);
+    expect(gameState.bird).not.toBeNull();
+    expect(gameState.bird.velocity).toBeLessThan(0);
+
+    const rendererFactory = vi.mocked(createThreeRenderer);
+    const lastCallIndex = rendererFactory.mock.results.length - 1;
+    const rendererInstance =
+      lastCallIndex >= 0 ? rendererFactory.mock.results[lastCallIndex]?.value : null;
+    expect(rendererInstance?.pulseBird).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- trigger an immediate flap and renderer pulse when a round starts from the intro or game-over state so the bird never drops on the first tap
- cover the new interaction with a loop-level unit test that stubs the renderer and HUD to verify the behavior

## Testing
- npm test -- --run
- npm run typecheck *(fails: existing repo errors around missing Three.js type declarations and generic constraints in HUD utilities)*
- npm run lint *(fails: existing repo parsing errors when ESLint processes TypeScript sources)*

------
https://chatgpt.com/codex/tasks/task_e_68e0697070d8832883395df4528a243c