### PR TITLE
Restore legacy event payloads for core loop

### DIFF
--- a/src/core/__tests__/state.spec.ts
+++ b/src/core/__tests__/state.spec.ts
@@ -1,10 +1,15 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { bus } from '../event-bus';
 import { createGameStateMachine, GAME_STATES, type GameStateValue } from '../state';
 
 const unsubscribeAll: Array<() => void> = [];
 
+beforeEach(() => {
+  vi.stubEnv('VITE_FF_F02', 'true');
+});
+
 afterEach(() => {
+  vi.unstubAllEnvs();
   while (unsubscribeAll.length > 0) {
     const unsubscribe = unsubscribeAll.pop();
     unsubscribe?.();
@@ -42,12 +47,17 @@ describe('game state machine', () => {
     expect(machine.getState()).toBe('READY');
 
     expect(events).toEqual([
-      { from: 'BOOT', to: 'READY' },
-      { from: 'READY', to: 'RUNNING' },
-      { from: 'RUNNING', to: 'PAUSED' },
-      { from: 'PAUSED', to: 'RUNNING' },
-      { from: 'RUNNING', to: 'GAME_OVER' },
-      { from: 'GAME_OVER', to: 'READY' },
+      { from: 'BOOT', to: 'READY', previousState: 'boot', state: 'ready' },
+      { from: 'READY', to: 'RUNNING', previousState: 'ready', state: 'running' },
+      { from: 'RUNNING', to: 'PAUSED', previousState: 'running', state: 'paused' },
+      { from: 'PAUSED', to: 'RUNNING', previousState: 'paused', state: 'running' },
+      {
+        from: 'RUNNING',
+        to: 'GAME_OVER',
+        previousState: 'running',
+        state: 'game-over',
+      },
+      { from: 'GAME_OVER', to: 'READY', previousState: 'game-over', state: 'ready' },
     ]);
   });
 
@@ -85,9 +95,9 @@ describe('game state machine', () => {
     expect(machine.getState()).toBe('BOOT');
 
     expect(events).toEqual([
-      { from: 'BOOT', to: 'READY' },
-      { from: 'READY', to: 'RUNNING' },
-      { from: 'RUNNING', to: 'BOOT' },
+      { from: 'BOOT', to: 'READY', previousState: 'boot', state: 'ready' },
+      { from: 'READY', to: 'RUNNING', previousState: 'ready', state: 'running' },
+      { from: 'RUNNING', to: 'BOOT', previousState: 'running', state: 'boot' },
     ]);
   });
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,9 +1,9 @@
 export { bus } from './event-bus';
 export type { GameEventName } from './event-bus';
 export { createGameLoop, FIXED_TIME_STEP } from './loop';
-export type { FrameScheduler, GameLoopController, GameLoopOptions } from './loop';
+export type { FrameScheduler, GameLoopController, GameLoopOptions, GameTickDetail } from './loop';
 export {
   createGameStateMachine,
   GAME_STATES,
 } from './state';
-export type { GameStateMachine, GameStateValue } from './state';
+export type { GameStateMachine, GameStateValue, GameStateChangeDetail } from './state';

--- a/src/features/F08_bird_rigidbody/events.d.ts
+++ b/src/features/F08_bird_rigidbody/events.d.ts
@@ -1,13 +1,7 @@
-import type {
-  BirdRigidbodyUpdateDetail,
-  GameStateChangeDetail,
-  GameTickEventDetail,
-} from "./types";
+import type { BirdRigidbodyUpdateDetail } from "./types";
 
 declare global {
   interface GameEvents {
-    "game:tick": GameTickEventDetail;
-    "game:state-change": GameStateChangeDetail;
     "world:reset": undefined;
   }
 }


### PR DESCRIPTION
## Summary
- emit `game:tick` events with the legacy-normalized delta, elapsed milliseconds, and frame counter while exporting the new `GameTickDetail` type
- mirror legacy lowercase state strings in `game:state-change` payloads and surface the combined detail through the core exports
- update Vitest coverage to stub the event-bus feature flag and align feature tests with the enriched payloads

## Testing
- npm run test -- src/core/__tests__/loop.spec.ts src/core/__tests__/state.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e078b9208c832882f123817862c8e9