### PR TITLE
Adjust intro banner and bird positions

### DIFF
--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -55,7 +55,7 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.bird.doWave(
       {
         x: this.canvasSize.width * 0.5,
-        y: this.canvasSize.height * 0.4
+        y: this.canvasSize.height * 0.46
       },
       1.4,
       9
@@ -84,7 +84,7 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     context.drawImage(
       this.flappyBirdBanner!,
       this.canvasSize.width * 0.5 - fbbScaled.width / 2,
-      this.canvasSize.height * 0.28 - fbbScaled.height / 2,
+      this.canvasSize.height * 0.36 - fbbScaled.height / 2,
       fbbScaled.width,
       fbbScaled.height
     );


### PR DESCRIPTION
## Summary
- lower the FlappyBird banner on the intro screen so the title sits further down the canvas
- drop the intro bird's wave anchor to keep it aligned with the lowered banner

## Testing
- npm run lint *(warnings about existing unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b338f9808328b99863b06e0e8d39