### PR TITLE
Add global event bus for typed game events

### DIFF
--- a/src/core/__tests__/event-bus.spec.ts
+++ b/src/core/__tests__/event-bus.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, expectTypeOf } from 'vitest';
+import { bus } from '../event-bus';
+import type { GameEventName } from '../event-bus';
+
+declare global {
+  interface GameEvents {
+    'core:test': { value: number };
+    'core:ping': undefined;
+  }
+}
+
+describe('event bus', () => {
+  it('delivers payloads to subscribed listeners', () => {
+    const handler = vi.fn<(payload: { value: number }) => void>();
+    const unsubscribe = bus.on('core:test', handler);
+
+    bus.emit('core:test', { value: 42 });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ value: 42 });
+
+    unsubscribe();
+  });
+
+  it('returns an unsubscribe function that detaches listeners', () => {
+    const handler = vi.fn<(payload: { value: number }) => void>();
+    const unsubscribe = bus.on('core:test', handler);
+
+    unsubscribe();
+    bus.emit('core:test', { value: 7 });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('supports events without payload detail', () => {
+    const handler = vi.fn<() => void>();
+    const unsubscribe = bus.on('core:ping', handler);
+
+    bus.emit('core:ping');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0]).toEqual([undefined]);
+
+    unsubscribe();
+  });
+
+  it('narrows event names and payloads via declaration merging', () => {
+    expectTypeOf<'core:test'>().toMatchTypeOf<GameEventName>();
+    expectTypeOf<'core:ping'>().toMatchTypeOf<GameEventName>();
+    expectTypeOf<'core:unknown'>().not.toMatchTypeOf<GameEventName>();
+
+    expectTypeOf<GameEvents['core:test']>().toEqualTypeOf<{ value: number }>();
+    expectTypeOf<GameEvents['core:ping']>().toEqualTypeOf<undefined>();
+
+    const unsubscribe = bus.on('core:test', (payload) => {
+      expectTypeOf(payload).toEqualTypeOf<{ value: number }>();
+    });
+    unsubscribe();
+
+    bus.emit('core:test', { value: 12 });
+    bus.emit('core:ping');
+  });
+});

--- a/src/core/event-bus.ts
+++ b/src/core/event-bus.ts
@@ -1,0 +1,52 @@
+import type { GameEventName } from './events';
+
+type ListenerCallback<Name extends GameEventName> = (payload: GameEvents[Name]) => void;
+
+type EmitArgs<Name extends GameEventName> = GameEvents[Name] extends undefined
+  ? [detail?: GameEvents[Name]]
+  : [detail: GameEvents[Name]];
+
+const HAS_DETAIL_FLAG = Symbol('game-event-has-detail');
+
+type DetailAwareEvent<Name extends GameEventName> = CustomEvent<GameEvents[Name]> & {
+  [HAS_DETAIL_FLAG]?: boolean;
+};
+
+const on = <Name extends GameEventName>(
+  eventName: Name,
+  listener: ListenerCallback<Name>,
+) => {
+  const eventListener: EventListener = (event) => {
+    const customEvent = event as DetailAwareEvent<Name>;
+    const marker = customEvent[HAS_DETAIL_FLAG];
+    const payload = marker === false ? (undefined as GameEvents[Name]) : customEvent.detail;
+    (listener as (payload: GameEvents[Name]) => void)(payload);
+  };
+
+  window.addEventListener(eventName, eventListener);
+
+  return () => {
+    window.removeEventListener(eventName, eventListener);
+  };
+};
+
+const emit = <Name extends GameEventName>(eventName: Name, ...args: EmitArgs<Name>) => {
+  const hasDetail = args.length > 0;
+  const detail = args[0];
+  const event = hasDetail
+    ? new CustomEvent<GameEvents[Name]>(eventName, { detail })
+    : new CustomEvent<GameEvents[Name]>(eventName);
+
+  Object.defineProperty(event, HAS_DETAIL_FLAG, {
+    value: hasDetail,
+  });
+
+  window.dispatchEvent(event);
+};
+
+export const bus = {
+  on,
+  emit,
+} as const;
+
+export type { GameEventName };

--- a/src/core/events.d.ts
+++ b/src/core/events.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  interface GameEvents {}
+}
+
+export type GameEventName = keyof GameEvents & string;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,2 @@
+export { bus } from './event-bus';
+export type { GameEventName } from './event-bus';


### PR DESCRIPTION
## Summary
- introduce a central event bus built on CustomEvent with typed payloads
- add global GameEvents declaration to support augmentation and typed event names
- cover the bus with vitest specs demonstrating emit/on behavior and declaration merging

## Testing
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e06eba99008328803cc9aefd723005