### PR TITLE
Add F13 ground collision handling

### DIFF
--- a/src/features/F13_ground_collision/__tests__/register.test.ts
+++ b/src/features/F13_ground_collision/__tests__/register.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FeatureBus } from "../../bus";
+import {
+  BIRD_COLLIDE_EVENT,
+  BIRD_POSITION_EVENT,
+  GAME_OVER_STATE,
+  GAME_RESET_EVENT,
+  register,
+  type BirdPositionUpdatePayload,
+  type GameStateValue,
+  type GameStateMachine,
+} from "../register";
+
+type MutableGameStateMachine = GameStateMachine & {
+  current: GameStateValue;
+  setCurrent(state: GameStateValue): void;
+};
+
+const createStateMachine = (): MutableGameStateMachine => {
+  let current: GameStateValue = "RUNNING";
+  const transition = vi.fn((next: GameStateValue) => {
+    current = next;
+  });
+  return {
+    get current() {
+      return current;
+    },
+    transition,
+    setCurrent(state: GameStateValue) {
+      current = state;
+    },
+  };
+};
+
+describe("F13 ground collision register", () => {
+  let bus: FeatureBus;
+  let stateMachine: MutableGameStateMachine;
+
+  beforeEach(() => {
+    bus = new FeatureBus();
+    stateMachine = createStateMachine();
+  });
+
+  const emitPosition = (payload: BirdPositionUpdatePayload) => {
+    bus.emit(BIRD_POSITION_EVENT, payload);
+  };
+
+  it("emits a collision event and transitions to GAME_OVER on ground contact", () => {
+    const collisions: BirdPositionUpdatePayload[] = [];
+    bus.on(BIRD_COLLIDE_EVENT, (detail) => {
+      collisions.push({
+        position: detail.position,
+        radius: 0,
+        dt: detail.dt,
+      });
+    });
+
+    const cleanup = register({
+      bus,
+      stateMachine,
+      groundHeight: 0,
+      freezeFlagEnabled: false,
+    });
+
+    emitPosition({
+      position: { x: 0, y: 1, z: 0 },
+      radius: 0.5,
+      dt: 1 / 60,
+    });
+
+    emitPosition({
+      position: { x: 0, y: 0.2, z: 0 },
+      radius: 0.5,
+      dt: 1 / 60,
+    });
+
+    expect(collisions).toHaveLength(1);
+    expect(stateMachine.transition).toHaveBeenCalledTimes(1);
+    expect(stateMachine.transition).toHaveBeenCalledWith(GAME_OVER_STATE);
+
+    cleanup();
+  });
+
+  it("performs swept collision checks for large dt values", () => {
+    const handler = vi.fn();
+    bus.on(BIRD_COLLIDE_EVENT, handler);
+
+    register({
+      bus,
+      stateMachine,
+      groundHeight: 0,
+      freezeFlagEnabled: false,
+    });
+
+    emitPosition({
+      position: { x: 0, y: 2, z: 0 },
+      radius: 0.4,
+      dt: 1 / 30,
+    });
+
+    emitPosition({
+      position: { x: 0, y: -3, z: 0 },
+      radius: 0.4,
+      dt: 1 / 30,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(stateMachine.transition).toHaveBeenCalledTimes(1);
+    expect(stateMachine.transition).toHaveBeenLastCalledWith(GAME_OVER_STATE);
+  });
+
+  it("freezes the bird rigidbody when the feature flag is enabled", () => {
+    const rigidBody = {
+      setLinvel: vi.fn(),
+      setAngvel: vi.fn(),
+      lockTranslations: vi.fn(),
+      lockRotations: vi.fn(),
+      sleep: vi.fn(),
+    };
+
+    register({
+      bus,
+      stateMachine,
+      groundHeight: 0,
+      freezeFlagEnabled: true,
+    });
+
+    emitPosition({
+      position: { x: 0, y: 0.3, z: 0 },
+      radius: 0.4,
+      dt: 1 / 60,
+      rigidBody,
+    });
+
+    expect(rigidBody.setLinvel).toHaveBeenCalledWith({ x: 0, y: 0, z: 0 }, true);
+    expect(rigidBody.setAngvel).toHaveBeenCalledWith({ x: 0, y: 0, z: 0 }, true);
+    expect(rigidBody.lockTranslations).toHaveBeenCalledWith(true, true);
+    expect(rigidBody.lockRotations).toHaveBeenCalledWith(true, true);
+    expect(rigidBody.sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets internal state when a game reset event is emitted", () => {
+    const handler = vi.fn();
+    bus.on(BIRD_COLLIDE_EVENT, handler);
+
+    register({
+      bus,
+      stateMachine,
+      groundHeight: 0,
+      freezeFlagEnabled: false,
+    });
+
+    emitPosition({
+      position: { x: 0, y: 1, z: 0 },
+      radius: 0.5,
+      dt: 1 / 60,
+    });
+
+    emitPosition({
+      position: { x: 0, y: 0.3, z: 0 },
+      radius: 0.5,
+      dt: 1 / 60,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    bus.emit(GAME_RESET_EVENT, undefined);
+    stateMachine.setCurrent("RUNNING");
+
+    emitPosition({
+      position: { x: 0, y: 1, z: 0 },
+      radius: 0.5,
+      dt: 1 / 60,
+    });
+
+    emitPosition({
+      position: { x: 0, y: 0.25, z: 0 },
+      radius: 0.5,
+      dt: 1 / 60,
+    });
+
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(stateMachine.transition).toHaveBeenCalledTimes(2);
+  });
+
+  it("removes listeners when the cleanup function is invoked", () => {
+    const handler = vi.fn();
+    bus.on(BIRD_COLLIDE_EVENT, handler);
+
+    const cleanup = register({
+      bus,
+      stateMachine,
+      groundHeight: 0,
+      freezeFlagEnabled: false,
+    });
+
+    cleanup();
+
+    emitPosition({
+      position: { x: 0, y: -1, z: 0 },
+      radius: 0.4,
+      dt: 1 / 60,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(stateMachine.transition).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/F13_ground_collision/events.d.ts
+++ b/src/features/F13_ground_collision/events.d.ts
@@ -1,0 +1,12 @@
+import type {
+  BirdCollisionDetail,
+  BirdPositionUpdatePayload,
+} from "./register";
+
+declare module "../bus" {
+  interface FeatureEventMap {
+    "bird:position": BirdPositionUpdatePayload;
+    "bird:collide": BirdCollisionDetail;
+    "game:reset": undefined;
+  }
+}

--- a/src/features/F13_ground_collision/register.ts
+++ b/src/features/F13_ground_collision/register.ts
@@ -1,0 +1,226 @@
+import { featureBus, type FeatureBus } from "../bus";
+
+export const BIRD_POSITION_EVENT = "bird:position" as const;
+export const BIRD_COLLIDE_EVENT = "bird:collide" as const;
+export const GAME_RESET_EVENT = "game:reset" as const;
+export const GAME_OVER_STATE = "GAME_OVER" as const;
+const FEATURE_FLAG_KEY = "VITE_FF_F13" as const;
+
+const noop = () => {};
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on", "enable", "enabled"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off", "disable", "disabled"]);
+
+export type Vector3 = {
+  x: number;
+  y: number;
+  z: number;
+};
+
+export interface RigidBodyLike {
+  setLinvel?(velocity: Vector3, wake: boolean): void;
+  setAngvel?(velocity: Vector3, wake: boolean): void;
+  lockTranslations?(locked: boolean, wake: boolean): void;
+  lockRotations?(locked: boolean, wake: boolean): void;
+  sleep?(): void;
+}
+
+export interface BirdPositionUpdatePayload {
+  position: Vector3;
+  radius: number;
+  dt: number;
+  rigidBody?: RigidBodyLike | null;
+}
+
+export interface BirdCollisionDetail {
+  position: Vector3;
+  groundHeight: number;
+  dt: number;
+}
+
+export type GameStateValue = typeof GAME_OVER_STATE | string;
+
+export interface GameStateMachine {
+  transition(nextState: GameStateValue): void;
+}
+
+export interface RegisterGroundCollisionOptions {
+  enabled?: boolean;
+  groundHeight?: number;
+  bus?: FeatureBus;
+  stateMachine: GameStateMachine;
+  freezeFlagEnabled?: boolean;
+}
+
+function normalizeBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (TRUE_VALUES.has(normalized)) return true;
+    if (FALSE_VALUES.has(normalized)) return false;
+  }
+
+  return null;
+}
+
+function resolveFreezeFlag(): boolean {
+  const meta = import.meta as unknown as { env?: Record<string, unknown> };
+  const fromMeta = normalizeBoolean(meta.env?.[FEATURE_FLAG_KEY]);
+  if (fromMeta !== null) {
+    return fromMeta;
+  }
+
+  if (typeof process !== "undefined" && process?.env) {
+    const fromProcess = normalizeBoolean(process.env[FEATURE_FLAG_KEY]);
+    if (fromProcess !== null) {
+      return fromProcess;
+    }
+  }
+
+  const globalShim = globalThis as unknown as {
+    __FEATURE_FLAGS__?: Record<string, unknown>;
+  };
+
+  const fromGlobal = normalizeBoolean(
+    globalShim.__FEATURE_FLAGS__?.[FEATURE_FLAG_KEY],
+  );
+  if (fromGlobal !== null) {
+    return fromGlobal;
+  }
+
+  return false;
+}
+
+function computeBottom(position: Vector3, radius: number): number {
+  return position.y - radius;
+}
+
+function crossesGround(
+  previousBottom: number | null,
+  currentBottom: number,
+  groundHeight: number,
+): boolean {
+  if (currentBottom <= groundHeight) {
+    return true;
+  }
+
+  if (previousBottom === null) {
+    return false;
+  }
+
+  if (previousBottom <= groundHeight) {
+    return true;
+  }
+
+  const min = Math.min(previousBottom, currentBottom);
+  const max = Math.max(previousBottom, currentBottom);
+  return min <= groundHeight && max >= groundHeight;
+}
+
+function freezeRigidBody(rigidBody: RigidBodyLike | null | undefined): void {
+  if (!rigidBody) {
+    return;
+  }
+
+  try {
+    rigidBody.setLinvel?.({ x: 0, y: 0, z: 0 }, true);
+  } catch (_error) {
+    // Ignore Rapier interop errors to avoid breaking the game loop.
+  }
+
+  try {
+    rigidBody.setAngvel?.({ x: 0, y: 0, z: 0 }, true);
+  } catch (_error) {
+    // Ignore Rapier interop errors to avoid breaking the game loop.
+  }
+
+  try {
+    rigidBody.lockTranslations?.(true, true);
+  } catch (_error) {
+    // Ignore Rapier interop errors to avoid breaking the game loop.
+  }
+
+  try {
+    rigidBody.lockRotations?.(true, true);
+  } catch (_error) {
+    // Ignore Rapier interop errors to avoid breaking the game loop.
+  }
+
+  try {
+    rigidBody.sleep?.();
+  } catch (_error) {
+    // Ignore Rapier interop errors to avoid breaking the game loop.
+  }
+}
+
+export function register({
+  enabled = true,
+  groundHeight = 0,
+  bus = featureBus,
+  stateMachine,
+  freezeFlagEnabled,
+}: RegisterGroundCollisionOptions): () => void {
+  if (!enabled) {
+    return noop;
+  }
+
+  const freezeOnCollision = freezeFlagEnabled ?? resolveFreezeFlag();
+
+  let previousBottom: number | null = null;
+  let hasCollided = false;
+
+  const handlePositionUpdate = (payload: BirdPositionUpdatePayload) => {
+    if (hasCollided) {
+      return;
+    }
+
+    const bottom = computeBottom(payload.position, payload.radius);
+    const didCollide = crossesGround(previousBottom, bottom, groundHeight);
+    previousBottom = bottom;
+
+    if (!didCollide) {
+      return;
+    }
+
+    hasCollided = true;
+
+    if (freezeOnCollision) {
+      freezeRigidBody(payload.rigidBody);
+    }
+
+    try {
+      stateMachine.transition(GAME_OVER_STATE);
+    } catch (_error) {
+      // Swallow state machine errors to keep the collision handler resilient.
+    }
+
+    bus.emit(BIRD_COLLIDE_EVENT, {
+      position: payload.position,
+      groundHeight,
+      dt: payload.dt,
+    });
+  };
+
+  const handleReset = () => {
+    previousBottom = null;
+    hasCollided = false;
+  };
+
+  const disposePosition = bus.on(BIRD_POSITION_EVENT, handlePositionUpdate);
+  const disposeReset = bus.on(GAME_RESET_EVENT, handleReset);
+
+  return () => {
+    disposePosition();
+    disposeReset();
+  };
+}
+
+export default register;


### PR DESCRIPTION
## Summary
- add the F13 ground collision registrar that watches bird position updates, performs swept ground checks, and triggers the GAME_OVER transition while freezing the rigidbody when the flag is enabled
- extend the feature bus typings for the new bird position and collision events
- cover normal, large-dt, freeze, reset, and cleanup scenarios with dedicated tests

## Testing
- npm run test -- F13_ground_collision

------
https://chatgpt.com/codex/tasks/task_e_68e072a83cbc8328b628da7a81a033d8