### PR TITLE
Fix lint violations in legacy modules

### DIFF
--- a/src/core/rng.ts
+++ b/src/core/rng.ts
@@ -107,7 +107,7 @@ const readSeedFromStorage = (storage: StorageLike | null, storageKey: string): s
       return null;
     }
     return stored;
-  } catch (error) {
+  } catch (_error) {
     return null;
   }
 };
@@ -119,7 +119,7 @@ const persistSeed = (storage: StorageLike | null, storageKey: string, seed: stri
 
   try {
     storage.setItem(storageKey, seed);
-  } catch (error) {
+  } catch (_error) {
     // Ignore persistence errors.
   }
 };

--- a/src/features/F05_settings_context/register.ts
+++ b/src/features/F05_settings_context/register.ts
@@ -154,7 +154,7 @@ const readSettingsFromStorage = (storage: StorageLike | null): PlainObject => {
   try {
     const parsed = JSON.parse(raw);
     return toPlainObject(parsed);
-  } catch (error) {
+  } catch (_error) {
     return {};
   }
 };
@@ -171,7 +171,7 @@ const persistSettings = (storage: StorageLike | null, settings: PlainObject): vo
     }
 
     storage.setItem(F05_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
-  } catch (error) {
+  } catch (_error) {
     // Ignore storage write failures (e.g., quota exceeded or disabled storage).
   }
 };
@@ -276,8 +276,8 @@ export const registerF05SettingsContext = (
     random: () => prng.next(),
     update: (patch: Record<string, unknown>) => {
       const normalizedPatch = normalizePatch(patch);
-      let nextLocal = { ...localSettings };
-      let nextSettings = { ...context.settings };
+      const nextLocal = { ...localSettings };
+      const nextSettings = { ...context.settings };
 
       const keys = Object.keys(normalizedPatch);
       if (keys.length === 0) {

--- a/src/game/systems/loop.js
+++ b/src/game/systems/loop.js
@@ -308,7 +308,6 @@ export function handleCanvasClick() {
   ensureState();
 
   if (state.awaitingStart || state.gameOver) {
-    const wasStartingRound = state.awaitingStart || state.gameOver;
     startGame();
     if (state.isRunning && state.bird) {
       state.bird.jump();

--- a/src/game/systems/loop.test.ts
+++ b/src/game/systems/loop.test.ts
@@ -41,8 +41,9 @@ describe("handleCanvasClick", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    globalThis.requestAnimationFrame = vi.fn(() => 1) as any;
-    globalThis.cancelAnimationFrame = vi.fn() as any;
+    globalThis.requestAnimationFrame = vi
+      .fn<(callback: FrameRequestCallback) => number>(() => 1);
+    globalThis.cancelAnimationFrame = vi.fn<(handle: number) => void>();
     document.body.innerHTML = "";
   });
 
@@ -56,7 +57,7 @@ describe("handleCanvasClick", () => {
   it("starts the round with an immediate flap on the first interaction", () => {
     const canvas = document.createElement("canvas");
     document.body.appendChild(canvas);
-    const gameState = createGameState(canvas) as any;
+    const gameState = createGameState(canvas);
 
     initializeGameLoop(gameState);
 

--- a/src/lib/animation/abstracts/fading.ts
+++ b/src/lib/animation/abstracts/fading.ts
@@ -7,7 +7,7 @@ export interface IFadingOptions {
   transition: IEasingKey;
 }
 
-export interface IConstructorFadingOptions extends Partial<IFadingOptions> {}
+export type IConstructorFadingOptions = Partial<IFadingOptions>;
 
 export interface IFadingStatus {
   running: boolean;

--- a/src/lib/animation/anims/bounce-in.ts
+++ b/src/lib/animation/anims/bounce-in.ts
@@ -14,7 +14,7 @@ export interface IBounceIn {
   };
 }
 
-export interface IBounceInConstructor extends Partial<IBounceIn> {}
+export type IBounceInConstructor = Partial<IBounceIn>;
 
 export interface IBounceInStatus {
   running: boolean;

--- a/src/lib/animation/anims/timing-event.ts
+++ b/src/lib/animation/anims/timing-event.ts
@@ -9,7 +9,7 @@ export interface ITimingEventOptions {
   diff: number; // Interval per number
 }
 
-export interface ITimingEventOptionsConstructor extends Partial<ITimingEventOptions> {}
+export type ITimingEventOptionsConstructor = Partial<ITimingEventOptions>;
 
 export interface ITimingEventStatus {
   running: boolean;

--- a/src/lib/asset-loader/interfaces.ts
+++ b/src/lib/asset-loader/interfaces.ts
@@ -2,7 +2,7 @@ import { AbstractLoader } from './abstraction';
 
 export interface IPromiseResolve {
   source: string;
-  object: any;
+  object: unknown;
 }
 
 export type ILoaders = new (source: string) => AbstractLoader;

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -20,7 +20,7 @@ export default class Storage {
       if ('localStorage' in window && typeof window.localStorage === 'object') {
         Storage.isAvailable = true;
       }
-    } catch (err) {
+    } catch (_error) {
       Storage.isAvailable = false;
     }
   }
@@ -79,7 +79,7 @@ export default class Storage {
 
       return return_value;
     } catch (err) {
-      console.error('Failed to fetch highscore');
+      console.error('Failed to fetch highscore', err);
       return void 0;
     }
   }

--- a/src/lib/web-sfx/index.ts
+++ b/src/lib/web-sfx/index.ts
@@ -67,8 +67,8 @@ export default class WebSfx {
       bufferSource.addEventListener('ended', () => endedcb?.());
       bufferSource.connect(WebSfx.gainContext!);
       bufferSource.start();
-    } catch (err) {
-      throw new Error(`Failed to play audio: ${key}. Error: ${err}`);
+    } catch (error) {
+      throw new Error(`Failed to play audio: ${key}. Error: ${String(error)}`);
     }
   }
 
@@ -88,7 +88,9 @@ export default class WebSfx {
 
     try {
       WebSfx.gainContext!.gain.value = num;
-    } catch (err) {}
+    } catch (error) {
+      console.error('Failed to adjust audio volume', error);
+    }
   }
 
   /**
@@ -157,23 +159,19 @@ export default class WebSfx {
     });
   }
 
-  private static load_requests(name: string, path: string): Promise<ILoadRequest> {
-    return new Promise<ILoadRequest>(async (resolve: Function, reject: Function) => {
-      try {
-        const response = await fetch(path, { method: 'GET', mode: 'no-cors' });
+  private static async load_requests(name: string, path: string): Promise<ILoadRequest> {
+    const response = await fetch(path, { method: 'GET', mode: 'no-cors' });
 
-        if (!response.ok) throw new TypeError(`Erro while fetching '${path}`);
+    if (!response.ok) {
+      throw new TypeError(`Erro while fetching '${path}`);
+    }
 
-        // We cannot cannot cache array buffer with dettached head
-        const buffer = await response.arrayBuffer();
+    // We cannot cannot cache array buffer with dettached head
+    const buffer = await response.arrayBuffer();
 
-        // But luckily, we can do cache the AudioBuffer
-        const content = await WebSfx.audioContext!.decodeAudioData(buffer);
+    // But luckily, we can do cache the AudioBuffer
+    const content = await WebSfx.audioContext!.decodeAudioData(buffer);
 
-        resolve({ content, path, name });
-      } catch (err) {
-        reject();
-      }
-    });
+    return { content, path, name };
   }
 }

--- a/src/model/bird.ts
+++ b/src/model/bird.ts
@@ -255,7 +255,9 @@ export default class Bird extends ParentClass {
 
         // Only the first pipe should be check
         break;
-      } catch (err) {}
+      } catch (error) {
+        console.error('Pipe collision detection failed', error);
+      }
     }
 
     return (this.flags & Bird.FLAG_IS_ALIVE) === 0;

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -174,7 +174,7 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     // })
   }
 
-  public click({ x, y }: ICoordinate): void {
+  public click(_: ICoordinate): void {
     if (this.gameState === 'died') return;
 
     this.state = 'playing';


### PR DESCRIPTION
## Summary
- update legacy test mocks and utilities to avoid `any` usage and satisfy ESLint type rules
- clean up feature flag handling and game loop helpers to eliminate unused variables
- harden legacy storage and audio helpers by surfacing caught errors instead of suppressing them

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0b1654a8c8328af51b89f0adb47e9