### PR TITLE
Align webpack build with ClassicGame bootstrap

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,19 +1,66 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>%TITLE%</title>
-    <ga4.analytics />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flappy Bird Classic</title>
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <canvas id="main-canvas"></canvas>
-    <div id="loading-modal">
-      <div>Loading</div>
-      <div class="lds-ellipsis">
-        <div></div>
-        <div></div>
-        <div></div>
-        <div></div>
-      </div>
-    </div>
+    <main class="game-layout">
+      <header class="hud-panel" aria-label="Game dashboard">
+        <div class="hud-metric" aria-live="polite">
+          <span class="hud-label">Score</span>
+          <span id="scoreValue" class="hud-value">0</span>
+        </div>
+        <div class="hud-metric" aria-live="polite">
+          <span class="hud-label">Best</span>
+          <span id="bestValue" class="hud-value">0</span>
+        </div>
+        <div class="hud-metric hud-metric--wide">
+          <span class="hud-label">Speed</span>
+          <div
+            id="speedProgress"
+            class="speed-meter"
+            role="progressbar"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            aria-valuenow="0"
+            aria-label="Pipe speed"
+          >
+            <span id="speedFill" class="speed-meter__fill"></span>
+          </div>
+        </div>
+        <div class="hud-metric hud-metric--perfect">
+          <span class="hud-label">Perfect</span>
+          <div
+            id="perfectIndicator"
+            class="perfect-indicator"
+            aria-live="polite"
+            aria-atomic="true"
+          ></div>
+        </div>
+      </header>
+
+      <section
+        id="app"
+        class="game-stage"
+        aria-label="Flappy Bird Classic game board"
+      >
+        <canvas id="gameCanvas" aria-describedby="gameMessage"></canvas>
+        <div id="gameOverlay" class="game-overlay" aria-live="assertive">
+          <p id="gameMessage" class="game-message">Tap or press Space to start</p>
+          <div id="sessionStats" class="session-stats" hidden></div>
+          <button id="startButton" type="button" class="game-button">Play</button>
+        </div>
+      </section>
+
+      <footer class="game-footer">
+        <p>
+          Controls: Tap/click, press <kbd>Space</kbd> or <kbd>Arrow Up</kbd> to flap.
+          Press <kbd>R</kbd> to restart.
+        </p>
+      </footer>
+    </main>
   </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ const CONFIG = {
     dir: 'dist' // Do not include './' or '/'
   },
   input: {
-    entry: './src/index.ts', // Typescript only
+    entry: './src/main.ts', // Typescript only
     dir: 'src'
   },
 


### PR DESCRIPTION
## Summary
- point the webpack entry at `src/main.ts` so the ClassicGame bundle is compiled
- replace the webpack HTML template with the modern HUD markup that `src/main.ts` expects so the bundle can inject itself

## Testing
- npm run build *(fails: existing ts-loader configuration does not allow `.ts` import specifiers and other project-level TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e19ae988cc83289c4b79640b0603aa