### PR TITLE
Add feature F09 flap input router

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ npm run test
 npm run typecheck
 ```
 
+## Flap input router (F09)
+
+The F09 router centralizes flap actions behind the `feature:F09/flap` event. The
+feature activates when `VITE_FF_F09` resolves to `true`, at which point
+`register()` from [`src/features/F09_flap_input/register.ts`](src/features/F09_flap_input/register.ts)
+listens for pointer, touch, and **Space** key presses. Incoming inputs are
+debounced to avoid double-flaps when browsers emit both pointer and touch
+events, and the router pauses while the core event bus reports a non-`running`
+game state.
+
+To support additional hardware (for example, a gamepad button), wire the input
+inside the same module:
+
+1. Extend `FlapInputSource` with the new identifier.
+2. Bind the event listener and call the internal `emitFlap()` helper so the
+   debounce and game-state gating remain consistent.
+3. Emit `feature:F09/flap` payloads only through this router to keep the
+   pause/resume semantics centralized.
+
+Downstream systems should subscribe to `feature:F09/flap` via
+[`featureBus`](src/features/bus.ts) instead of handling DOM events directly.
+
 ## HUD performance guidelines
 
 Documented HUD performance hints live in [docs/hud-perf.md](docs/hud-perf.md). Review the checklist before adjusting scoreboard, overlay, or control styles so frequent updates stay isolated from the rest of the layout.

--- a/src/features/F09_flap_input/__tests__/register.test.ts
+++ b/src/features/F09_flap_input/__tests__/register.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { featureBus, resetFeatureBus } from "../../bus";
+import { bus } from "@/core";
+import { register, type FlapInputEvent } from "../register";
+
+describe("F09 flap input register", () => {
+  beforeEach(() => {
+    resetFeatureBus();
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  const createCanvas = (): HTMLCanvasElement => {
+    const canvas = document.createElement("canvas");
+    canvas.tabIndex = 0;
+    document.body.appendChild(canvas);
+    return canvas;
+  };
+
+  const setRunningState = (state: string) => {
+    bus.emit("game:state-change", { state });
+  };
+
+  it("exits early when the feature flag is disabled", () => {
+    const canvas = createCanvas();
+    const cleanup = register({ env: { VITE_FF_F09: "false" }, canvas });
+
+    const handler = vi.fn();
+    featureBus.on("feature:F09/flap", handler);
+
+    setRunningState("running");
+    canvas.dispatchEvent(new Event("pointerdown", { bubbles: true, cancelable: true }));
+
+    expect(handler).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("emits a single flap event per user action across input types", () => {
+    vi.useFakeTimers();
+    const canvas = createCanvas();
+    const cleanup = register({ env: { VITE_FF_F09: "true" }, canvas });
+    const handler = vi.fn();
+    const unsubscribe = featureBus.on("feature:F09/flap", handler);
+
+    const nowSpy = vi
+      .spyOn(window.performance, "now")
+      .mockImplementationOnce(() => 100)
+      .mockImplementationOnce(() => 100)
+      .mockImplementation(() => 250);
+
+    setRunningState("running");
+
+    const pointerEvent = new Event("pointerdown", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(pointerEvent);
+
+    const touchEvent = new Event("touchstart", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(touchEvent);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject<FlapInputEvent>({
+      source: "pointer",
+      originalEvent: pointerEvent,
+    });
+
+    vi.advanceTimersByTime(100);
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(keyEvent);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1][0]).toMatchObject<FlapInputEvent>({
+      source: "keyboard",
+      originalEvent: keyEvent,
+    });
+
+    expect(pointerEvent.defaultPrevented).toBe(true);
+    expect(touchEvent.defaultPrevented).toBe(false);
+    expect(keyEvent.defaultPrevented).toBe(true);
+
+    nowSpy.mockRestore();
+    unsubscribe();
+    cleanup();
+  });
+
+  it("ignores interactions when the game is not running", () => {
+    vi.useFakeTimers();
+    const canvas = createCanvas();
+    const cleanup = register({ env: { VITE_FF_F09: "true" }, canvas });
+    const handler = vi.fn();
+    featureBus.on("feature:F09/flap", handler);
+
+    const nowSpy = vi.spyOn(window.performance, "now").mockReturnValue(400);
+
+    const pointerEvent = new Event("pointerdown", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(pointerEvent);
+
+    expect(handler).not.toHaveBeenCalled();
+
+    setRunningState("running");
+    canvas.dispatchEvent(pointerEvent);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    setRunningState("paused");
+    const touchEvent = new Event("touchstart", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(touchEvent);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    setRunningState("running");
+    nowSpy.mockReturnValue(410);
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    window.dispatchEvent(keyEvent);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1][0]).toMatchObject<FlapInputEvent>({
+      source: "keyboard",
+      originalEvent: keyEvent,
+    });
+
+    nowSpy.mockRestore();
+    cleanup();
+  });
+
+  it("resets the debounce window when the game state changes", () => {
+    vi.useFakeTimers();
+    const canvas = createCanvas();
+    const cleanup = register({ env: { VITE_FF_F09: "true" }, canvas, debounceMs: 120 });
+    const handler = vi.fn();
+    featureBus.on("feature:F09/flap", handler);
+
+    const nowSpy = vi
+      .spyOn(window.performance, "now")
+      .mockImplementationOnce(() => 1000)
+      .mockImplementation(() => 1050);
+
+    setRunningState("running");
+
+    const pointerEvent = new Event("pointerdown", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(pointerEvent);
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    setRunningState("paused");
+    setRunningState("running");
+
+    const touchEvent = new Event("touchstart", { bubbles: true, cancelable: true });
+    canvas.dispatchEvent(touchEvent);
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler.mock.calls[1][0]).toMatchObject<FlapInputEvent>({
+      source: "touch",
+      originalEvent: touchEvent,
+    });
+
+    nowSpy.mockRestore();
+    cleanup();
+  });
+});

--- a/src/features/F09_flap_input/events.d.ts
+++ b/src/features/F09_flap_input/events.d.ts
@@ -1,0 +1,13 @@
+import type { FlapInputEvent, GameStateChangeDetail } from "./register";
+
+declare module "../bus" {
+  interface FeatureEventMap {
+    "feature:F09/flap": FlapInputEvent;
+  }
+}
+
+declare global {
+  interface GameEvents {
+    "game:state-change": GameStateChangeDetail;
+  }
+}

--- a/src/features/F09_flap_input/register.ts
+++ b/src/features/F09_flap_input/register.ts
@@ -1,0 +1,276 @@
+import { featureBus, type FeatureBus } from "../bus";
+import { bus as gameBus } from "@/core";
+
+type GameBus = typeof gameBus;
+
+export type FlapInputSource = "keyboard" | "pointer" | "touch";
+
+export interface FlapInputEvent {
+  source: FlapInputSource;
+  originalEvent: Event;
+}
+
+export interface GameStateChangeDetail {
+  state?: string;
+}
+
+export interface RegisterFlapInputOptions {
+  /**
+   * Optional override for feature flag evaluation. When provided this takes precedence
+   * over the environment flag.
+   */
+  enabled?: boolean;
+  /**
+   * Environment variables used to resolve feature flags. Defaults to `import.meta.env`.
+   */
+  env?: Record<string, unknown>;
+  /** Optional window object override, primarily for testing. */
+  window?: Window | null;
+  /** Optional document object override, primarily for testing. */
+  document?: Document | null;
+  /** Canvas element that should receive pointer/touch interactions. */
+  canvas?: HTMLElement | null;
+  /** Event bus instance used to emit feature events. Defaults to the shared feature bus. */
+  bus?: FeatureBus;
+  /** Game event bus used to observe state transitions. */
+  gameBus?: GameBus;
+  /** Minimum interval in milliseconds before another flap event can be emitted. */
+  debounceMs?: number;
+}
+
+const FEATURE_FLAG_KEY = "VITE_FF_F09" as const;
+const TRUE_VALUES = new Set(["1", "true", "yes", "on", "enable", "enabled"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off", "disable", "disabled"]);
+const DEFAULT_DEBOUNCE_MS = 80;
+
+const noop = () => {};
+
+const normalizeBoolean = (value: unknown): boolean | null => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (TRUE_VALUES.has(normalized)) {
+      return true;
+    }
+    if (FALSE_VALUES.has(normalized)) {
+      return false;
+    }
+  }
+
+  return null;
+};
+
+const resolveEnv = (env?: Record<string, unknown>): Record<string, unknown> => {
+  if (env) {
+    return { ...env };
+  }
+
+  const meta = import.meta as unknown as { env?: Record<string, unknown> };
+  return { ...(meta.env ?? {}) };
+};
+
+const resolveFlag = (
+  options: Pick<RegisterFlapInputOptions, "enabled" | "env">,
+): boolean => {
+  if (typeof options.enabled === "boolean") {
+    return options.enabled;
+  }
+
+  const env = resolveEnv(options.env);
+  const raw = env[FEATURE_FLAG_KEY];
+  const normalized = normalizeBoolean(raw);
+  return normalized ?? false;
+};
+
+const resolveWindow = (win?: Window | null): Window | null => {
+  if (win !== undefined) {
+    return win ?? null;
+  }
+
+  if (typeof window !== "undefined") {
+    return window;
+  }
+
+  return null;
+};
+
+const resolveDocument = (doc?: Document | null, win?: Window | null): Document | null => {
+  if (doc !== undefined) {
+    return doc ?? null;
+  }
+
+  return win?.document ?? null;
+};
+
+const resolveCanvas = (
+  canvas: HTMLElement | null | undefined,
+  doc: Document | null,
+): HTMLElement | null => {
+  if (canvas !== undefined) {
+    return canvas ?? null;
+  }
+
+  return (doc?.getElementById?.("gameCanvas") as HTMLElement | null) ?? null;
+};
+
+const getTimestamp = (event: Event, win: Window): number => {
+  const timeStamp = (event as { timeStamp?: unknown }).timeStamp;
+  if (typeof timeStamp === "number" && Number.isFinite(timeStamp)) {
+    return timeStamp;
+  }
+
+  if (typeof win.performance?.now === "function") {
+    return win.performance.now();
+  }
+
+  return Date.now();
+};
+
+export function register(options: RegisterFlapInputOptions = {}): () => void {
+  if (!resolveFlag(options)) {
+    return noop;
+  }
+
+  const win = resolveWindow(options.window);
+  const doc = resolveDocument(options.document, win);
+  const canvas = resolveCanvas(options.canvas ?? null, doc);
+
+  if (!win || !doc || !canvas) {
+    return noop;
+  }
+
+  const bus = options.bus ?? featureBus;
+  const game = options.gameBus ?? gameBus;
+  const debounceMs = Math.max(0, options.debounceMs ?? DEFAULT_DEBOUNCE_MS);
+
+  let isRunning = false;
+  let lastEmitTime = -Infinity;
+
+  const cleanupTasks = new Set<() => void>();
+  let disposed = false;
+
+  const registerCleanup = (task: () => void) => {
+    cleanupTasks.add(task);
+  };
+
+  const resetDebounce = () => {
+    lastEmitTime = -Infinity;
+  };
+
+  const shouldEmit = (event: Event): boolean => {
+    if (!isRunning) {
+      return false;
+    }
+
+    const now = getTimestamp(event, win);
+    if (now - lastEmitTime < debounceMs) {
+      return false;
+    }
+
+    lastEmitTime = now;
+    return true;
+  };
+
+  const emitFlap = (source: FlapInputSource, event: Event) => {
+    if (!shouldEmit(event)) {
+      return;
+    }
+
+    if (typeof event.preventDefault === "function") {
+      event.preventDefault();
+    }
+
+    bus.emit("feature:F09/flap", {
+      source,
+      originalEvent: event,
+    });
+  };
+
+  const pointerHandler = (event: Event) => {
+    emitFlap("pointer", event);
+  };
+
+  const touchHandler = (event: Event) => {
+    emitFlap("touch", event);
+  };
+
+  const keydownHandler = (event: KeyboardEvent) => {
+    if (event.repeat) {
+      return;
+    }
+
+    if (event.code !== "Space") {
+      return;
+    }
+
+    emitFlap("keyboard", event);
+  };
+
+  const pointerOptions: AddEventListenerOptions = { passive: false };
+  const touchOptions: AddEventListenerOptions = { passive: false };
+  const keyOptions: AddEventListenerOptions = { passive: false };
+
+  canvas.addEventListener("pointerdown", pointerHandler, pointerOptions);
+  registerCleanup(() => {
+    canvas.removeEventListener("pointerdown", pointerHandler, pointerOptions);
+  });
+
+  canvas.addEventListener("touchstart", touchHandler, touchOptions);
+  registerCleanup(() => {
+    canvas.removeEventListener("touchstart", touchHandler, touchOptions);
+  });
+
+  canvas.addEventListener("keydown", keydownHandler, keyOptions);
+  win.addEventListener("keydown", keydownHandler, keyOptions);
+  registerCleanup(() => {
+    canvas.removeEventListener("keydown", keydownHandler, keyOptions);
+    win.removeEventListener("keydown", keydownHandler, keyOptions);
+  });
+
+  if (game && typeof game.on === "function") {
+    const unsubscribe = game.on("game:state-change", (detail: GameStateChangeDetail | undefined) => {
+      isRunning = detail?.state === "running";
+      resetDebounce();
+    });
+    registerCleanup(unsubscribe);
+  }
+
+  const unloadHandler = () => {
+    cleanup();
+  };
+
+  win.addEventListener("beforeunload", unloadHandler);
+  registerCleanup(() => {
+    win.removeEventListener("beforeunload", unloadHandler);
+  });
+
+  const cleanup = () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+
+    cleanupTasks.forEach((task) => {
+      try {
+        task();
+      } catch {
+        // Ignore teardown errors to prevent masking subsequent cleanup tasks.
+      }
+    });
+
+    cleanupTasks.clear();
+    resetDebounce();
+  };
+
+  return cleanup;
+}
+
+export default register;


### PR DESCRIPTION
## Summary
- add the F09 flap input router that debounces pointer, touch, and Space key presses while respecting game-state transitions
- register feature and core event typings for the new flap emission
- document how additional controllers should integrate with the router

## Testing
- npm run test
- npm run typecheck *(fails: existing project configuration lacks typing for the `@/` alias and vitest mock helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68e072a23a9c83288b022fc148e5c082