### PR TITLE
Configure GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,34 +1,56 @@
-name: Deploy to GitHub Pages
+name: Deploy Flappy Bird to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-        cache: 'npm'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Build
-      run: npm run build
+      - name: Build project
+        run: npm run build
 
-    - name: Deploy to GitHub Pages
-      if: github.ref == 'refs/heads/main'
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dist
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,7 +86,7 @@ let prodPlugins = [
 
   new WebpackManifestPlugin({
     basePath: '',
-    publicPath: 'Flappybird/',
+    publicPath: 'flappy-bird/',
     fileName: 'asset-manifest.json'
   }),
 


### PR DESCRIPTION
## Summary
- replace the Pages workflow with the official build/deploy pipeline that uploads the production bundle and publishes it to GitHub Pages
- ensure the workflow runs on pushes, pull requests, or manual dispatch while only deploying from main
- align the Webpack manifest public path with the repository slug so the game assets resolve correctly when hosted

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1aec0f9788328b8d8e689f949809a