### PR TITLE
Improve renderer typings and stabilize HUD events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.6.2",
+        "@types/three": "^0.180.0",
         "@vitest/coverage-v8": "^1.6.1",
         "eslint": "^8.57.0",
         "jsdom": "^27.0.0",
@@ -264,6 +265,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1172,6 +1180,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1201,10 +1216,40 @@
         "undici-types": "~7.13.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1345,6 +1390,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -1990,6 +2042,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2610,6 +2669,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.6.2",
+    "@types/three": "^0.180.0",
     "@vitest/coverage-v8": "^1.6.1",
     "eslint": "^8.57.0",
     "jsdom": "^27.0.0",

--- a/src/game/systems/prng.test.ts
+++ b/src/game/systems/prng.test.ts
@@ -3,12 +3,12 @@ import { Pipe } from "../entities/Pipe.js";
 import { DeterministicPRNG } from "./prng";
 
 describe("deterministic pipe spawning", () => {
-  function spawnSequence(seed) {
+  function spawnSequence(seed: number) {
     const prng = new DeterministicPRNG(seed);
     const heights = [];
 
     for (let i = 0; i < 10; i += 1) {
-      const pipe = new Pipe(0, 400, 120, prng);
+      const pipe = new Pipe(0, 400, 120, () => prng.next());
       heights.push(pipe.topHeight);
     }
 

--- a/src/hud/hud-bus.ts
+++ b/src/hud/hud-bus.ts
@@ -2,14 +2,10 @@ import type { HudChannel, HudEventPayloads } from "./hud-events";
 
 type HudEventHandler<K extends HudChannel> = (payload: HudEventPayloads[K]) => void;
 
-type HandlerRegistry = {
-  [K in HudChannel]?: Set<HudEventHandler<K>>;
-};
-
-const registry: HandlerRegistry = {};
+const registry = new Map<HudChannel, Set<HudEventHandler<HudChannel>>>();
 
 function getHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K>> | undefined {
-  return registry[channel] as Set<HudEventHandler<K>> | undefined;
+  return registry.get(channel) as Set<HudEventHandler<K>> | undefined;
 }
 
 function ensureHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K>> {
@@ -17,7 +13,7 @@ function ensureHandlers<K extends HudChannel>(channel: K): Set<HudEventHandler<K
 
   if (!handlers) {
     handlers = new Set<HudEventHandler<K>>();
-    registry[channel] = handlers as Set<HudEventHandler<typeof channel>>;
+    registry.set(channel, handlers as Set<HudEventHandler<HudChannel>>);
   }
 
   return handlers;
@@ -48,7 +44,7 @@ export function unsubscribe<K extends HudChannel>(
   const removed = handlers.delete(handler);
 
   if (handlers.size === 0) {
-    delete registry[channel];
+    registry.delete(channel);
   }
 
   return removed;
@@ -77,7 +73,5 @@ export function hasSubscribers(channel: HudChannel): boolean {
 }
 
 export function resetHudBus(): void {
-  (Object.keys(registry) as HudChannel[]).forEach((channel) => {
-    delete registry[channel];
-  });
+  registry.clear();
 }

--- a/src/hud/hud-i18n.ts
+++ b/src/hud/hud-i18n.ts
@@ -110,20 +110,26 @@ const DICTIONARIES: Record<HudLocale, HudDictionary> = {
 
 const LOCALE_SEPARATOR_REGEX = /[-_]/;
 
-const normalizeLocale = (locale?: string): string => {
+const hasDictionary = (locale: string): locale is HudLocale =>
+  Object.prototype.hasOwnProperty.call(DICTIONARIES, locale);
+
+const normalizeLocale = (locale?: string): HudLocale => {
   if (!locale) {
     return DEFAULT_LOCALE;
   }
 
   const primarySubtag = locale.toLowerCase().split(LOCALE_SEPARATOR_REGEX)[0];
+  if (primarySubtag && hasDictionary(primarySubtag)) {
+    return primarySubtag;
+  }
 
-  return primarySubtag || DEFAULT_LOCALE;
+  return DEFAULT_LOCALE;
 };
 
 const getHudDictionary = (locale?: string): HudDictionary => {
   const normalizedLocale = normalizeLocale(locale);
 
-  return DICTIONARIES[normalizedLocale] ?? ENGLISH_DICTIONARY;
+  return DICTIONARIES[normalizedLocale];
 };
 
 export const getHudString = (key: HudStringKey, locale?: string): string =>

--- a/src/rendering/three/assets.test.ts
+++ b/src/rendering/three/assets.test.ts
@@ -16,6 +16,9 @@ const loadSpy = vi.fn(async (url: string) => ({
   scene: { url },
 }));
 
+const hasClonedFlag = (value: unknown): value is { cloned: boolean } =>
+  typeof value === 'object' && value !== null && 'cloned' in value;
+
 vi.mock('three/examples/jsm/loaders/GLTFLoader.js', () => ({
   __esModule: true,
   GLTFLoader: class {
@@ -64,8 +67,8 @@ describe('three asset loader cache', () => {
 
     expect(loadSpy).toHaveBeenCalledTimes(1);
     expect(first).not.toBe(second);
-    expect(first.cloned).toBe(true);
-    expect(second.cloned).toBe(true);
+    expect(hasClonedFlag(first) && first.cloned).toBe(true);
+    expect(hasClonedFlag(second) && second.cloned).toBe(true);
   });
 
   it('shares cached data between preload and clone helpers', async () => {
@@ -73,7 +76,7 @@ describe('three asset loader cache', () => {
     const birdClone = await loadCoreModel.bird();
 
     expect(loadSpy).toHaveBeenCalledTimes(1);
-    expect(birdClone.cloned).toBe(true);
+    expect(hasClonedFlag(birdClone) && birdClone.cloned).toBe(true);
   });
 });
 

--- a/src/rendering/three/assets.ts
+++ b/src/rendering/three/assets.ts
@@ -51,7 +51,7 @@ function getLoader(): GLTFLoader {
 async function loadGLTF(url: string): Promise<GLTF> {
   let promise = gltfCache.get(url);
   if (!promise) {
-    promise = getLoader()
+    const loaderPromise = getLoader()
       .loadAsync(url)
       .catch((error: unknown) => {
         gltfCache.delete(url);
@@ -67,7 +67,8 @@ async function loadGLTF(url: string): Promise<GLTF> {
             `Original error: ${message}`,
         );
       });
-    gltfCache.set(url, promise);
+    gltfCache.set(url, loaderPromise);
+    promise = loaderPromise;
   }
 
   return promise;

--- a/src/types/three-jsm.d.ts
+++ b/src/types/three-jsm.d.ts
@@ -1,0 +1,34 @@
+declare module 'three/examples/jsm/loaders/DRACOLoader.js' {
+  export class DRACOLoader {
+    constructor();
+    setDecoderPath(path: string): this;
+    dispose(): void;
+  }
+}
+
+declare module 'three/examples/jsm/loaders/GLTFLoader.js' {
+  import type { AnimationClip, Group, Loader, LoadingManager } from 'three';
+  import type { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader.js';
+
+  export interface GLTF {
+    scene: Group;
+    scenes: Group[];
+    animations: AnimationClip[];
+    parser: unknown;
+    asset: Record<string, unknown>;
+    userData: Record<string, unknown>;
+  }
+
+  export class GLTFLoader extends Loader<GLTF> {
+    constructor(manager?: LoadingManager);
+    loadAsync(url: string, onProgress?: (event: ProgressEvent<EventTarget>) => void): Promise<GLTF>;
+    setDRACOLoader(loader: DRACOLoader): this;
+  }
+}
+
+declare module 'three/examples/jsm/utils/SkeletonUtils.js' {
+  import type { Group, Object3D } from 'three';
+
+  export function clone<T extends Object3D>(source: T): T;
+  export function clone(source: Group): Group;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "allowJs": true,
     "checkJs": false,
     "strict": true,
+    "lib": ["ES2022", "DOM"],
     "noEmit": true,
     "types": ["vitest", "vite/client", "node"]
   },


### PR DESCRIPTION
## Summary
- add @types/three along with scoped declarations to type Three.js loader imports
- harden the HUD event bus and locale helpers to satisfy strict TypeScript checks
- adjust deterministic PRNG tests and asset loader tests for stronger type coverage

## Testing
- npm run typecheck
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06c57edfc83288719eb0a007df5cd