### PR TITLE
Update Pages workflow to build docs artifact

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint checks
+        run: npm run lint
+      - name: Run tests
+        run: npm run test
+      - name: Build application
+        run: npm run build
+      - name: Prepare docs deployment
+        run: npm run deploy
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:
-          # Upload entire repository
-          path: '.'
+          path: docs
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "npm run dev",
     "prettier-format": "prettier --config .prettierrc \"./src\" \"./types\" --write",
     "prettier-format:md": "prettier --config .prettierrc \"./*.js\" --write",
-    "lint": "eslint ./src/**/*.ts"
+    "lint": "eslint ./src/**/*.ts",
+    "deploy": "node scripts/deploy-docs.mjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- set up Node.js with caching in the Pages workflow and add lint/test/build/deploy steps before uploading artifacts
- restrict the upload-pages-artifact step to the generated docs folder
- expose the deploy-docs helper through a new npm script for local and CI usage

## Testing
- npm ci
- npm run build *(fails: TypeScript compilation errors in existing sources)*
- npm run deploy *(fails: dist/ is not generated because build step fails)*

------
https://chatgpt.com/codex/tasks/task_e_68e19a7e67f88328a68ba8a8f603ac42