### PR TITLE
Copy HUD styles assets into webpack dist

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -321,6 +321,13 @@ module.exports = function (env, config) {
         chunkFilename: CONFIG.output.chunk + '.css'
       }),
 
+      new CopyPlugin({
+        patterns: [
+          { from: 'styles.css', to: '.' },
+          { from: 'src/hud/styles', to: 'src/hud/styles' }
+        ]
+      }),
+
       new InterpolateHtmlPlugin({
         CDN: '',
         PUBLIC_URL: '',


### PR DESCRIPTION
## Summary
- add a CopyPlugin step in the webpack configuration to copy the root styles.css and HUD partial directories into the dist output so CSS imports resolve in production builds

## Testing
- npm run build *(fails: TypeScript loader flags existing issues in classic game modules and Vitest-based files)*

------
https://chatgpt.com/codex/tasks/task_e_68e19aedcfa4832889194005bceca983