### PR TITLE
Add reusable Three.js scene context bootstrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ npm install
 npm run dev
 ```
 
+## Scene bootstrap
+
+The Three.js renderer is initialized through `createSceneContext()` found in
+`src/core/scene.ts`. Import and call this helper from the Vite entry point to
+obtain the shared `scene`, `camera`, and `renderer` instances while the helper
+appends the renderer's canvas to the `#app` container:
+
+```ts
+import { createSceneContext } from "./core/scene";
+
+const { scene, camera, renderer } = createSceneContext();
+```
+
+The helper automatically matches the container size, clamps the pixel ratio for
+high-DPI displays, and responds to future `resize` events.
+
 ### Available Scripts
 
 - `npm run dev` – Start the Vite development server.

--- a/index.html
+++ b/index.html
@@ -42,7 +42,11 @@
         </div>
       </header>
 
-      <section class="game-stage" aria-label="Flappy Bird 3D game board">
+      <section
+        id="app"
+        class="game-stage"
+        aria-label="Flappy Bird 3D game board"
+      >
         <canvas id="gameCanvas" aria-describedby="gameMessage"></canvas>
         <div id="gameOverlay" class="game-overlay" aria-live="assertive">
           <p id="gameMessage" class="game-message">Tap or press Space to start</p>

--- a/src/core/__tests__/scene.spec.ts
+++ b/src/core/__tests__/scene.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+const scenes: any[] = [];
+const cameras: any[] = [];
+const renderers: any[] = [];
+const colorArgs: unknown[] = [];
+
+vi.mock("three", () => {
+  class SceneMock {
+    background: unknown = null;
+    constructor() {
+      scenes.push(this);
+    }
+  }
+
+  class PerspectiveCameraMock {
+    aspect: number;
+    position = { set: vi.fn() };
+    updateProjectionMatrix = vi.fn();
+    constructor(public fov: number, aspect: number, public near: number, public far: number) {
+      this.aspect = aspect;
+      cameras.push(this);
+    }
+  }
+
+  class WebGLRendererMock {
+    domElement: HTMLCanvasElement;
+    setPixelRatio = vi.fn();
+    setSize = vi.fn();
+    constructor(public params: unknown) {
+      this.domElement = document.createElement("canvas");
+      renderers.push(this);
+    }
+  }
+
+  class ColorMock {
+    value: unknown;
+    constructor(value: unknown) {
+      this.value = value;
+      colorArgs.push(value);
+    }
+  }
+
+  return {
+    Scene: SceneMock,
+    PerspectiveCamera: PerspectiveCameraMock,
+    WebGLRenderer: WebGLRendererMock,
+    Color: ColorMock,
+  };
+});
+
+// eslint-disable-next-line import/first
+import { createSceneContext } from "../scene";
+
+describe("createSceneContext", () => {
+  const originalPixelRatio = window.devicePixelRatio ?? 1;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="app"></div>';
+    container = document.getElementById("app") as HTMLElement;
+
+    Object.defineProperty(container, "clientWidth", {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(container, "clientHeight", {
+      configurable: true,
+      value: 480,
+    });
+
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 1.5,
+    });
+
+    scenes.length = 0;
+    cameras.length = 0;
+    renderers.length = 0;
+    colorArgs.length = 0;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: originalPixelRatio,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("creates the renderer, scene, and camera, and appends the canvas", () => {
+    const context = createSceneContext();
+
+    expect(context.scene).toBe(scenes[0]);
+    expect(context.camera).toBe(cameras[0]);
+    expect(context.renderer).toBe(renderers[0]);
+    expect(renderers[0]?.params).toEqual({ antialias: true, alpha: true });
+    expect(colorArgs).toContain("#87ceeb");
+    expect(container.contains(context.renderer.domElement)).toBe(true);
+    expect(context.renderer.domElement.style.position).toBe("absolute");
+    expect(context.renderer.domElement.style.pointerEvents).toBe("none");
+  });
+
+  it("clamps the renderer pixel ratio", () => {
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 3,
+    });
+
+    const context = createSceneContext();
+    const renderer = context.renderer as any;
+
+    expect(renderer.setPixelRatio).toHaveBeenCalledWith(2);
+  });
+
+  it("updates size and camera aspect when the window resizes", () => {
+    const context = createSceneContext();
+    const renderer = context.renderer as any;
+
+    expect(renderer.setSize).toHaveBeenCalledWith(640, 480, false);
+
+    const newWidth = 900;
+    const newHeight = 600;
+    Object.defineProperty(container, "clientWidth", { configurable: true, value: newWidth });
+    Object.defineProperty(container, "clientHeight", { configurable: true, value: newHeight });
+
+    renderer.setSize.mockClear();
+    (context.camera.updateProjectionMatrix as any).mockClear();
+
+    window.dispatchEvent(new Event("resize"));
+
+    expect(renderer.setSize).toHaveBeenCalledWith(newWidth, newHeight, false);
+    expect(context.camera.aspect).toBeCloseTo(newWidth / newHeight);
+    expect(context.camera.updateProjectionMatrix).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/scene.ts
+++ b/src/core/scene.ts
@@ -1,0 +1,76 @@
+import { Color, PerspectiveCamera, Scene, WebGLRenderer } from "three";
+
+const MAX_PIXEL_RATIO = 2;
+const DEFAULT_BACKGROUND = "#87ceeb";
+const DEFAULT_FOV = 50;
+const NEAR_PLANE = 0.1;
+const FAR_PLANE = 100;
+
+export interface SceneContext {
+  scene: Scene;
+  camera: PerspectiveCamera;
+  renderer: WebGLRenderer;
+}
+
+function getContainer(): HTMLElement {
+  const container = document.getElementById("app");
+  if (!container) {
+    throw new Error("Missing #app container for scene initialization");
+  }
+  return container;
+}
+
+function computePixelRatio(): number {
+  if (typeof window === "undefined") {
+    return 1;
+  }
+  const ratio = window.devicePixelRatio ?? 1;
+  return Math.min(Math.max(ratio, 1), MAX_PIXEL_RATIO);
+}
+
+function updateRendererSize(
+  renderer: WebGLRenderer,
+  camera: PerspectiveCamera,
+  container: HTMLElement
+): void {
+  const width = container.clientWidth || container.offsetWidth || window.innerWidth || 1;
+  const height =
+    container.clientHeight || container.offsetHeight || window.innerHeight || width || 1;
+
+  if (height === 0) {
+    return;
+  }
+
+  renderer.setSize(width, height, false);
+  const aspect = width / height;
+  if (camera.aspect !== aspect) {
+    camera.aspect = aspect;
+    camera.updateProjectionMatrix();
+  }
+}
+
+export function createSceneContext(): SceneContext {
+  const container = getContainer();
+
+  const scene = new Scene();
+  scene.background = new Color(DEFAULT_BACKGROUND);
+
+  const camera = new PerspectiveCamera(DEFAULT_FOV, 1, NEAR_PLANE, FAR_PLANE);
+  camera.position.set(0, 1.5, 6);
+
+  const renderer = new WebGLRenderer({ antialias: true, alpha: true });
+  renderer.setPixelRatio(computePixelRatio());
+  renderer.domElement.style.position = "absolute";
+  renderer.domElement.style.inset = "0";
+  renderer.domElement.style.width = "100%";
+  renderer.domElement.style.height = "100%";
+  renderer.domElement.style.display = "block";
+  renderer.domElement.style.pointerEvents = "none";
+
+  updateRendererSize(renderer, camera, container);
+  window.addEventListener("resize", () => updateRendererSize(renderer, camera, container));
+
+  container.appendChild(renderer.domElement);
+
+  return { scene, camera, renderer };
+}

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import {
   handleCanvasClick,
 } from "./game/systems/index.js";
 import { initSessionStats } from "./hud/components/SessionStats.ts";
+import { createSceneContext } from "./core/scene.ts";
 
 function bindInput(canvas) {
   const pressAction = (event) => {
@@ -67,6 +68,12 @@ function resizeCanvas(canvas) {
 }
 
 function init() {
+  try {
+    createSceneContext();
+  } catch (error) {
+    console.warn("Unable to initialize Three.js scene", error);
+  }
+
   const canvas = document.getElementById("gameCanvas");
   if (!canvas) {
     throw new Error("Game canvas not found");


### PR DESCRIPTION
## Summary
- add a core createSceneContext helper that sets up the Three.js scene, camera, renderer, and resize handling
- append the renderer canvas to the #app container during app initialization and document the entry-point usage
- cover the scene bootstrap with Vitest using mocked Three.js classes

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e06ebbbdec832897dce28e60c444e1