### PR TITLE
Remove intro screen version badge

### DIFF
--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -17,7 +17,6 @@ import PlayButton from '../model/btn-play';
 import RankingButton from '../model/btn-ranking';
 import ToggleSpeaker from '../model/btn-toggle-speaker';
 import SpriteDestructor from '../lib/sprite-destructor';
-import { APP_VERSION } from '../constants';
 
 export default class Introduction extends ParentClass implements IScreenChangerObject {
   public playButton: PlayButton;
@@ -91,21 +90,6 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     );
     // ----------------------------------
 
-    this.insertAppVersion(context);
-  }
-
-  private insertAppVersion(context: CanvasRenderingContext2D): void {
-    const fSize = this.canvasSize.width * 0.04;
-    const bot = this.canvasSize.height * 0.985;
-    const right = this.canvasSize.width * 0.985;
-
-    context.font = `bold ${fSize}px monospace`;
-    context.textAlign = 'center';
-    context.fillStyle = '#8E8E93';
-    context.fillText(`v${APP_VERSION}`, right - 2 * fSize, bot);
-
-    // context.strokeStyle = 'black';
-    // context.strokeText(`v${APP_VERSION}`, right - 2 * fSize, bot);
   }
 
   public mouseDown({ x, y }: ICoordinate): void {


### PR DESCRIPTION
## Summary
- remove the version label rendering from the intro screen so it no longer shows in the corner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1b1a69a1083288920b1ec410d0e33