### PR TITLE
Fix module script path for Vite base routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,6 @@
       </footer>
     </main>
 
-    <script type="module" src="./src/main.js"></script>
+    <script type="module" src="/src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- point the HTML entry to the Vite-managed `/src/main.js` module so the dev and production servers load the bundle correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07271a1688328a1178894f081804e