### PR TITLE
Add F06 input manager feature scaffolding

### DIFF
--- a/src/features/F06_input_manager/__tests__/register.test.ts
+++ b/src/features/F06_input_manager/__tests__/register.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { featureBus, resetFeatureBus } from "../../bus";
+import { register, type InputFlapEvent } from "../register";
+
+describe("F06 input manager register", () => {
+  beforeEach(() => {
+    resetFeatureBus();
+    document.body.innerHTML = "";
+  });
+
+  const createCanvas = (): HTMLCanvasElement => {
+    const canvas = document.createElement("canvas");
+    canvas.tabIndex = 0;
+    document.body.appendChild(canvas);
+    return canvas;
+  };
+
+  it("does nothing when the flag is disabled", () => {
+    const canvas = createCanvas();
+    const cleanup = register({ enabled: false, canvas });
+
+    const handler = vi.fn();
+    featureBus.on("feature:F06/input:flap", handler);
+
+    canvas.dispatchEvent(new Event("pointerdown", { bubbles: true, cancelable: true }));
+
+    expect(handler).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("emits flap events for pointer, touch, and keyboard interactions", () => {
+    const canvas = createCanvas();
+    const cleanup = register({ enabled: true, canvas });
+    const handler = vi.fn();
+    const unsubscribe = featureBus.on("feature:F06/input:flap", handler);
+
+    const pointerEvent = new Event("pointerdown", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(pointerEvent);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject<InputFlapEvent>({
+      source: "pointer",
+      originalEvent: pointerEvent,
+    });
+    expect(pointerEvent.defaultPrevented).toBe(true);
+
+    const touchEvent = new Event("touchstart", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(touchEvent);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1][0]).toMatchObject<InputFlapEvent>({
+      source: "touch",
+      originalEvent: touchEvent,
+    });
+    expect(touchEvent.defaultPrevented).toBe(true);
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(keyEvent);
+
+    expect(handler).toHaveBeenCalledTimes(3);
+    expect(handler.mock.calls[2][0]).toMatchObject<InputFlapEvent>({
+      source: "keyboard",
+      originalEvent: keyEvent,
+    });
+    expect(keyEvent.defaultPrevented).toBe(true);
+
+    unsubscribe();
+    cleanup();
+  });
+
+  it("cleans up listeners when the disposer is invoked", () => {
+    const canvas = createCanvas();
+    const cleanup = register({ enabled: true, canvas });
+
+    const handler = vi.fn();
+    featureBus.on("feature:F06/input:flap", handler);
+
+    cleanup();
+
+    canvas.dispatchEvent(new Event("pointerdown", { bubbles: true, cancelable: true }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("tears down listeners when the window unloads", () => {
+    const canvas = createCanvas();
+    const cleanup = register({ enabled: true, canvas });
+
+    const handler = vi.fn();
+    featureBus.on("feature:F06/input:flap", handler);
+
+    window.dispatchEvent(new Event("beforeunload"));
+
+    canvas.dispatchEvent(new Event("pointerdown", { bubbles: true, cancelable: true }));
+    expect(handler).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("toggles pointer lock when the pointer lock key is pressed", () => {
+    const canvas = createCanvas();
+
+    const requestPointerLock = vi.fn(function thisRequest(this: typeof canvas) {
+      Object.defineProperty(document, "pointerLockElement", {
+        configurable: true,
+        writable: true,
+        value: this,
+      });
+    });
+
+    const exitPointerLock = vi.fn(() => {
+      Object.defineProperty(document, "pointerLockElement", {
+        configurable: true,
+        writable: true,
+        value: null,
+      });
+    });
+
+    Object.defineProperty(canvas, "requestPointerLock", {
+      configurable: true,
+      writable: true,
+      value: requestPointerLock,
+    });
+
+    Object.defineProperty(document, "exitPointerLock", {
+      configurable: true,
+      writable: true,
+      value: exitPointerLock,
+    });
+
+    Object.defineProperty(document, "pointerLockElement", {
+      configurable: true,
+      writable: true,
+      value: null,
+    });
+
+    const cleanup = register({ enabled: true, canvas });
+
+    const toggleEvent = new KeyboardEvent("keydown", {
+      code: "KeyP",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(toggleEvent);
+    expect(requestPointerLock).toHaveBeenCalledTimes(1);
+    expect(document.pointerLockElement).toBe(canvas);
+
+    const secondToggle = new KeyboardEvent("keydown", {
+      code: "KeyP",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(secondToggle);
+    expect(exitPointerLock).toHaveBeenCalledTimes(1);
+    expect(document.pointerLockElement).toBeNull();
+
+    cleanup();
+  });
+});

--- a/src/features/F06_input_manager/events.d.ts
+++ b/src/features/F06_input_manager/events.d.ts
@@ -1,0 +1,7 @@
+import type { InputFlapEvent } from "./register";
+
+declare module "../bus" {
+  interface FeatureEventMap {
+    "feature:F06/input:flap": InputFlapEvent;
+  }
+}

--- a/src/features/F06_input_manager/register.ts
+++ b/src/features/F06_input_manager/register.ts
@@ -1,0 +1,167 @@
+import { featureBus, type FeatureBus } from "../bus";
+
+export type InputSource = "keyboard" | "pointer" | "touch";
+
+export interface InputFlapEvent {
+  source: InputSource;
+  originalEvent: Event;
+}
+
+export interface RegisterInputManagerOptions {
+  /**
+   * Whether the feature flag is enabled. When disabled, the function performs no work
+   * and returns a noop disposer.
+   */
+  enabled?: boolean;
+  /** Canvas element that should receive pointer and keyboard focus. */
+  canvas?: HTMLElement | null;
+  /** Optional window object override, primarily for testing. */
+  window?: Window | null;
+  /** Optional document object override, primarily for testing. */
+  document?: Document | null;
+  /**
+   * Event bus instance used to emit feature events. Defaults to the shared feature bus
+   * singleton.
+   */
+  bus?: FeatureBus;
+  /** Set of keyboard codes that should trigger a flap. */
+  actionKeys?: readonly string[];
+  /** Keyboard code used to toggle pointer lock. */
+  pointerLockKey?: string;
+}
+
+const DEFAULT_ACTION_KEYS = ["Space", "ArrowUp", "KeyW", "KeyX"] as const;
+const DEFAULT_POINTER_LOCK_KEY = "KeyP" as const;
+
+const noop = () => {};
+
+export function register(options: RegisterInputManagerOptions = {}): () => void {
+  if (!options.enabled) {
+    return noop;
+  }
+
+  const win = options.window ?? (typeof window !== "undefined" ? window : null);
+  const doc = options.document ?? win?.document ?? null;
+  const canvas =
+    options.canvas ?? (doc?.getElementById?.("gameCanvas") as HTMLElement | null);
+
+  if (!win || !doc || !canvas) {
+    return noop;
+  }
+
+  const bus = options.bus ?? featureBus;
+  const actionKeys = new Set(options.actionKeys ?? DEFAULT_ACTION_KEYS);
+  const pointerLockKey = options.pointerLockKey ?? DEFAULT_POINTER_LOCK_KEY;
+
+  const cleanupTasks = new Set<() => void>();
+  let cleaned = false;
+
+  const registerCleanup = (task: () => void) => {
+    cleanupTasks.add(task);
+  };
+
+  const emitFlap = (source: InputSource, event: Event) => {
+    bus.emit("feature:F06/input:flap", {
+      source,
+      originalEvent: event,
+    });
+  };
+
+  const togglePointerLock = () => {
+    const requestPointerLock = (canvas as unknown as { requestPointerLock?: () => void })
+      .requestPointerLock;
+    const exitPointerLock = (doc as unknown as { exitPointerLock?: () => void }).exitPointerLock;
+
+    if (doc.pointerLockElement === canvas) {
+      exitPointerLock?.call(doc);
+    } else {
+      requestPointerLock?.call(canvas);
+    }
+  };
+
+  const pointerDownHandler = (event: Event) => {
+    if (typeof event.preventDefault === "function") {
+      event.preventDefault();
+    }
+    emitFlap("pointer", event);
+  };
+
+  canvas.addEventListener("pointerdown", pointerDownHandler);
+  registerCleanup(() => {
+    canvas.removeEventListener("pointerdown", pointerDownHandler);
+  });
+
+  const touchStartHandler = (event: Event) => {
+    if (typeof event.preventDefault === "function") {
+      event.preventDefault();
+    }
+    emitFlap("touch", event);
+  };
+
+  const touchOptions: AddEventListenerOptions = { passive: false };
+  canvas.addEventListener("touchstart", touchStartHandler, touchOptions);
+  registerCleanup(() => {
+    canvas.removeEventListener("touchstart", touchStartHandler, touchOptions);
+  });
+
+  const keydownHandler = (event: KeyboardEvent) => {
+    if (event.repeat) return;
+
+    if (event.code === pointerLockKey) {
+      event.preventDefault();
+      togglePointerLock();
+      return;
+    }
+
+    if (!actionKeys.has(event.code)) {
+      return;
+    }
+
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    emitFlap("keyboard", event);
+  };
+
+  const keyOptions: AddEventListenerOptions = { passive: false };
+  canvas.addEventListener("keydown", keydownHandler, keyOptions);
+  win.addEventListener("keydown", keydownHandler, keyOptions);
+
+  registerCleanup(() => {
+    canvas.removeEventListener("keydown", keydownHandler, keyOptions);
+    win.removeEventListener("keydown", keydownHandler, keyOptions);
+  });
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+
+    cleanupTasks.forEach((task) => {
+      try {
+        task();
+      } catch {
+        // Ignore teardown errors to avoid masking later cleanup tasks.
+      }
+    });
+    cleanupTasks.clear();
+
+    if (doc.pointerLockElement === canvas) {
+      const exitPointerLock = (doc as unknown as { exitPointerLock?: () => void }).exitPointerLock;
+      exitPointerLock?.call(doc);
+    }
+  };
+
+  const unloadHandler = () => {
+    cleanup();
+  };
+
+  win.addEventListener("beforeunload", unloadHandler);
+  registerCleanup(() => {
+    win.removeEventListener("beforeunload", unloadHandler);
+  });
+
+  return cleanup;
+}
+
+export default register;

--- a/src/features/bus.ts
+++ b/src/features/bus.ts
@@ -1,0 +1,69 @@
+export interface FeatureEventMap {
+  [event: string]: unknown;
+}
+
+export type FeatureEventKey = keyof FeatureEventMap & string;
+
+export type FeatureEventListener<K extends FeatureEventKey> = (
+  payload: FeatureEventMap[K],
+) => void;
+
+type ListenerSet = Set<FeatureEventListener<FeatureEventKey>>;
+
+export class FeatureBus {
+  private readonly listeners = new Map<FeatureEventKey, ListenerSet>();
+
+  private getHandlers<K extends FeatureEventKey>(type: K): Set<FeatureEventListener<K>> | undefined {
+    return this.listeners.get(type) as Set<FeatureEventListener<K>> | undefined;
+  }
+
+  private ensureHandlers<K extends FeatureEventKey>(type: K): Set<FeatureEventListener<K>> {
+    let handlers = this.getHandlers(type);
+    if (!handlers) {
+      handlers = new Set<FeatureEventListener<K>>();
+      this.listeners.set(type, handlers as unknown as ListenerSet);
+    }
+    return handlers;
+  }
+
+  on<K extends FeatureEventKey>(type: K, listener: FeatureEventListener<K>): () => void {
+    const handlers = this.ensureHandlers(type);
+    handlers.add(listener);
+    return () => {
+      this.off(type, listener);
+    };
+  }
+
+  off<K extends FeatureEventKey>(type: K, listener: FeatureEventListener<K>): boolean {
+    const handlers = this.getHandlers(type);
+    if (!handlers) {
+      return false;
+    }
+    const removed = handlers.delete(listener);
+    if (handlers.size === 0) {
+      this.listeners.delete(type);
+    }
+    return removed;
+  }
+
+  emit<K extends FeatureEventKey>(type: K, payload: FeatureEventMap[K]): boolean {
+    const handlers = this.getHandlers(type);
+    if (!handlers || handlers.size === 0) {
+      return false;
+    }
+    handlers.forEach((handler) => {
+      handler(payload);
+    });
+    return true;
+  }
+
+  clear(): void {
+    this.listeners.clear();
+  }
+}
+
+export const featureBus = new FeatureBus();
+
+export function resetFeatureBus(): void {
+  featureBus.clear();
+}


### PR DESCRIPTION
## Summary
- add a shared feature bus to emit typed feature events
- scaffold the F06 input manager register helper with pointer, touch, and keyboard handling plus pointer lock toggle
- provide feature event typings and Vitest coverage for the new input manager behaviour

## Testing
- npm run test
- npm run lint *(fails: existing lint errors in src/game/systems)*
- npm run typecheck *(fails: existing typing errors in src/hud/util/haptics.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e06ebcc92483289e30e4d758eed4b1