### PR TITLE
Fix legacy game types and stabilize tooling

### DIFF
--- a/src/classic/Game.ts
+++ b/src/classic/Game.ts
@@ -1,11 +1,11 @@
-import { CANVAS_HEIGHT, CANVAS_WIDTH, GAME_SPEED, SCORE_NUMBER_HEIGHT } from './constants.ts';
-import { playSound, preloadAudio } from './assets.ts';
-import type { Dimension } from './types.ts';
-import { Background } from './entities/Background.ts';
-import { Bird } from './entities/Bird.ts';
-import { PipeField } from './entities/PipeField.ts';
-import { Platform } from './entities/Platform.ts';
-import { loadSpriteSheet, type SpriteName, type SpriteSheet } from './spriteSheet.ts';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, GAME_SPEED, SCORE_NUMBER_HEIGHT } from './constants';
+import { playSound, preloadAudio } from './assets';
+import type { Dimension } from './types';
+import { Background } from './entities/Background';
+import { Bird } from './entities/Bird';
+import { PipeField } from './entities/PipeField';
+import { Platform } from './entities/Platform';
+import { loadSpriteSheet, type SpriteName, type SpriteSheet } from './spriteSheet';
 
 export type GameState = 'intro' | 'running' | 'gameover';
 

--- a/src/classic/entities/Background.ts
+++ b/src/classic/entities/Background.ts
@@ -1,6 +1,6 @@
-import { BG_SPEED } from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteSheet } from '../spriteSheet.ts';
+import { BG_SPEED } from '../constants';
+import type { Dimension } from '../types';
+import type { SpriteSheet } from '../spriteSheet';
 
 type Theme = 'day' | 'night';
 

--- a/src/classic/entities/Bird.ts
+++ b/src/classic/entities/Bird.ts
@@ -7,10 +7,10 @@ import {
   BIRD_WEIGHT,
   BIRD_WIDTH,
   BIRD_X_POSITION,
-} from '../constants.ts';
-import { playSound } from '../assets.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteName, SpriteSheet } from '../spriteSheet.ts';
+} from '../constants';
+import { playSound } from '../assets';
+import type { Dimension } from '../types';
+import type { SpriteName, SpriteSheet } from '../spriteSheet';
 
 const BODY_COLOR = '#f7d75b';
 const WING_COLOR = '#fceba2';

--- a/src/classic/entities/PipeField.ts
+++ b/src/classic/entities/PipeField.ts
@@ -1,7 +1,7 @@
-import { GAME_SPEED, PIPE_DISTANCE } from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import { PipePair, type PipeColor, randomGapCenter } from './PipePair.ts';
-import type { SpriteSheet } from '../spriteSheet.ts';
+import { GAME_SPEED, PIPE_DISTANCE } from '../constants';
+import type { Dimension } from '../types';
+import { PipePair, type PipeColor, randomGapCenter } from './PipePair';
+import type { SpriteSheet } from '../spriteSheet';
 
 export class PipeField {
   private pipes: PipePair[] = [];

--- a/src/classic/entities/PipePair.ts
+++ b/src/classic/entities/PipePair.ts
@@ -3,9 +3,9 @@ import {
   PIPE_HEIGHT,
   PIPE_MIN_GAP,
   PIPE_WIDTH,
-} from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteName, SpriteSheet } from '../spriteSheet.ts';
+} from '../constants';
+import type { Dimension } from '../types';
+import type { SpriteName, SpriteSheet } from '../spriteSheet';
 
 const PIPE_MAIN = '#7dd36f';
 const PIPE_DARK = '#3a7c47';

--- a/src/classic/entities/Platform.ts
+++ b/src/classic/entities/Platform.ts
@@ -1,6 +1,6 @@
-import { CANVAS_HEIGHT, PLATFORM_HEIGHT } from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteSheet } from '../spriteSheet.ts';
+import { CANVAS_HEIGHT, PLATFORM_HEIGHT } from '../constants';
+import type { Dimension } from '../types';
+import type { SpriteSheet } from '../spriteSheet';
 
 const TOP_COLOR = '#ded48a';
 const FRONT_COLOR = '#c4a34a';

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -47,7 +47,26 @@ const normalizeBoolean = (value: unknown): boolean | null => {
 const isEventBusEnabled = (): boolean => {
   const meta = import.meta as unknown as { env?: Record<string, unknown> };
   const raw = meta.env?.[FEATURE_FLAG_KEY];
-  return normalizeBoolean(raw) ?? false;
+  const fromMeta = normalizeBoolean(raw);
+  if (fromMeta !== null) {
+    return fromMeta;
+  }
+
+  if (typeof process !== 'undefined' && process.env) {
+    const fromProcess = normalizeBoolean(process.env[FEATURE_FLAG_KEY]);
+    if (fromProcess !== null) {
+      return fromProcess;
+    }
+  }
+
+  const globalFlags =
+    (globalThis as unknown as { __FEATURE_FLAGS__?: Record<string, unknown> }).__FEATURE_FLAGS__ ?? {};
+  const fromGlobal = normalizeBoolean(globalFlags[FEATURE_FLAG_KEY]);
+  if (fromGlobal !== null) {
+    return fromGlobal;
+  }
+
+  return false;
 };
 
 const listenerRegistry = new Map<string, WeakMap<AnyGameEventListener, EventListener>>();

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -192,7 +192,16 @@ export const createGameLoop = ({
 
 declare global {
   interface GameEvents {
-    'game:tick': { dt: number; elapsed: number };
+    'game:tick': {
+      dt: number;
+      elapsed: number;
+      /** Optional normalized delta provided by legacy publishers. */
+      delta?: number;
+      /** Optional frame counter provided by callers. */
+      frame?: number;
+      /** Optional elapsed milliseconds for the current frame. */
+      elapsedMs?: number;
+    };
   }
 }
 

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -74,7 +74,14 @@ export const createGameStateMachine = (
 
 declare global {
   interface GameEvents {
-    'game:state-change': { from: GameStateValue; to: GameStateValue };
+    'game:state-change': {
+      from: GameStateValue;
+      to: GameStateValue;
+      /** Optional normalized state string provided by legacy consumers. */
+      state?: string | null;
+      /** Optional previous state string provided by legacy consumers. */
+      previousState?: string | null;
+    };
   }
 }
 

--- a/src/features/F08_bird_rigidbody/events.d.ts
+++ b/src/features/F08_bird_rigidbody/events.d.ts
@@ -1,13 +1,7 @@
-import type {
-  BirdRigidbodyUpdateDetail,
-  GameStateChangeDetail,
-  GameTickEventDetail,
-} from "./types";
+import type { BirdRigidbodyUpdateDetail } from "./types";
 
 declare global {
   interface GameEvents {
-    "game:tick": GameTickEventDetail;
-    "game:state-change": GameStateChangeDetail;
     "world:reset": undefined;
   }
 }

--- a/src/features/F08_bird_rigidbody/types.ts
+++ b/src/features/F08_bird_rigidbody/types.ts
@@ -18,11 +18,17 @@ export interface GameTickEventDetail {
    * Alias for delta provided by older publishers.
    */
   dt?: number;
+  /**
+   * Total elapsed time reported by the loop in seconds.
+   */
+  elapsed?: number;
 }
 
 export interface GameStateChangeDetail {
   state?: string | null;
   previousState?: string | null;
+  to?: string | null;
+  from?: string | null;
 }
 
 export interface BirdRigidbodyUpdateDetail {

--- a/src/features/F12_bird_tilt/__tests__/register.test.ts
+++ b/src/features/F12_bird_tilt/__tests__/register.test.ts
@@ -1,10 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { featureBus, resetFeatureBus } from "../../bus";
+import type { BirdRigidbodyUpdateDetail } from "../../F08_bird_rigidbody";
 import register, {
   type FeatureF12TiltEventDetail,
   type TiltRendererAdapter,
 } from "../register";
+
+const createBirdUpdate = (
+  overrides: Partial<BirdRigidbodyUpdateDetail>,
+): BirdRigidbodyUpdateDetail => ({
+  position: 0,
+  velocity: 0,
+  acceleration: 0,
+  delta: 0,
+  elapsedMs: 0,
+  frame: 0,
+  previousVelocity: 0,
+  previousPosition: 0,
+  terminalVelocity: 0,
+  ...overrides,
+});
 
 describe("F12 bird tilt feature", () => {
   afterEach(() => {
@@ -19,7 +35,10 @@ describe("F12 bird tilt feature", () => {
     const dispose = register({ enabled: false, bus: featureBus });
     expect(typeof dispose).toBe("function");
 
-    featureBus.emit("feature:F08/bird:update", { velocity: 5, deltaMs: 16 });
+    featureBus.emit(
+      "feature:F08/bird:update",
+      createBirdUpdate({ velocity: 5, elapsedMs: 16 }),
+    );
     expect(handler).not.toHaveBeenCalled();
   });
 
@@ -39,7 +58,10 @@ describe("F12 bird tilt feature", () => {
       adapters: [adapter],
     });
 
-    featureBus.emit("feature:F08/bird:update", { velocity: 6, deltaMs: 16 });
+    featureBus.emit(
+      "feature:F08/bird:update",
+      createBirdUpdate({ velocity: 6, elapsedMs: 16 }),
+    );
 
     expect(events).toHaveLength(2); // initial reset + update
     const [, update] = events;
@@ -68,7 +90,10 @@ describe("F12 bird tilt feature", () => {
       ],
     });
 
-    featureBus.emit("feature:F08/bird:update", { velocity: 50, deltaMs: 16 });
+    featureBus.emit(
+      "feature:F08/bird:update",
+      createBirdUpdate({ velocity: 50, elapsedMs: 16 }),
+    );
 
     const [, update] = events;
     expect(update.targetAngle).toBe(0.5);
@@ -92,7 +117,10 @@ describe("F12 bird tilt feature", () => {
       ],
     });
 
-    featureBus.emit("feature:F08/bird:update", { velocity: 6, deltaMs: 16 });
+    featureBus.emit(
+      "feature:F08/bird:update",
+      createBirdUpdate({ velocity: 6, elapsedMs: 16 }),
+    );
     worldTarget.dispatchEvent(new Event("world:reset"));
 
     expect(events).toHaveLength(3);
@@ -109,7 +137,10 @@ describe("F12 bird tilt feature", () => {
     const dispose = register({ enabled: true, bus: featureBus });
     dispose();
 
-    featureBus.emit("feature:F08/bird:update", { velocity: -4, deltaMs: 16 });
+    featureBus.emit(
+      "feature:F08/bird:update",
+      createBirdUpdate({ velocity: -4, elapsedMs: 16 }),
+    );
     expect(handler).toHaveBeenCalledTimes(1); // initial reset emission only
   });
 });

--- a/src/features/F12_bird_tilt/events.d.ts
+++ b/src/features/F12_bird_tilt/events.d.ts
@@ -1,11 +1,7 @@
-import type {
-  FeatureF08BirdUpdateEvent,
-  FeatureF12TiltEventDetail,
-} from "./register";
+import type { FeatureF12TiltEventDetail } from "./register";
 
 declare module "../bus" {
   interface FeatureEventMap {
-    "feature:F08/bird:update": FeatureF08BirdUpdateEvent;
     "feature:F12/tilt": FeatureF12TiltEventDetail;
   }
 }

--- a/src/features/F12_bird_tilt/register.ts
+++ b/src/features/F12_bird_tilt/register.ts
@@ -32,6 +32,7 @@ export interface FeatureF08BirdUpdateEvent {
    * Duration in milliseconds since the previous update. Used to scale smoothing factors.
    */
   deltaMs?: number;
+  elapsedMs?: number;
   /**
    * Optional hint describing the lifecycle state of the bird or world. Certain states reset
    * the tilt controller (e.g., respawning or world reset).
@@ -178,7 +179,7 @@ const extractVelocity = (event: FeatureF08BirdUpdateEvent): number => {
 };
 
 const extractDelta = (event: FeatureF08BirdUpdateEvent, fallback: number): number => {
-  const deltaCandidates: unknown[] = [event.deltaMs];
+  const deltaCandidates: unknown[] = [event.deltaMs, event.elapsedMs];
   for (const candidate of deltaCandidates) {
     if (isFiniteNumber(candidate) && candidate >= 0) {
       return candidate;

--- a/src/game/systems/prng.ts
+++ b/src/game/systems/prng.ts
@@ -1,4 +1,4 @@
-import { createRng, isRngFeatureEnabled, stringToUint32 } from "../../core/rng.ts";
+import { createRng, isRngFeatureEnabled, stringToUint32 } from "../../core/rng";
 
 const LEGACY_STORAGE_KEY = "flappy-bird/prng-seed" as const;
 const MODERN_STORAGE_KEY = "flappy.seed" as const;
@@ -9,6 +9,7 @@ const DEFAULT_STORAGE_KEY = isRngFeatureEnabled()
 export interface StorageAdapter {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
+  removeItem(key: string): void;
 }
 
 function resolveStorage(storage?: StorageAdapter | null): StorageAdapter | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { CANVAS_DIMENSION } from './constants';
 import EventHandler from './events';
 import GameObject from './game';
 import prepareAssets from './asset-preparation';
-import createRAF, { targetFPS } from '@solid-primitives/raf';
+import { createRAF, targetFPS } from './utils/raf';
 import SwOffline from './lib/workbox-work-offline';
 
 if (process.env.NODE_ENV === 'production') {

--- a/src/lib/asset-loader/abstraction.ts
+++ b/src/lib/asset-loader/abstraction.ts
@@ -9,13 +9,13 @@ class ParentLoader {
     this.ready = 0;
   }
 
-  protected eventTracking<T>(resolve: IEmptyFunction, object: T): void {
+  protected eventTracking<T>(resolve: (value: IPromiseResolve) => void, object: T): void {
     this.ready--;
 
     if (this.ready < 1) {
       resolve({
         source: this.source,
-        object: object
+        object,
       });
     }
   }

--- a/src/lib/asset-loader/loaders/audio.ts
+++ b/src/lib/asset-loader/loaders/audio.ts
@@ -12,7 +12,7 @@ export default class AudioLoader extends AbstractLoader {
     // Load Event Count
     this.ready = 2;
 
-    return new Promise<IPromiseResolve>((resolve: IEmptyFunction, reject) => {
+    return new Promise<IPromiseResolve>((resolve, reject) => {
       const audio = new Audio();
 
       /**
@@ -36,7 +36,7 @@ export default class AudioLoader extends AbstractLoader {
         this.eventTracking<HTMLAudioElement>(resolve, audio);
       });
 
-      audio.addEventListener('error', reject);
+      audio.addEventListener('error', (event) => reject(event));
 
       audio.src = this.source;
     });

--- a/src/lib/asset-loader/loaders/image.ts
+++ b/src/lib/asset-loader/loaders/image.ts
@@ -12,7 +12,7 @@ export default class ImageLoader extends AbstractLoader {
     // Load Event Count
     this.ready = 1;
 
-    return new Promise<IPromiseResolve>((resolve: IEmptyFunction, reject) => {
+    return new Promise<IPromiseResolve>((resolve, reject) => {
       const img = new Image();
 
       /**
@@ -22,7 +22,7 @@ export default class ImageLoader extends AbstractLoader {
         this.eventTracking<HTMLImageElement>(resolve, img);
       });
 
-      img.addEventListener('error', reject);
+      img.addEventListener('error', (event) => reject(event));
 
       img.src = this.source;
     });

--- a/src/lib/sprite-destructor/index.ts
+++ b/src/lib/sprite-destructor/index.ts
@@ -87,14 +87,12 @@ export default class SpriteDestructor {
      * Load the cutout image then push it into promse handler
      * */
     this.loading.push(
-      new Promise<IPromiseImageHandled>(
-        (resolve: IEmptyFunction, reject: IEmptyFunction) => {
-          const img = new Image();
-          img.src = this.Canvas.toDataURL();
-          img.addEventListener('load', () => resolve({ name, img }));
-          img.addEventListener('error', (err) => reject(err));
-        }
-      )
+      new Promise<IPromiseImageHandled>((resolve, reject) => {
+        const img = new Image();
+        img.src = this.Canvas.toDataURL();
+        img.addEventListener('load', () => resolve({ name, img }));
+        img.addEventListener('error', (err) => reject(err));
+      })
     );
 
     // this.cutout_call_count++;

--- a/src/lib/web-sfx/index.ts
+++ b/src/lib/web-sfx/index.ts
@@ -33,7 +33,7 @@ export default class WebSfx {
    * to load.
    * @param {Function} callback - A function that will be called when all the files have been loaded.
    */
-  constructor(files: IWebSfxObject, callback: IEmptyFunction) {
+  constructor(files: IWebSfxObject, callback: (cache: IWebSfxCache) => void = () => {}) {
     WebSfx.audioContext = new (AudioContext || webkitAudioContext)();
 
     WebSfx.audioContext.addEventListener('statechange', () => {
@@ -118,7 +118,11 @@ export default class WebSfx {
   /**
    * Loading Assets Section
    * */
-  private static load(files: IWebSfxObject, complete: IEmptyFunction, level = 0): void {
+  private static load(
+    files: IWebSfxObject,
+    complete: (cache: IWebSfxCache) => void,
+    level = 0,
+  ): void {
     const loading = [];
     const entries = Object.entries(files);
 
@@ -158,7 +162,7 @@ export default class WebSfx {
   }
 
   private static load_requests(name: string, path: string): Promise<ILoadRequest> {
-    return new Promise<ILoadRequest>(async (resolve: Function, reject: Function) => {
+    return new Promise<ILoadRequest>(async (resolve, reject) => {
       try {
         const response = await fetch(path, { method: 'GET', mode: 'no-cors' });
 
@@ -172,7 +176,7 @@ export default class WebSfx {
 
         resolve({ content, path, name });
       } catch (err) {
-        reject();
+        reject(err);
       }
     });
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { ClassicGame } from './classic/Game.ts';
+import { ClassicGame } from './classic/Game';
 
 function resizeCanvas(canvas) {
   const container = canvas.parentElement;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,4 +2,9 @@
  * Shared test setup for Vitest. Extend this file with any global mocks or
  * configuration needed across the test suite.
  */
+
+if (typeof process !== 'undefined' && process.env) {
+  process.env.VITE_FF_F02 ??= 'true';
+}
+
 export {};

--- a/src/types/legacy-game.d.ts
+++ b/src/types/legacy-game.d.ts
@@ -1,0 +1,16 @@
+interface ICoordinate {
+  x: number;
+  y: number;
+}
+
+interface IDimension {
+  width: number;
+  height: number;
+}
+
+interface IVelocity {
+  x: number;
+  y: number;
+}
+
+type IEmptyFunction = () => void;

--- a/src/types/three-examples.d.ts
+++ b/src/types/three-examples.d.ts
@@ -3,6 +3,7 @@ declare module 'three/examples/jsm/loaders/GLTFLoader.js' {
 
   export interface GLTF {
     scene: Group;
+    scenes?: Group[];
     animations: AnimationClip[];
   }
 
@@ -10,6 +11,9 @@ declare module 'three/examples/jsm/loaders/GLTFLoader.js' {
     constructor(manager?: unknown);
     loadAsync(url: string, onProgress?: (event: ProgressEvent<EventTarget>) => void): Promise<GLTF>;
     setDRACOLoader(loader: unknown): this;
+    setResourcePath(path: string): this;
+    setPath(path: string): this;
+    setCrossOrigin(value: string): this;
   }
 }
 

--- a/src/utils/raf.ts
+++ b/src/utils/raf.ts
@@ -1,0 +1,98 @@
+const hasWindow = typeof window !== 'undefined';
+
+type FrameHandle = number;
+
+let requestFrame: (callback: FrameRequestCallback) => FrameHandle;
+let cancelFrame: (handle: FrameHandle) => void;
+
+if (hasWindow && typeof window.requestAnimationFrame === 'function') {
+  requestFrame = window.requestAnimationFrame.bind(window);
+  cancelFrame = window.cancelAnimationFrame.bind(window);
+} else {
+  let nextHandle = 1;
+  const timeoutHandles = new Map<FrameHandle, ReturnType<typeof setTimeout>>();
+  const now = () =>
+    typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+
+  requestFrame = (callback: FrameRequestCallback): FrameHandle => {
+    const handle = nextHandle as FrameHandle;
+    nextHandle += 1;
+    const timeout = setTimeout(() => {
+      timeoutHandles.delete(handle);
+      callback(now());
+    }, 1000 / 60);
+    timeoutHandles.set(handle, timeout);
+    return handle;
+  };
+
+  cancelFrame = (handle: FrameHandle): void => {
+    const timeout = timeoutHandles.get(handle);
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+      timeoutHandles.delete(handle);
+    }
+  };
+}
+
+export type RafController = [isRunning: () => boolean, start: () => void, stop: () => void];
+
+export const createRAF = (callback: FrameRequestCallback): RafController => {
+  let running = false;
+  let handle: FrameHandle | null = null;
+
+  const tick: FrameRequestCallback = (time) => {
+    if (!running) {
+      return;
+    }
+    callback(time);
+    handle = requestFrame(tick);
+  };
+
+  const start = () => {
+    if (running) {
+      return;
+    }
+    running = true;
+    handle = requestFrame(tick);
+  };
+
+  const stop = () => {
+    if (!running) {
+      return;
+    }
+    running = false;
+    if (handle !== null) {
+      cancelFrame(handle);
+      handle = null;
+    }
+  };
+
+  return [() => running, start, stop];
+};
+
+export const targetFPS = (callback: () => void, fps: number): FrameRequestCallback => {
+  const frameDuration = fps > 0 ? 1000 / fps : 0;
+  let accumulator = 0;
+  let lastTimestamp = 0;
+
+  return (time) => {
+    if (!Number.isFinite(frameDuration) || frameDuration <= 0) {
+      callback();
+      return;
+    }
+
+    if (lastTimestamp === 0) {
+      lastTimestamp = time;
+    }
+
+    accumulator += time - lastTimestamp;
+    lastTimestamp = time;
+
+    if (accumulator >= frameDuration) {
+      accumulator %= frameDuration;
+      callback();
+    }
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,7 @@
     "checkJs": false,
     "strict": true,
     "noEmit": true,
-    "types": ["vitest", "vite/client", "node", "three"],
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"],
-      "src/*": ["src/*"]
-    }
+    "types": ["vitest", "vite/client", "node", "three"]
   },
   "include": ["src/**/*", "playgrounds/**/*"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- add shared type declarations for legacy game data structures and clean up import paths that used .ts extensions
- replace the missing RAF helper with a local implementation and harden asset loaders and audio helpers to satisfy strict typing
- extend feature flag detection for the event bus, enable it during tests, and adjust configuration to remove duplicate compiler options

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0b20685708328bd928ddb71d09fe9