### PR TITLE
Remove rate button from intro screen

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -68,7 +68,6 @@ export default class Game extends ParentClass {
 
     this.screenIntro.playButton.active = true;
     this.screenIntro.rankingButton.active = true;
-    this.screenIntro.rateButton.active = true;
 
     // Register screens
     this.screenChanger.register('intro', this.screenIntro);
@@ -137,7 +136,6 @@ export default class Game extends ParentClass {
       // Deactivate buttons
       this.screenIntro.playButton.active = false;
       this.screenIntro.rankingButton.active = false;
-      this.screenIntro.rateButton.active = false;
       this.screenIntro.toggleSpeakerButton.active = false;
 
       this.transition.reset();

--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -2,7 +2,7 @@
  * Display "FlappyBird"
  * Display the bird close to the middle and at the center
  *
- * Display "Play", "Rate" buttons and maybe include the
+ * Display "Play" button and include the
  * "Ranking" button but with no function. Just to mimic the
  * original game since ranking only works if the game is
  * connected to Google Play Games or Apple Game Center
@@ -15,7 +15,6 @@ import { IScreenChangerObject } from '../lib/screen-changer';
 import ParentClass from '../abstracts/parent-class';
 import PlayButton from '../model/btn-play';
 import RankingButton from '../model/btn-ranking';
-import RateButton from '../model/btn-rate';
 import ToggleSpeaker from '../model/btn-toggle-speaker';
 import SpriteDestructor from '../lib/sprite-destructor';
 import { APP_VERSION } from '../constants';
@@ -23,7 +22,6 @@ import { APP_VERSION } from '../constants';
 export default class Introduction extends ParentClass implements IScreenChangerObject {
   public playButton: PlayButton;
   public rankingButton: RankingButton;
-  public rateButton: RateButton;
   public toggleSpeakerButton: ToggleSpeaker;
 
   private bird: BirdModel;
@@ -35,7 +33,6 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.bird = new BirdModel();
     this.playButton = new PlayButton();
     this.rankingButton = new RankingButton();
-    this.rateButton = new RateButton();
     this.toggleSpeakerButton = new ToggleSpeaker();
     this.flappyBirdBanner = void 0;
     this.copyright = void 0;
@@ -45,7 +42,6 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.bird.init();
     this.playButton.init();
     this.rankingButton.init();
-    this.rateButton.init();
     this.toggleSpeakerButton.init();
     this.flappyBirdBanner = SpriteDestructor.asset('banner-flappybird');
     this.copyright = SpriteDestructor.asset('copyright');
@@ -56,7 +52,6 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.bird.resize({ width, height });
     this.playButton.resize({ width, height });
     this.rankingButton.resize({ width, height });
-    this.rateButton.resize({ width, height });
     this.toggleSpeakerButton.resize({ width, height });
   }
 
@@ -72,7 +67,6 @@ export default class Introduction extends ParentClass implements IScreenChangerO
 
     this.playButton.Update();
     this.rankingButton.Update();
-    this.rateButton.Update();
     this.toggleSpeakerButton.Update();
   }
 
@@ -80,7 +74,6 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.toggleSpeakerButton.Display(context);
     this.playButton.Display(context);
     this.rankingButton.Display(context);
-    this.rateButton.Display(context);
     this.bird.Display(context);
 
     // Flappy Bird Banner
@@ -140,14 +133,12 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.toggleSpeakerButton.mouseEvent('down', { x, y });
     this.playButton.mouseEvent('down', { x, y });
     this.rankingButton.mouseEvent('down', { x, y });
-    this.rateButton.mouseEvent('down', { x, y });
   }
 
   public mouseUp({ x, y }: ICoordinate): void {
     this.toggleSpeakerButton.mouseEvent('up', { x, y });
     this.playButton.mouseEvent('up', { x, y });
     this.rankingButton.mouseEvent('up', { x, y });
-    this.rateButton.mouseEvent('up', { x, y });
   }
 
   public startAtKeyBoardEvent(): void {


### PR DESCRIPTION
## Summary
- remove the rate button from the intro screen implementation
- update intro screen setup and game event handling to reflect the remaining buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b05cfb448328b81e92e5337ae72c