### PR TITLE
Add score HUD feature with renderer overlay

### DIFF
--- a/src/features/F10_score_hud/ScoreHud.test.ts
+++ b/src/features/F10_score_hud/ScoreHud.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  GAME_STATE_CHANGE_EVENT,
+  PIPE_CLEARED_EVENT,
+  ScoreHud,
+} from "./ScoreHud";
+
+const createContainer = () => {
+  const container = document.createElement("div");
+  container.className = "game-stage";
+  container.style.position = "relative";
+  document.body.appendChild(container);
+  return container;
+};
+
+describe("ScoreHud", () => {
+  let container: HTMLDivElement;
+  let eventTarget: EventTarget;
+  let hud: ScoreHud | null = null;
+
+  beforeEach(() => {
+    container = createContainer();
+    eventTarget = new EventTarget();
+    hud = new ScoreHud({ container, eventTarget });
+  });
+
+  afterEach(() => {
+    hud?.destroy();
+    container.remove();
+  });
+
+  it("increments the score when pipes are cleared", () => {
+    eventTarget.dispatchEvent(new CustomEvent(PIPE_CLEARED_EVENT));
+    eventTarget.dispatchEvent(
+      new CustomEvent(PIPE_CLEARED_EVENT, { detail: { value: 2 } }),
+    );
+
+    expect(hud?.element.textContent).toBe("3");
+    expect(hud?.element.dataset.score).toBe("3");
+  });
+
+  it("resets when the game returns to the ready state", () => {
+    eventTarget.dispatchEvent(new CustomEvent(PIPE_CLEARED_EVENT));
+    expect(hud?.element.textContent).toBe("1");
+
+    eventTarget.dispatchEvent(
+      new CustomEvent(GAME_STATE_CHANGE_EVENT, { detail: { state: "ready" } }),
+    );
+
+    expect(hud?.element.textContent).toBe("0");
+  });
+});

--- a/src/features/F10_score_hud/ScoreHud.ts
+++ b/src/features/F10_score_hud/ScoreHud.ts
@@ -1,0 +1,143 @@
+export const PIPE_CLEARED_EVENT = "feature:F09/pipe:cleared" as const;
+export const GAME_STATE_CHANGE_EVENT = "game:state-change" as const;
+
+type PipeClearedDetail = {
+  /**
+   * Absolute score to display. Optional; falls back to incrementing by one.
+   */
+  score?: number;
+  /**
+   * Increment delta for this clear.
+   */
+  value?: number;
+  /**
+   * Alternate field name for deltas.
+   */
+  increment?: number;
+};
+
+type GameStateChangeDetail = {
+  state?: string;
+};
+
+type ScoreHudOptions = {
+  container: HTMLElement;
+  eventTarget?: EventTarget;
+};
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+  return null;
+}
+
+export class ScoreHud {
+  readonly element: HTMLDivElement;
+  private score = 0;
+  private readonly eventTarget: EventTarget;
+  private listeners: Array<() => void> = [];
+
+  constructor({ container, eventTarget }: ScoreHudOptions) {
+    this.eventTarget = eventTarget ?? window;
+
+    this.element = document.createElement("div");
+    this.element.className = "f10-score-hud";
+    this.element.setAttribute("role", "status");
+    this.element.setAttribute("aria-live", "polite");
+    this.element.setAttribute("aria-atomic", "true");
+
+    container.appendChild(this.element);
+
+    this.updateDisplay(0);
+    this.bindEvents();
+  }
+
+  private bindEvents() {
+    const handlePipeCleared = (event: Event) => {
+      if (event instanceof CustomEvent) {
+        const detail = (event.detail ?? {}) as PipeClearedDetail;
+        const absolute = toNumber(detail.score);
+        if (absolute !== null) {
+          this.updateDisplay(Math.max(0, Math.floor(absolute)));
+          return;
+        }
+
+        const increment =
+          toNumber(detail.value) ?? toNumber(detail.increment) ?? 1;
+        this.increment(Math.max(0, Math.floor(increment)) || 1);
+        return;
+      }
+
+      this.increment(1);
+    };
+
+    const handleGameStateChange = (event: Event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+      const detail = (event.detail ?? {}) as GameStateChangeDetail;
+      if (detail.state === "ready") {
+        this.reset();
+      }
+    };
+
+    this.eventTarget.addEventListener(
+      PIPE_CLEARED_EVENT,
+      handlePipeCleared as EventListener,
+    );
+    this.listeners.push(() =>
+      this.eventTarget.removeEventListener(
+        PIPE_CLEARED_EVENT,
+        handlePipeCleared as EventListener,
+      ),
+    );
+
+    this.eventTarget.addEventListener(
+      GAME_STATE_CHANGE_EVENT,
+      handleGameStateChange as EventListener,
+    );
+    this.listeners.push(() =>
+      this.eventTarget.removeEventListener(
+        GAME_STATE_CHANGE_EVENT,
+        handleGameStateChange as EventListener,
+      ),
+    );
+  }
+
+  private updateDisplay(nextScore: number) {
+    this.score = Math.max(0, Math.floor(nextScore));
+    const content = String(this.score);
+    this.element.textContent = content;
+    this.element.dataset.score = content;
+  }
+
+  private increment(delta: number) {
+    if (!Number.isFinite(delta) || delta <= 0) {
+      delta = 1;
+    }
+    this.updateDisplay(this.score + Math.floor(delta));
+  }
+
+  reset() {
+    this.updateDisplay(0);
+  }
+
+  destroy() {
+    this.listeners.forEach((dispose) => {
+      try {
+        dispose();
+      } catch (error) {
+        console.error("Failed to dispose ScoreHud listener", error);
+      }
+    });
+    this.listeners = [];
+    this.element.remove();
+  }
+}
+
+export default ScoreHud;

--- a/src/features/F10_score_hud/register.test.ts
+++ b/src/features/F10_score_hud/register.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const FEATURE_FLAG_KEY = "FEATURE_F10_SCORE_HUD";
+
+const setupStage = () => {
+  const stage = document.createElement("section");
+  stage.className = "game-stage";
+  const canvas = document.createElement("canvas");
+  canvas.id = "gameCanvas";
+  stage.appendChild(canvas);
+  document.body.appendChild(stage);
+  return stage;
+};
+
+describe("F10 score HUD register", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete (globalThis as { __FEATURE_FLAGS__?: Record<string, unknown> })
+      .__FEATURE_FLAGS__;
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    delete process.env[FEATURE_FLAG_KEY];
+    document.body.innerHTML = "";
+  });
+
+  it("installs the DOM overlay when the feature flag is enabled", async () => {
+    process.env[FEATURE_FLAG_KEY] = "true";
+    const stage = setupStage();
+
+    const { initializeScoreHud, teardownScoreHud } = await import("./register");
+    const instance = initializeScoreHud();
+
+    expect(instance).not.toBeNull();
+    expect(stage.querySelector(".f10-score-hud")?.textContent).toBe("0");
+
+    teardownScoreHud();
+  });
+
+  it("updates the overlay when pipe cleared events fire", async () => {
+    process.env[FEATURE_FLAG_KEY] = "true";
+    const stage = setupStage();
+    const { initializeScoreHud, teardownScoreHud, PIPE_CLEARED_EVENT } =
+      await import("./register");
+
+    const instance = initializeScoreHud();
+    expect(instance).not.toBeNull();
+
+    window.dispatchEvent(new CustomEvent(PIPE_CLEARED_EVENT));
+
+    expect(stage.querySelector(".f10-score-hud")?.textContent).toBe("1");
+
+    teardownScoreHud();
+  });
+});

--- a/src/features/F10_score_hud/register.ts
+++ b/src/features/F10_score_hud/register.ts
@@ -1,0 +1,103 @@
+import "./styles.css";
+import ScoreHud, { PIPE_CLEARED_EVENT } from "./ScoreHud";
+
+type InitializeOptions = {
+  container?: HTMLElement | null;
+  eventTarget?: EventTarget;
+  force?: boolean;
+};
+
+const FEATURE_FLAG_KEY = "FEATURE_F10_SCORE_HUD";
+
+const normalizeBoolean = (value: unknown): boolean => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return ["true", "1", "yes", "on"].includes(normalized);
+  }
+  return false;
+};
+
+const readFeatureFlag = (): boolean => {
+  const meta = (import.meta as unknown as { env?: Record<string, unknown> })?.
+    env;
+  if (meta && FEATURE_FLAG_KEY in meta) {
+    return normalizeBoolean(meta[FEATURE_FLAG_KEY]);
+  }
+
+  if (typeof process !== "undefined" && process?.env) {
+    const fromProcess = process.env[FEATURE_FLAG_KEY];
+    if (fromProcess !== undefined) {
+      return normalizeBoolean(fromProcess);
+    }
+  }
+
+  const globalShim =
+    globalThis as unknown as { __FEATURE_FLAGS__?: Record<string, unknown> };
+  if (globalShim.__FEATURE_FLAGS__ && FEATURE_FLAG_KEY in globalShim.__FEATURE_FLAGS__) {
+    return normalizeBoolean(globalShim.__FEATURE_FLAGS__[FEATURE_FLAG_KEY]);
+  }
+
+  return false;
+};
+
+let instance: ScoreHud | null = null;
+
+export const isScoreHudEnabled = (): boolean => readFeatureFlag();
+
+export const initializeScoreHud = (
+  options: InitializeOptions = {},
+): ScoreHud | null => {
+  if (!options.force && !isScoreHudEnabled()) {
+    return null;
+  }
+
+  if (instance) {
+    return instance;
+  }
+
+  const container =
+    options.container ??
+    document.querySelector<HTMLElement>(".game-stage") ??
+    document.getElementById("gameCanvas")?.parentElement ??
+    null;
+
+  if (!container) {
+    return null;
+  }
+
+  const eventTarget = options.eventTarget ?? window;
+  instance = new ScoreHud({ container, eventTarget });
+  return instance;
+};
+
+export const teardownScoreHud = () => {
+  if (!instance) return;
+  instance.destroy();
+  instance = null;
+};
+
+const bootstrap = () => {
+  if (!isScoreHudEnabled()) {
+    return;
+  }
+
+  const ready = () => {
+    initializeScoreHud();
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", ready, { once: true });
+  } else {
+    ready();
+  }
+};
+
+if (typeof window !== "undefined") {
+  bootstrap();
+}
+
+// Re-export event names for convenience in tests and integration points.
+export { PIPE_CLEARED_EVENT };

--- a/src/features/F10_score_hud/styles.css
+++ b/src/features/F10_score_hud/styles.css
@@ -1,0 +1,28 @@
+.f10-score-hud {
+  position: absolute;
+  top: clamp(12px, 5vw, 28px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: clamp(8px, 2.2vw, 16px) clamp(20px, 4.5vw, 32px);
+  border-radius: 999px;
+  background: linear-gradient(
+    135deg,
+    rgba(15, 23, 42, 0.85),
+    rgba(30, 64, 175, 0.82)
+  );
+  color: #f8fafc;
+  font-size: clamp(22px, 6vw, 44px);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.26);
+  pointer-events: none;
+  z-index: 32;
+  text-shadow: 0 4px 12px rgba(15, 23, 42, 0.6);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: clamp(120px, 28vw, 220px);
+  contain: layout paint;
+  font-feature-settings: "tnum";
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,4 @@
+import "./features/F10_score_hud/register.ts";
 import {
   CONFIG,
   createGameState,


### PR DESCRIPTION
## Summary
- add an event-driven Score HUD component that listens for feature:F09 pipe clear events and game state resets
- register the feature behind a FEATURE_F10_SCORE_HUD flag, attach it to the renderer container, and ship dedicated styles
- cover the new behaviour with unit tests for both the ScoreHud class and the feature bootstrapper

## Testing
- npm run test
- npm run lint *(fails: existing lint errors in src/game/systems/loop.js and src/game/systems/loop.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e06ec289048328b329f7fad76519d0