### PR TITLE
Fix typecheck and lint configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,6 @@
 dist
 node_modules
+coverage
+docs
+playgrounds
+**/*.d.ts

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -2,12 +2,45 @@ module.exports = {
   root: true,
   env: {
     browser: true,
-    es2022: true,
+    es2023: true,
   },
   extends: ["eslint:recommended"],
   parserOptions: {
     ecmaVersion: "latest",
     sourceType: "module",
   },
-  rules: {},
+  rules: {
+    "no-useless-escape": "off",
+    "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+  },
+  overrides: [
+    {
+      files: ["**/*.ts"],
+      parser: "@typescript-eslint/parser",
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+      plugins: ["@typescript-eslint"],
+      extends: ["plugin:@typescript-eslint/recommended"],
+      rules: {
+        "no-unused-vars": "off",
+        "no-undef": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            argsIgnorePattern: "^_",
+            varsIgnorePattern: "^_",
+            caughtErrorsIgnorePattern: "^_",
+          },
+        ],
+      },
+    },
+    {
+      files: ["*.cjs", "*.mjs", "vite.config.ts", "vitest.config.ts"],
+      env: {
+        node: true,
+      },
+    },
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
       "devDependencies": {
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.6.2",
+        "@types/three": "^0.180.0",
+        "@typescript-eslint/eslint-plugin": "^8.45.0",
+        "@typescript-eslint/parser": "^8.45.0",
         "@vitest/coverage-v8": "^1.6.1",
         "eslint": "^8.57.0",
         "jsdom": "^27.0.0",
@@ -264,6 +267,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1172,6 +1182,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1201,12 +1218,313 @@
         "undici-types": "~7.13.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
+      "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/type-utils": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.45.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
+      "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
+      "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.45.0",
+        "@typescript-eslint/types": "^8.45.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
+      "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
+      "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
+      "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0",
+        "@typescript-eslint/utils": "8.45.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
+      "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
+      "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.45.0",
+        "@typescript-eslint/tsconfig-utils": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/visitor-keys": "8.45.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
+      "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.45.0",
+        "@typescript-eslint/types": "8.45.0",
+        "@typescript-eslint/typescript-estree": "8.45.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
+      "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.45.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -1346,6 +1664,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1478,6 +1803,19 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cac": {
@@ -1966,6 +2304,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1990,6 +2358,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2001,6 +2376,19 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -2303,6 +2691,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -2613,6 +3011,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -2876,6 +3305,19 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-types": {
       "version": "1.3.1",
@@ -3369,6 +3811,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
@@ -3393,6 +3848,19 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.6.2",
+    "@types/three": "^0.180.0",
+    "@typescript-eslint/eslint-plugin": "^8.45.0",
+    "@typescript-eslint/parser": "^8.45.0",
     "@vitest/coverage-v8": "^1.6.1",
     "eslint": "^8.57.0",
     "jsdom": "^27.0.0",

--- a/src/game/entities/Pipe.js
+++ b/src/game/entities/Pipe.js
@@ -1,3 +1,15 @@
+/**
+ * @typedef {() => number} RandomFunction
+ * @typedef {{ next: () => number }} NextMethodSource
+ * @typedef {{ nextInt: (min: number, max: number) => number }} NextIntSource
+ * @typedef {RandomFunction | NextMethodSource | NextIntSource} RandomSource
+ */
+
+/**
+ * @param {RandomSource | undefined} randomSource
+ * @param {number} min
+ * @param {number} max
+ */
 function randomIntInRange(randomSource, min, max) {
   if (max < min) {
     throw new Error("max must be greater than or equal to min");
@@ -25,6 +37,12 @@ function randomIntInRange(randomSource, min, max) {
 }
 
 export class Pipe {
+  /**
+   * @param {number} x
+   * @param {number} playfieldHeight
+   * @param {number} gapSize
+   * @param {RandomSource} [randomSource]
+   */
   constructor(x, playfieldHeight, gapSize, randomSource = Math.random) {
     this.x = x;
     this.width = 60;

--- a/src/game/systems/prng.test.ts
+++ b/src/game/systems/prng.test.ts
@@ -3,7 +3,7 @@ import { Pipe } from "../entities/Pipe.js";
 import { DeterministicPRNG } from "./prng";
 
 describe("deterministic pipe spawning", () => {
-  function spawnSequence(seed) {
+  function spawnSequence(seed: number): number[] {
     const prng = new DeterministicPRNG(seed);
     const heights = [];
 

--- a/src/hud/components/GameOverPanel.ts
+++ b/src/hud/components/GameOverPanel.ts
@@ -193,7 +193,7 @@ export class GameOverPanel {
     if (this.previouslyFocused && typeof this.previouslyFocused.focus === 'function') {
       try {
         this.previouslyFocused.focus();
-      } catch (error) {
+      } catch (_error) {
         // Swallow focus errors to avoid breaking dismissal.
       }
     }

--- a/src/hud/events.ts
+++ b/src/hud/events.ts
@@ -27,31 +27,40 @@ type EventKey = keyof HudEvents;
 
 type Listener<K extends EventKey> = (payload: HudEvents[K]) => void;
 
-type ListenerRegistry = {
-  [K in EventKey]?: Set<Listener<K>>;
-};
-
 /**
  * Minimal typed event bus for heads-up-display components. Components can
  * subscribe to events and receive strongly typed payloads.
  */
 class HudEventBus {
-  private listeners: ListenerRegistry = {};
+  private readonly listeners = new Map<EventKey, Set<Listener<EventKey>>>();
+
+  private getHandlers<K extends EventKey>(type: K): Set<Listener<K>> | undefined {
+    return this.listeners.get(type) as Set<Listener<K>> | undefined;
+  }
+
+  private ensureHandlers<K extends EventKey>(type: K): Set<Listener<K>> {
+    let handlers = this.getHandlers(type);
+    if (!handlers) {
+      handlers = new Set<Listener<K>>();
+      this.listeners.set(type, handlers as Set<Listener<EventKey>>);
+    }
+    return handlers;
+  }
 
   on<K extends EventKey>(type: K, handler: Listener<K>): () => void {
-    const handlers = (this.listeners[type] ??= new Set());
+    const handlers = this.ensureHandlers(type);
     handlers.add(handler);
 
     return () => {
       handlers.delete(handler);
       if (handlers.size === 0) {
-        delete this.listeners[type];
+        this.listeners.delete(type);
       }
     };
   }
 
   emit<K extends EventKey>(type: K, payload: HudEvents[K]): void {
-    const handlers = this.listeners[type];
+    const handlers = this.getHandlers(type);
     if (!handlers) return;
 
     for (const handler of handlers) {
@@ -60,7 +69,7 @@ class HudEventBus {
   }
 
   clear(): void {
-    this.listeners = {};
+    this.listeners.clear();
   }
 }
 

--- a/src/hud/hud-bus.ts
+++ b/src/hud/hud-bus.ts
@@ -2,14 +2,10 @@ import type { HudChannel, HudEventPayloads } from "./hud-events";
 
 type HudEventHandler<K extends HudChannel> = (payload: HudEventPayloads[K]) => void;
 
-type HandlerRegistry = {
-  [K in HudChannel]?: Set<HudEventHandler<K>>;
-};
-
-const registry: HandlerRegistry = {};
+const registry = new Map<HudChannel, Set<HudEventHandler<HudChannel>>>();
 
 function getHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K>> | undefined {
-  return registry[channel] as Set<HudEventHandler<K>> | undefined;
+  return registry.get(channel) as Set<HudEventHandler<K>> | undefined;
 }
 
 function ensureHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K>> {
@@ -17,7 +13,7 @@ function ensureHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K
 
   if (!handlers) {
     handlers = new Set<HudEventHandler<K>>();
-    registry[channel] = handlers as Set<HudEventHandler<typeof channel>>;
+    registry.set(channel, handlers as Set<HudEventHandler<HudChannel>>);
   }
 
   return handlers;
@@ -48,7 +44,7 @@ export function unsubscribe<K extends HudChannel>(
   const removed = handlers.delete(handler);
 
   if (handlers.size === 0) {
-    delete registry[channel];
+    registry.delete(channel);
   }
 
   return removed;
@@ -77,7 +73,5 @@ export function hasSubscribers(channel: HudChannel): boolean {
 }
 
 export function resetHudBus(): void {
-  (Object.keys(registry) as HudChannel[]).forEach((channel) => {
-    delete registry[channel];
-  });
+  registry.clear();
 }

--- a/src/hud/hud-i18n.ts
+++ b/src/hud/hud-i18n.ts
@@ -38,19 +38,28 @@ const DEFAULT_HINT_LOCALE: HudLocale = DEFAULT_LOCALE;
 
 const SUPPORTED_LOCALES = Object.keys(HUD_MESSAGES) as HudLocale[];
 
+const isHudLocale = (value: string): value is HudLocale => {
+  for (const locale of SUPPORTED_LOCALES) {
+    if (locale === value) {
+      return true;
+    }
+  }
+  return false;
+};
+
 export function resolveLocale(input?: string | null): HudLocale {
   if (!input) {
     return DEFAULT_HINT_LOCALE;
   }
 
   const normalized = input.toLowerCase();
-  if (SUPPORTED_LOCALES.includes(normalized as HudLocale)) {
-    return normalized as HudLocale;
+  if (isHudLocale(normalized)) {
+    return normalized;
   }
 
   const [languageCode] = normalized.split('-');
-  if (SUPPORTED_LOCALES.includes(languageCode as HudLocale)) {
-    return languageCode as HudLocale;
+  if (languageCode && isHudLocale(languageCode)) {
+    return languageCode;
   }
 
   return DEFAULT_HINT_LOCALE;
@@ -110,14 +119,17 @@ const DICTIONARIES: Record<HudLocale, HudDictionary> = {
 
 const LOCALE_SEPARATOR_REGEX = /[-_]/;
 
-const normalizeLocale = (locale?: string): string => {
+const normalizeLocale = (locale?: string): HudLocale => {
   if (!locale) {
     return DEFAULT_LOCALE;
   }
 
   const primarySubtag = locale.toLowerCase().split(LOCALE_SEPARATOR_REGEX)[0];
+  if (primarySubtag && isHudLocale(primarySubtag)) {
+    return primarySubtag;
+  }
 
-  return primarySubtag || DEFAULT_LOCALE;
+  return DEFAULT_LOCALE;
 };
 
 const getHudDictionary = (locale?: string): HudDictionary => {

--- a/src/hud/hud-store.ts
+++ b/src/hud/hud-store.ts
@@ -19,7 +19,7 @@ function getStorage(): Storage | null {
 
   try {
     return window.localStorage;
-  } catch (error) {
+  } catch (_error) {
     return null;
   }
 }
@@ -45,7 +45,7 @@ function loadFromStorage(): HudPreferences {
       ...DEFAULT_PREFERENCES,
       ...parsed,
     };
-  } catch (error) {
+  } catch (_error) {
     return { ...DEFAULT_PREFERENCES };
   }
 }
@@ -59,7 +59,7 @@ function persistPreferences(preferences: HudPreferences): void {
 
   try {
     storage.setItem(STORAGE_KEY, JSON.stringify(preferences));
-  } catch (error) {
+  } catch (_error) {
     // Ignore storage failures to keep the HUD responsive even when storage is unavailable.
   }
 
@@ -125,7 +125,7 @@ export function resetHudPreferences(): HudPreferences {
   const storage = getStorage();
   try {
     storage?.removeItem(STORAGE_KEY);
-  } catch (error) {
+  } catch (_error) {
     // Ignore failures when clearing storage.
   }
   notifyListeners(defaults);

--- a/src/hud/util/haptics.test.ts
+++ b/src/hud/util/haptics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createHapticsAdapter, detectVibrationSupport } from "./haptics";
+import { createHapticsAdapter, detectVibrationSupport, type NavigatorLike } from "./haptics";
 
 describe("detectVibrationSupport", () => {
   it("reports unsupported when navigator is undefined", () => {
@@ -9,15 +9,18 @@ describe("detectVibrationSupport", () => {
   });
 
   it("reports unsupported when vibrate is not a function", () => {
-    const fakeNavigator = {} as any;
+    const fakeNavigator: NavigatorLike = {};
     const result = detectVibrationSupport(fakeNavigator);
     expect(result.supported).toBe(false);
     expect(result.vibrate).toBeNull();
   });
 
   it("binds the vibrate function when available", () => {
-    const vibrate = vi.fn(() => true);
-    const fakeNavigator = { vibrate } as any;
+    const vibrate = vi.fn<
+      ReturnType<NonNullable<NavigatorLike["vibrate"]>>,
+      Parameters<NonNullable<NavigatorLike["vibrate"]>>
+    >(() => true);
+    const fakeNavigator: NavigatorLike = { vibrate };
     const result = detectVibrationSupport(fakeNavigator);
 
     expect(result.supported).toBe(true);
@@ -37,8 +40,11 @@ describe("createHapticsAdapter", () => {
   });
 
   it("delegates to navigator.vibrate when supported", () => {
-    const vibrate = vi.fn(() => true);
-    const fakeNavigator = { vibrate } as any;
+    const vibrate = vi.fn<
+      ReturnType<NonNullable<NavigatorLike["vibrate"]>>,
+      Parameters<NonNullable<NavigatorLike["vibrate"]>>
+    >(() => true);
+    const fakeNavigator: NavigatorLike = { vibrate };
 
     const adapter = createHapticsAdapter({ navigator: fakeNavigator });
     expect(adapter.supported).toBe(true);

--- a/src/hud/util/haptics.ts
+++ b/src/hud/util/haptics.ts
@@ -2,7 +2,7 @@ export type VibrationPattern = number | number[];
 
 type VibrateFunction = (pattern: VibrationPattern) => boolean;
 
-interface NavigatorLike {
+export interface NavigatorLike {
   vibrate?: VibrateFunction;
 }
 

--- a/src/rendering/three/assets.test.ts
+++ b/src/rendering/three/assets.test.ts
@@ -59,8 +59,8 @@ describe('three asset loader cache', () => {
   });
 
   it('loads a scene once and returns cloned instances on subsequent requests', async () => {
-    const first = await getSceneClone('mock.glb');
-    const second = await getSceneClone('mock.glb');
+    const first = (await getSceneClone('mock.glb')) as { cloned?: boolean };
+    const second = (await getSceneClone('mock.glb')) as { cloned?: boolean };
 
     expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(first).not.toBe(second);
@@ -70,7 +70,7 @@ describe('three asset loader cache', () => {
 
   it('shares cached data between preload and clone helpers', async () => {
     await preloadScene(MODEL_URLS.bird);
-    const birdClone = await loadCoreModel.bird();
+    const birdClone = (await loadCoreModel.bird()) as { cloned?: boolean };
 
     expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(birdClone.cloned).toBe(true);

--- a/src/rendering/three/assets.ts
+++ b/src/rendering/three/assets.ts
@@ -49,26 +49,27 @@ function getLoader(): GLTFLoader {
 }
 
 async function loadGLTF(url: string): Promise<GLTF> {
-  let promise = gltfCache.get(url);
-  if (!promise) {
-    promise = getLoader()
-      .loadAsync(url)
-      .catch((error: unknown) => {
-        gltfCache.delete(url);
-        const message =
-          error instanceof Error
-            ? error.message
-            : typeof error === 'string'
-              ? error
-              : JSON.stringify(error);
-        throw new Error(
-          `Failed to load GLTF asset at "${url}". ` +
-            'If this is the procedural bird, run "python tools/generate_bird_assets.py" to regenerate the binaries before retrying. ' +
-            `Original error: ${message}`,
-        );
-      });
-    gltfCache.set(url, promise);
+  const cached = gltfCache.get(url);
+  if (cached) {
+    return cached;
   }
+
+  const loader = getLoader();
+  const promise: Promise<GLTF> = loader.loadAsync(url).catch((error: unknown) => {
+    gltfCache.delete(url);
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === 'string'
+          ? error
+          : JSON.stringify(error);
+    throw new Error(
+      `Failed to load GLTF asset at "${url}". ` +
+        'If this is the procedural bird, run "python tools/generate_bird_assets.py" to regenerate the binaries before retrying. ' +
+        `Original error: ${message}`,
+    );
+  });
+  gltfCache.set(url, promise);
 
   return promise;
 }

--- a/src/rendering/three/renderer.js
+++ b/src/rendering/three/renderer.js
@@ -180,7 +180,7 @@ function createGroundPlane() {
   return mesh;
 }
 
-export function createThreeRenderer(canvas, options = {}) {
+export function createThreeRenderer(canvas, _options = {}) {
   const renderer = new THREE.WebGLRenderer({
     canvas,
     antialias: true,

--- a/src/types/three-examples.d.ts
+++ b/src/types/three-examples.d.ts
@@ -1,0 +1,27 @@
+declare module 'three/examples/jsm/loaders/GLTFLoader.js' {
+  import type { AnimationClip, Group } from 'three';
+
+  export interface GLTF {
+    scene: Group;
+    animations: AnimationClip[];
+  }
+
+  export class GLTFLoader {
+    constructor(manager?: unknown);
+    loadAsync(url: string, onProgress?: (event: ProgressEvent<EventTarget>) => void): Promise<GLTF>;
+    setDRACOLoader(loader: unknown): this;
+  }
+}
+
+declare module 'three/examples/jsm/loaders/DRACOLoader.js' {
+  export class DRACOLoader {
+    setDecoderPath(path: string): this;
+    dispose(): void;
+  }
+}
+
+declare module 'three/examples/jsm/utils/SkeletonUtils.js' {
+  import type { Object3D } from 'three';
+
+  export function clone<T extends Object3D>(source: T): T;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "checkJs": false,
     "strict": true,
     "noEmit": true,
-    "types": ["vitest", "vite/client", "node"]
+    "types": ["vitest", "vite/client", "node", "three"]
   },
   "include": ["src/**/*", "playgrounds/**/*"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- add type safety for the deterministic PRNG, Three.js assets, and supporting tests so the TypeScript compiler succeeds
- replace HUD event bus registries with typed maps and tighten locale resolution and haptics typings
- configure ESLint to understand TypeScript, ignore generated assets, and declare three.js example modules

## Testing
- npm run typecheck
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e06bc20ec48328b13a9d4d7b54a325