### PR TITLE
Add HUD root mount utilities and performance guidance

### DIFF
--- a/docs/hud-perf-notes.md
+++ b/docs/hud-perf-notes.md
@@ -1,0 +1,11 @@
+# HUD Performance Notes
+
+The HUD layer renders dynamic text updates at a much higher cadence than the rest of the DOM. To keep these updates cheap:
+
+- **Mount into an isolated root.** Use `mountHudRoot()` from `src/core/hud.ts` to create or reuse the shared `#hud-root` container. The element applies GPU-friendly transforms and `isolation` so frequent writes stay sandboxed.
+- **Batch DOM writes.** Prefer updating text nodes or attributes inside a single animation frame. Avoid removing/adding large subtrees when incrementing scores; reuse nodes instead.
+- **Respect CSS containment.** `hud.css` pins the HUD to the viewport and applies `contain: layout paint style`, preventing layout invalidation outside the HUD subtree. Keep new HUD widgets inside this root to preserve isolation.
+- **Avoid forced reflows.** Do not read layout metrics (e.g., `offsetWidth`) during the same frame you mutate HUD elements. When measurements are required, schedule them in a separate frame or rely on cached values from the game loop.
+- **Keep pointer passthrough explicit.** The HUD root blocks pointer events by default. Re-enable them on interactive descendants (buttons, sliders) so overlays do not intercept gameplay input.
+
+Following these guidelines keeps HUD updates deterministic and avoids hitching during rapid score changes.

--- a/src/core/__tests__/hud.spec.ts
+++ b/src/core/__tests__/hud.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mountHudRoot } from "../hud";
+
+describe("mountHudRoot", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.head.innerHTML = "";
+    delete (process.env as Record<string, string | undefined>).VITE_FF_F07;
+  });
+
+  it("creates the HUD root inside the game stage when available", () => {
+    const stage = document.createElement("div");
+    stage.className = "game-stage";
+    document.body.appendChild(stage);
+
+    const root = mountHudRoot();
+
+    expect(root.id).toBe("hud-root");
+    expect(root.parentElement).toBe(stage);
+    expect(root.getAttribute("role")).toBe("presentation");
+  });
+
+  it("reuses an existing HUD root element", () => {
+    const stage = document.createElement("div");
+    stage.className = "game-stage";
+    const preExisting = document.createElement("div");
+    preExisting.id = "hud-root";
+    stage.appendChild(preExisting);
+    document.body.appendChild(stage);
+
+    const root = mountHudRoot();
+
+    expect(root).toBe(preExisting);
+    expect(root.style.transform).toBe("translate3d(0, 0, 0)");
+    expect(root.style.willChange).toBe("transform");
+    expect(root.style.isolation).toBe("isolate");
+  });
+
+  it("loads HUD CSS when the performance flag is enabled", () => {
+    process.env.VITE_FF_F07 = "true";
+
+    mountHudRoot();
+
+    const styleLink = document.head.querySelector(
+      'link[data-hud-root-styles="true"]',
+    );
+    expect(styleLink).toBeInstanceOf(HTMLLinkElement);
+    expect((styleLink as HTMLLinkElement).href).toContain("hud.css");
+  });
+
+  it("avoids re-measuring siblings when frequently updating scores", () => {
+    const stage = document.createElement("div");
+    stage.className = "game-stage";
+    const unrelated = document.createElement("div");
+    const reflowSpy = vi.fn();
+    unrelated.getBoundingClientRect = reflowSpy;
+    stage.appendChild(unrelated);
+    document.body.appendChild(stage);
+
+    const root = mountHudRoot();
+    const score = document.createElement("span");
+    root.appendChild(score);
+
+    for (let i = 0; i < 20; i += 1) {
+      score.textContent = `${i}`;
+    }
+
+    expect(reflowSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/hud.css
+++ b/src/core/hud.css
@@ -1,0 +1,13 @@
+#hud-root {
+  position: fixed;
+  inset: 0;
+  contain: layout paint style;
+  pointer-events: none;
+  display: block;
+  isolation: isolate;
+  z-index: 20;
+}
+
+#hud-root > * {
+  pointer-events: auto;
+}

--- a/src/core/hud.ts
+++ b/src/core/hud.ts
@@ -1,0 +1,116 @@
+const HUD_ROOT_ID = "hud-root";
+const DEFAULT_CONTAINER_SELECTOR = ".game-stage";
+
+const normalizeBoolean = (value: unknown): boolean => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return ["true", "1", "yes", "on"].includes(normalized);
+  }
+
+  return false;
+};
+
+const isHudPerfFlagEnabled = (): boolean => {
+  const meta = (import.meta as unknown as { env?: Record<string, unknown> })?.env;
+  if (meta && "VITE_FF_F07" in meta) {
+    return normalizeBoolean(meta.VITE_FF_F07);
+  }
+
+  if (typeof process !== "undefined" && process?.env?.VITE_FF_F07 !== undefined) {
+    return normalizeBoolean(process.env.VITE_FF_F07);
+  }
+
+  const globalShim = globalThis as unknown as {
+    __FEATURE_FLAGS__?: Record<string, unknown>;
+  };
+  if (globalShim.__FEATURE_FLAGS__ && "VITE_FF_F07" in globalShim.__FEATURE_FLAGS__) {
+    return normalizeBoolean(globalShim.__FEATURE_FLAGS__.VITE_FF_F07);
+  }
+
+  return false;
+};
+
+let cachedRoot: HTMLElement | null = null;
+let styleLink: HTMLLinkElement | null = null;
+
+const ensureHudCssLoaded = () => {
+  if (!isHudPerfFlagEnabled()) {
+    return;
+  }
+
+  if (styleLink && document.head?.contains(styleLink)) {
+    return;
+  }
+
+  const existing = document.head?.querySelector(
+    'link[data-hud-root-styles="true"]',
+  );
+  if (existing instanceof HTMLLinkElement) {
+    styleLink = existing;
+    return;
+  }
+
+  const href = new URL("./hud.css", import.meta.url).href;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = href;
+  link.dataset.hudRootStyles = "true";
+  document.head?.appendChild(link);
+  styleLink = link;
+};
+
+export type MountHudRootOptions = {
+  /**
+   * Explicit container that should receive the HUD root element.
+   * Defaults to the element with `.game-stage` if present, otherwise `document.body`.
+   */
+  mountPoint?: HTMLElement | null;
+};
+
+const applyPerformanceStyles = (element: HTMLElement) => {
+  element.style.transform = "translate3d(0, 0, 0)";
+  element.style.willChange = "transform";
+  element.style.isolation = "isolate";
+};
+
+export const mountHudRoot = (
+  options: MountHudRootOptions = {},
+): HTMLElement => {
+  if (cachedRoot && document.contains(cachedRoot)) {
+    ensureHudCssLoaded();
+    return cachedRoot;
+  }
+
+  const existing = document.getElementById(HUD_ROOT_ID);
+  if (existing instanceof HTMLElement) {
+    cachedRoot = existing;
+    applyPerformanceStyles(existing);
+    ensureHudCssLoaded();
+    return existing;
+  }
+
+  const mountPoint =
+    options.mountPoint ??
+    document.querySelector<HTMLElement>(DEFAULT_CONTAINER_SELECTOR) ??
+    document.body;
+
+  if (!mountPoint) {
+    throw new Error("Unable to determine HUD mount point");
+  }
+
+  const hudRoot = document.createElement("div");
+  hudRoot.id = HUD_ROOT_ID;
+  hudRoot.setAttribute("role", "presentation");
+  applyPerformanceStyles(hudRoot);
+
+  mountPoint.appendChild(hudRoot);
+  cachedRoot = hudRoot;
+
+  ensureHudCssLoaded();
+
+  return hudRoot;
+};

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,4 @@
 export { bus } from './event-bus';
 export type { GameEventName } from './event-bus';
+export { mountHudRoot } from './hud';
+export type { MountHudRootOptions } from './hud';

--- a/src/game/systems/loop.js
+++ b/src/game/systems/loop.js
@@ -206,7 +206,9 @@ export function initializeGameLoop(gameState, options = {}) {
   state = gameState;
 
   renderer = createThreeRenderer(state.canvas, options.rendererOptions);
-  hud = createHudController(options.hudElements ?? {});
+  hud = createHudController(options.hudElements ?? {}, {
+    hudRoot: options.hudRoot,
+  });
   refreshHud();
   renderer.render(state, 0);
   showIntro();

--- a/src/game/systems/loop.test.ts
+++ b/src/game/systems/loop.test.ts
@@ -6,6 +6,7 @@ import {
   teardownGameLoop,
 } from "./loop.js";
 import { createThreeRenderer } from "../../rendering/three/renderer.js";
+import { createHudController } from "../../rendering/index.js";
 
 vi.mock("../../rendering/three/renderer.js", () => ({
   createThreeRenderer: vi.fn(() => ({
@@ -58,7 +59,9 @@ describe("handleCanvasClick", () => {
     document.body.appendChild(canvas);
     const gameState = createGameState(canvas) as any;
 
-    initializeGameLoop(gameState);
+    const hudRoot = document.createElement("div");
+
+    initializeGameLoop(gameState, { hudRoot });
 
     expect(gameState.awaitingStart).toBe(true);
     handleCanvasClick();
@@ -73,5 +76,10 @@ describe("handleCanvasClick", () => {
     const rendererInstance =
       lastCallIndex >= 0 ? rendererFactory.mock.results[lastCallIndex]?.value : null;
     expect(rendererInstance?.pulseBird).toHaveBeenCalledTimes(1);
+
+    const hudFactory = vi.mocked(createHudController);
+    expect(hudFactory).toHaveBeenCalledWith(expect.anything(), {
+      hudRoot,
+    });
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import {
 } from "./game/systems/index.js";
 import { initSessionStats } from "./hud/components/SessionStats.ts";
 import { createSceneContext } from "./core/scene.ts";
+import { mountHudRoot } from "./core/hud.ts";
 
 function bindInput(canvas) {
   const pressAction = (event) => {
@@ -75,6 +76,8 @@ function init() {
     console.warn("Unable to initialize Three.js scene", error);
   }
 
+  const hudRoot = mountHudRoot();
+
   const canvas = document.getElementById("gameCanvas");
   if (!canvas) {
     throw new Error("Game canvas not found");
@@ -96,6 +99,7 @@ function init() {
       speedProgress: "#speedProgress",
       perfectIndicator: "#perfectIndicator",
     },
+    hudRoot,
   });
 
   initSessionStats();

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -131,7 +131,8 @@ export function createHudController(elements = {}, options = {}) {
 
   const dimLayer = overlay ? new DimLayer(overlay) : null;
 
-  const hudRoot = new HudRoot({ host: overlayParent ?? document.body });
+  const hudRootHost = options.hudRoot ?? overlayParent ?? document.body;
+  const hudRoot = new HudRoot({ host: hudRootHost });
   const pauseMenu = new PauseMenu();
   hudRoot.mount(pauseMenu.element, "modal");
 


### PR DESCRIPTION
## Summary
- add a `mountHudRoot` helper that caches the shared HUD root, applies transform/isolation styles, and loads the FF F07 stylesheet on demand
- mount the HUD root during startup and provide it to the HUD controller so DOM overlays share the isolated container
- document HUD performance best practices and add DOM-focused tests around HUD root creation and reflow isolation

## Testing
- npm test
- npm run typecheck *(fails: pre-existing typing issues in tests and settings context module)*

------
https://chatgpt.com/codex/tasks/task_e_68e072a0da588328a2126ac4a9b18a73