### PR TITLE
Add F11 input buffering feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ npm run test
 npm run typecheck
 ```
 
+## Input Buffer Configuration
+
+Feature flag `VITE_FF_F11` enables the input buffering experiment implemented in
+`src/features/F11_input_buffer/register.ts`. Two exported constants document the
+timing defaults:
+
+- `DEFAULT_BUFFER_WINDOW_MS` (120 ms) – how long flap attempts remain queued
+  while the bird is ineligible to jump.
+- `DEFAULT_COYOTE_WINDOW_MS` (90 ms) – the extra grace period applied to ground
+  attempts so they can still trigger shortly after lift-off.
+
+Adjust these constants if you need to tune responsiveness; the unit tests cover
+expected behavior around eligibility and the ground coyote window.
+
 ## HUD performance guidelines
 
 Documented HUD performance hints live in [docs/hud-perf.md](docs/hud-perf.md). Review the checklist before adjusting scoreboard, overlay, or control styles so frequent updates stay isolated from the rest of the layout.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,2 +1,4 @@
 export { bus } from './event-bus';
 export type { GameEventName } from './event-bus';
+export { getTicker, setTicker, resetTicker } from './ticker';
+export type { CoreTicker as Ticker } from './ticker';

--- a/src/core/ticker.ts
+++ b/src/core/ticker.ts
@@ -1,0 +1,32 @@
+export interface Ticker {
+  now(): number;
+}
+
+class PerformanceTicker implements Ticker {
+  now(): number {
+    if (typeof performance !== "undefined" && typeof performance.now === "function") {
+      return performance.now();
+    }
+    return Date.now();
+  }
+}
+
+let activeTicker: Ticker = new PerformanceTicker();
+
+export function getTicker(): Ticker {
+  return activeTicker;
+}
+
+export function setTicker(ticker: Ticker | null | undefined): void {
+  if (ticker) {
+    activeTicker = ticker;
+    return;
+  }
+  activeTicker = new PerformanceTicker();
+}
+
+export function resetTicker(): void {
+  setTicker(undefined);
+}
+
+export type { Ticker as CoreTicker };

--- a/src/features/F11_input_buffer/__tests__/register.test.ts
+++ b/src/features/F11_input_buffer/__tests__/register.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { DeterministicPRNG } from "@/game/systems/prng";
+import { featureBus, FeatureBus, resetFeatureBus } from "../../bus";
+import type { InputFlapEvent } from "../../F06_input_manager/register";
+import {
+  BIRD_ELIGIBILITY_EVENT,
+  DEFAULT_BUFFER_WINDOW_MS,
+  DEFAULT_COYOTE_WINDOW_MS,
+  INPUT_IMPULSE_EVENT,
+  register,
+  type BirdEligibilityState,
+  type BufferedImpulseEvent,
+  type RegisterInputBufferOptions,
+} from "../register";
+import type { Ticker } from "@/core/ticker";
+
+class ManualTicker implements Ticker {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): number {
+    this.current += ms;
+    return this.current;
+  }
+
+  set(time: number): void {
+    this.current = time;
+  }
+}
+
+const createAttempt = (): InputFlapEvent => ({
+  source: "keyboard",
+  originalEvent: new Event("flap"),
+});
+
+const emitEligibility = (bus: FeatureBus, state: BirdEligibilityState): void => {
+  bus.emit(BIRD_ELIGIBILITY_EVENT, state);
+};
+
+const registerWithOptions = (options: RegisterInputBufferOptions = {}) =>
+  register({ enabled: true, ...options });
+
+describe("F11 input buffer register", () => {
+  beforeEach(() => {
+    resetFeatureBus();
+  });
+
+  it("buffers flap attempts triggered just before eligibility", () => {
+    const ticker = new ManualTicker();
+    const impulses: BufferedImpulseEvent[] = [];
+
+    const cleanup = registerWithOptions({ ticker });
+    const unsubscribe = featureBus.on(INPUT_IMPULSE_EVENT, (payload) => {
+      impulses.push(payload);
+    });
+
+    emitEligibility(featureBus, { grounded: true, eligible: false });
+
+    ticker.advance(20);
+    featureBus.emit("feature:F06/input:flap", createAttempt());
+
+    expect(impulses).toHaveLength(0);
+
+    ticker.advance(10);
+    emitEligibility(featureBus, { grounded: false, eligible: true });
+
+    expect(impulses).toHaveLength(1);
+    expect(impulses[0]).toMatchObject({
+      attemptedAt: 20,
+      triggeredAt: 30,
+      bufferedMs: 10,
+    });
+
+    unsubscribe();
+    cleanup();
+  });
+
+  it("extends ground attempts through the coyote window", () => {
+    const ticker = new ManualTicker();
+    const impulses: BufferedImpulseEvent[] = [];
+    const bufferWindowMs = 40;
+    const coyoteWindowMs = 120;
+
+    const cleanup = registerWithOptions({
+      ticker,
+      bufferWindowMs,
+      coyoteWindowMs,
+    });
+    const unsubscribe = featureBus.on(INPUT_IMPULSE_EVENT, (payload) => {
+      impulses.push(payload);
+    });
+
+    emitEligibility(featureBus, { grounded: true, eligible: false });
+
+    ticker.advance(10);
+    featureBus.emit("feature:F06/input:flap", createAttempt());
+
+    ticker.advance(20);
+    emitEligibility(featureBus, { grounded: false, eligible: false });
+
+    ticker.advance(100);
+    emitEligibility(featureBus, { grounded: false, eligible: true });
+
+    expect(impulses).toHaveLength(1);
+    expect(impulses[0].triggeredAt).toBe(130);
+    expect(impulses[0].attemptedAt).toBe(10);
+
+    unsubscribe();
+    cleanup();
+  });
+
+  it("produces deterministic results across seeds", () => {
+    const runSimulation = (seed: number) => {
+      const bus = new FeatureBus();
+      const ticker = new ManualTicker();
+      const impulses: Array<Pick<BufferedImpulseEvent, "attemptedAt" | "triggeredAt">> = [];
+      const prng = new DeterministicPRNG(seed);
+
+      const cleanup = registerWithOptions({ bus, ticker });
+      const unsubscribe = bus.on(INPUT_IMPULSE_EVENT, (payload) => {
+        impulses.push({
+          attemptedAt: payload.attemptedAt,
+          triggeredAt: payload.triggeredAt,
+        });
+      });
+
+      bus.emit(BIRD_ELIGIBILITY_EVENT, { grounded: true, eligible: false });
+
+      for (let i = 0; i < 5; i += 1) {
+        ticker.advance(Math.floor(prng.next() * DEFAULT_BUFFER_WINDOW_MS));
+        bus.emit("feature:F06/input:flap", createAttempt());
+
+        ticker.advance(Math.floor(prng.next() * DEFAULT_COYOTE_WINDOW_MS));
+        bus.emit(BIRD_ELIGIBILITY_EVENT, { grounded: false, eligible: true });
+        ticker.advance(1);
+        bus.emit(BIRD_ELIGIBILITY_EVENT, { grounded: false, eligible: false });
+      }
+
+      unsubscribe();
+      cleanup();
+      return impulses;
+    };
+
+    const seeds = [1, 42, 12345];
+    for (const seed of seeds) {
+      const first = runSimulation(seed);
+      const second = runSimulation(seed);
+      expect(second).toEqual(first);
+    }
+  });
+});

--- a/src/features/F11_input_buffer/events.d.ts
+++ b/src/features/F11_input_buffer/events.d.ts
@@ -1,0 +1,11 @@
+import type {
+  BirdEligibilityState,
+  BufferedImpulseEvent,
+} from "./register";
+
+declare module "../bus" {
+  interface FeatureEventMap {
+    "feature:F11/input-buffer:impulse": BufferedImpulseEvent;
+    "feature:F11/bird:eligibility": BirdEligibilityState;
+  }
+}

--- a/src/features/F11_input_buffer/register.ts
+++ b/src/features/F11_input_buffer/register.ts
@@ -1,0 +1,211 @@
+import { getTicker, type Ticker } from "../../core/ticker";
+import { featureBus, type FeatureBus } from "../bus";
+import type { InputFlapEvent } from "../F06_input_manager/register";
+
+export const FEATURE_FLAG_KEY = "VITE_FF_F11" as const;
+export const DEFAULT_BUFFER_WINDOW_MS = 120;
+export const DEFAULT_COYOTE_WINDOW_MS = 90;
+export const INPUT_IMPULSE_EVENT = "feature:F11/input-buffer:impulse" as const;
+export const BIRD_ELIGIBILITY_EVENT = "feature:F11/bird:eligibility" as const;
+
+type BooleanLike = boolean | number | string | null | undefined;
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on", "enable", "enabled"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off", "disable", "disabled"]);
+
+const normalizeBoolean = (value: BooleanLike): boolean | null => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (TRUE_VALUES.has(normalized)) {
+      return true;
+    }
+    if (FALSE_VALUES.has(normalized)) {
+      return false;
+    }
+  }
+  return null;
+};
+
+const readFeatureFlag = (env?: Record<string, unknown>): boolean => {
+  if (env) {
+    const candidate = normalizeBoolean(env[FEATURE_FLAG_KEY] as BooleanLike);
+    if (candidate !== null) {
+      return candidate;
+    }
+  }
+
+  const meta = import.meta as unknown as { env?: Record<string, unknown> };
+  const metaValue = normalizeBoolean(meta.env?.[FEATURE_FLAG_KEY] as BooleanLike);
+  if (metaValue !== null) {
+    return metaValue;
+  }
+
+  if (typeof process !== "undefined" && process?.env) {
+    const processValue = normalizeBoolean(
+      process.env[FEATURE_FLAG_KEY] as BooleanLike,
+    );
+    if (processValue !== null) {
+      return processValue;
+    }
+  }
+
+  return false;
+};
+
+export interface BirdEligibilityState {
+  eligible: boolean;
+  grounded: boolean;
+}
+
+interface BufferedAttempt {
+  event: InputFlapEvent;
+  timestamp: number;
+  expiresAt: number;
+}
+
+export interface BufferedImpulseEvent extends InputFlapEvent {
+  attemptedAt: number;
+  triggeredAt: number;
+  bufferedMs: number;
+}
+
+export interface RegisterInputBufferOptions {
+  enabled?: boolean;
+  env?: Record<string, unknown>;
+  bus?: FeatureBus;
+  ticker?: Ticker;
+  bufferWindowMs?: number;
+  coyoteWindowMs?: number;
+}
+
+const noop = () => {};
+
+const clampDuration = (value: number, fallback: number): number => {
+  if (!Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+  return value;
+};
+
+export function register(options: RegisterInputBufferOptions = {}): () => void {
+  const enabled = options.enabled ?? readFeatureFlag(options.env);
+  if (!enabled) {
+    return noop;
+  }
+
+  const bus = options.bus ?? featureBus;
+  const ticker = options.ticker ?? getTicker();
+  const bufferWindowMs = clampDuration(
+    options.bufferWindowMs ?? DEFAULT_BUFFER_WINDOW_MS,
+    DEFAULT_BUFFER_WINDOW_MS,
+  );
+  const coyoteWindowMs = clampDuration(
+    options.coyoteWindowMs ?? DEFAULT_COYOTE_WINDOW_MS,
+    DEFAULT_COYOTE_WINDOW_MS,
+  );
+
+  const attempts: BufferedAttempt[] = [];
+  let eligible = false;
+  let grounded = false;
+  let lastGroundExitAt: number | null = null;
+
+  const pruneExpired = (now: number) => {
+    while (attempts.length > 0) {
+      const next = attempts[0];
+      if (now <= next.expiresAt) {
+        break;
+      }
+      attempts.shift();
+    }
+  };
+
+  const emitImpulse = (attempt: BufferedAttempt, triggeredAt: number) => {
+    bus.emit(INPUT_IMPULSE_EVENT, {
+      source: attempt.event.source,
+      originalEvent: attempt.event.originalEvent,
+      attemptedAt: attempt.timestamp,
+      triggeredAt,
+      bufferedMs: Math.max(0, triggeredAt - attempt.timestamp),
+    });
+  };
+
+  const processQueue = () => {
+    const now = ticker.now();
+    pruneExpired(now);
+    if (attempts.length === 0) {
+      return;
+    }
+
+    if (!eligible) {
+      return;
+    }
+
+    const attempt = attempts.shift();
+    if (!attempt) {
+      return;
+    }
+    emitImpulse(attempt, now);
+  };
+
+  const computeExpiration = (now: number): number => {
+    let expiresAt = now + bufferWindowMs;
+    if (grounded) {
+      expiresAt = Math.max(expiresAt, now + coyoteWindowMs);
+    } else if (lastGroundExitAt !== null && now - lastGroundExitAt <= coyoteWindowMs) {
+      expiresAt = Math.max(expiresAt, lastGroundExitAt + coyoteWindowMs);
+    }
+    return expiresAt;
+  };
+
+  const handleAttempt = (event: InputFlapEvent) => {
+    const now = ticker.now();
+    attempts.push({
+      event,
+      timestamp: now,
+      expiresAt: computeExpiration(now),
+    });
+    processQueue();
+  };
+
+  const handleEligibility = (state: BirdEligibilityState) => {
+    const now = ticker.now();
+    const wasGrounded = grounded;
+    grounded = state.grounded;
+    eligible = state.eligible;
+
+    if (grounded) {
+      lastGroundExitAt = null;
+    } else if (wasGrounded && !grounded) {
+      lastGroundExitAt = now;
+    } else if (lastGroundExitAt !== null && now - lastGroundExitAt > coyoteWindowMs) {
+      lastGroundExitAt = null;
+    }
+
+    processQueue();
+  };
+
+  const disposers: Array<() => void> = [];
+  disposers.push(bus.on("feature:F06/input:flap", handleAttempt));
+  disposers.push(bus.on(BIRD_ELIGIBILITY_EVENT, handleEligibility));
+
+  return () => {
+    while (disposers.length > 0) {
+      const dispose = disposers.pop();
+      try {
+        dispose?.();
+      } catch {
+        // Ignore teardown errors so all listeners are attempted.
+      }
+    }
+    attempts.length = 0;
+  };
+}
+
+export default register;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,11 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "src/*": ["src/*"]
+    },
     "allowJs": true,
     "checkJs": false,
     "strict": true,


### PR DESCRIPTION
## Summary
- add the F11 input buffer feature to queue flap attempts until eligibility and emit buffered impulses under `VITE_FF_F11`
- introduce a core ticker helper, expose it through the core index, and wire up module path aliases for `@/*`
- cover the buffer/coyote behaviour with tests and document the tuning constants in the README

## Testing
- `npm run test`
- `npm run typecheck` *(fails: existing Vitest mock generics and legacy settings context typings)*

------
https://chatgpt.com/codex/tasks/task_e_68e072a515348328a705c7d2af66508a