### PR TITLE
Fix build by migrating entry script to TypeScript

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { ClassicGame } from './classic/Game.ts';
 
-function resizeCanvas(canvas) {
+type PrimaryInputEvent = PointerEvent | TouchEvent | KeyboardEvent;
+
+function resizeCanvas(canvas: HTMLCanvasElement): void {
   const container = canvas.parentElement;
   if (!container) return;
   const aspect = 512 / 288;
@@ -11,12 +13,10 @@ function resizeCanvas(canvas) {
   canvas.style.height = `${height}px`;
 }
 
-function setupInput(canvas, game) {
-  const handleAction = (event) => {
+function setupInput(canvas: HTMLCanvasElement, game: ClassicGame): void {
+  const handleAction = (event: PrimaryInputEvent): void => {
     event.preventDefault();
-    if (typeof canvas.focus === 'function') {
-      canvas.focus();
-    }
+    canvas.focus();
     game.handlePrimaryAction();
   };
 
@@ -24,7 +24,7 @@ function setupInput(canvas, game) {
   canvas.addEventListener('touchstart', handleAction, { passive: false });
   canvas.addEventListener(
     'keydown',
-    (event) => {
+    (event: KeyboardEvent) => {
       if (event.repeat) return;
       if (['Space', 'ArrowUp', 'KeyW'].includes(event.code)) {
         handleAction(event);
@@ -38,7 +38,7 @@ function setupInput(canvas, game) {
 
   window.addEventListener(
     'keydown',
-    (event) => {
+    (event: KeyboardEvent) => {
       if (event.repeat) return;
       if (['Space', 'ArrowUp', 'KeyW'].includes(event.code)) {
         handleAction(event);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,6 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    },
     "allowJs": true,
     "checkJs": false,
     "strict": true,


### PR DESCRIPTION
## Summary
- rename the Vite entry file to `main.ts` and add explicit DOM/input typings so the module can be resolved during build
- clean up duplicate `baseUrl`/`paths` entries in `tsconfig.json` to remove esbuild warnings

## Testing
- npm run build
- npm run test *(fails: several pre-existing unit expectations for the game loop and bird rigidbody still fail)*
- npm run typecheck *(fails: project currently lacks shared `ICoordinate`/`IDimension` declarations and disallows `.ts` import extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b1f4866c832883907cfc066889a5