### PR TITLE
Fix TypeScript config to restore production build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@solid-primitives/raf": "^2.3.0",
-        "gh-pages": "^6.3.0"
+        "gh-pages": "^6.3.0",
+        "three": "^0.169.0"
       },
       "devDependencies": {
         "@total-typescript/ts-reset": "^0.3.7",
         "@types/raf": "^3.4.3",
+        "@types/three": "^0.169.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "browser-sync": "^2.29.3",
@@ -2843,6 +2845,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -2934,10 +2943,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3304,6 +3342,13 @@
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@webpack-cli/configtest": {
       "version": "2.1.1",
@@ -5533,6 +5578,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7653,6 +7705,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10299,6 +10358,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
       "license": "MIT"
     },
     "node_modules/timm": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@total-typescript/ts-reset": "^0.3.7",
     "@types/raf": "^3.4.3",
+    "@types/three": "^0.169.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "browser-sync": "^2.29.3",
@@ -61,6 +62,7 @@
   },
   "dependencies": {
     "@solid-primitives/raf": "^2.3.0",
-    "gh-pages": "^6.3.0"
+    "gh-pages": "^6.3.0",
+    "three": "^0.169.0"
   }
 }

--- a/src/classic/Game.ts
+++ b/src/classic/Game.ts
@@ -1,11 +1,11 @@
-import { CANVAS_HEIGHT, CANVAS_WIDTH, GAME_SPEED, SCORE_NUMBER_HEIGHT } from './constants.ts';
-import { playSound, preloadAudio } from './assets.ts';
-import type { Dimension } from './types.ts';
-import { Background } from './entities/Background.ts';
-import { Bird } from './entities/Bird.ts';
-import { PipeField } from './entities/PipeField.ts';
-import { Platform } from './entities/Platform.ts';
-import { loadSpriteSheet, type SpriteName, type SpriteSheet } from './spriteSheet.ts';
+import { CANVAS_HEIGHT, CANVAS_WIDTH, GAME_SPEED, SCORE_NUMBER_HEIGHT } from './constants';
+import { playSound, preloadAudio } from './assets';
+import type { Dimension } from './types';
+import { Background } from './entities/Background';
+import { Bird } from './entities/Bird';
+import { PipeField } from './entities/PipeField';
+import { Platform } from './entities/Platform';
+import { loadSpriteSheet, type SpriteName, type SpriteSheet } from './spriteSheet';
 
 export type GameState = 'intro' | 'running' | 'gameover';
 

--- a/src/classic/entities/Background.ts
+++ b/src/classic/entities/Background.ts
@@ -1,6 +1,6 @@
-import { BG_SPEED } from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteSheet } from '../spriteSheet.ts';
+import { BG_SPEED } from '../constants';
+import type { Dimension } from '../types';
+import type { SpriteSheet } from '../spriteSheet';
 
 type Theme = 'day' | 'night';
 

--- a/src/classic/entities/Bird.ts
+++ b/src/classic/entities/Bird.ts
@@ -7,10 +7,10 @@ import {
   BIRD_WEIGHT,
   BIRD_WIDTH,
   BIRD_X_POSITION,
-} from '../constants.ts';
-import { playSound } from '../assets.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteName, SpriteSheet } from '../spriteSheet.ts';
+} from '../constants';
+import { playSound } from '../assets';
+import type { Dimension } from '../types';
+import type { SpriteName, SpriteSheet } from '../spriteSheet';
 
 const BODY_COLOR = '#f7d75b';
 const WING_COLOR = '#fceba2';

--- a/src/classic/entities/PipeField.ts
+++ b/src/classic/entities/PipeField.ts
@@ -1,7 +1,7 @@
-import { GAME_SPEED, PIPE_DISTANCE } from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import { PipePair, type PipeColor, randomGapCenter } from './PipePair.ts';
-import type { SpriteSheet } from '../spriteSheet.ts';
+import { GAME_SPEED, PIPE_DISTANCE } from '../constants';
+import type { Dimension } from '../types';
+import { PipePair, type PipeColor, randomGapCenter } from './PipePair';
+import type { SpriteSheet } from '../spriteSheet';
 
 export class PipeField {
   private pipes: PipePair[] = [];
@@ -59,7 +59,6 @@ export class PipeField {
   private spawnPipe(startX?: number): void {
     const pipe = new PipePair(
       this.canvasSize,
-      this.platformHeight,
       startX ?? this.canvasSize.width,
       randomGapCenter(this.canvasSize, this.platformHeight)
     );

--- a/src/classic/entities/PipePair.ts
+++ b/src/classic/entities/PipePair.ts
@@ -3,9 +3,9 @@ import {
   PIPE_HEIGHT,
   PIPE_MIN_GAP,
   PIPE_WIDTH,
-} from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteName, SpriteSheet } from '../spriteSheet.ts';
+} from '../constants';
+import type { Dimension } from '../types';
+import type { SpriteName, SpriteSheet } from '../spriteSheet';
 
 const PIPE_MAIN = '#7dd36f';
 const PIPE_DARK = '#3a7c47';
@@ -23,7 +23,6 @@ export class PipePair {
   private color: PipeColor = 'green';
   constructor(
     private readonly canvasSize: Dimension,
-    private readonly platformHeight: number,
     public x: number,
     public gapCenter: number
   ) {}

--- a/src/classic/entities/Platform.ts
+++ b/src/classic/entities/Platform.ts
@@ -1,6 +1,6 @@
-import { CANVAS_HEIGHT, PLATFORM_HEIGHT } from '../constants.ts';
-import type { Dimension } from '../types.ts';
-import type { SpriteSheet } from '../spriteSheet.ts';
+import { CANVAS_HEIGHT, PLATFORM_HEIGHT } from '../constants';
+import type { Dimension } from '../types';
+import type { SpriteSheet } from '../spriteSheet';
 
 const TOP_COLOR = '#ded48a';
 const FRONT_COLOR = '#c4a34a';

--- a/src/game/systems/prng.ts
+++ b/src/game/systems/prng.ts
@@ -1,4 +1,4 @@
-import { createRng, isRngFeatureEnabled, stringToUint32 } from "../../core/rng.ts";
+import { createRng, isRngFeatureEnabled, stringToUint32 } from '../../core/rng';
 
 const LEGACY_STORAGE_KEY = "flappy-bird/prng-seed" as const;
 const MODERN_STORAGE_KEY = "flappy.seed" as const;
@@ -9,6 +9,7 @@ const DEFAULT_STORAGE_KEY = isRngFeatureEnabled()
 export interface StorageAdapter {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
+  removeItem(key: string): void;
 }
 
 function resolveStorage(storage?: StorageAdapter | null): StorageAdapter | null {

--- a/src/hud/components/SessionStats.ts
+++ b/src/hud/components/SessionStats.ts
@@ -227,16 +227,8 @@ export class SessionStatsPanel {
       }
     });
 
-    // expose for internal reuse
-    this.expand = expandPanel;
-    this.collapse = collapsePanel;
     this.updateToggleLabel = updateToggleLabel;
   }
-
-  // Methods assigned within constructor
-  private expand: (shouldFocus?: boolean) => void = () => {};
-
-  private collapse: () => void = () => {};
 
   private updateToggleLabel: () => void = () => {};
 

--- a/src/types/three-examples.d.ts
+++ b/src/types/three-examples.d.ts
@@ -3,6 +3,7 @@ declare module 'three/examples/jsm/loaders/GLTFLoader.js' {
 
   export interface GLTF {
     scene: Group;
+    scenes?: Group[];
     animations: AnimationClip[];
   }
 
@@ -10,6 +11,9 @@ declare module 'three/examples/jsm/loaders/GLTFLoader.js' {
     constructor(manager?: unknown);
     loadAsync(url: string, onProgress?: (event: ProgressEvent<EventTarget>) => void): Promise<GLTF>;
     setDRACOLoader(loader: unknown): this;
+    setResourcePath(path: string): this;
+    setPath(path: string): this;
+    setCrossOrigin(origin: string): this;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "lib": ["dom", "es2019"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+    "target": "es2019" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "lib": ["dom", "es2020"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -25,11 +25,13 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "es6" /* Specify what module code is generated. */,
+    "module": "es2020" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    "baseUrl": "./src" /* Specify the base directory to resolve non-relative module names. */,
+    "paths": {
+      "@/*": ["./*"]
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": ["./types", "./node_modules/@types"] /* Specify multiple folders that act like './node_modules/@types'. */,
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
@@ -100,6 +102,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["./dist"],
+  "exclude": ["./dist", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"],
   "include": ["src/**/*", "./types"]
 }

--- a/types/import-meta.d.ts
+++ b/types/import-meta.d.ts
@@ -1,0 +1,8 @@
+interface ImportMetaEnv {
+  readonly BASE_URL?: string;
+  readonly [key: string]: unknown;
+}
+
+declare interface ImportMeta {
+  readonly env?: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- update the TypeScript compiler target/module settings and exclude tests so webpack can compile without downlevel errors
- add three runtime and type dependencies plus minimal module declarations for import.meta and GLTF helpers to satisfy type checking
- normalize classic mode imports, pipe spawning signatures, and supporting utilities to align with the stricter build configuration

## Testing
- npm run build
- npm run lint *(fails: existing lint violations in unrelated files such as empty functions and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e198fed7688328a9c3d239989c00a9