### PR TITLE
Switch medal artwork to SVG assets

### DIFF
--- a/src/assets/medal-bronze.svg
+++ b/src/assets/medal-bronze.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
+  <defs>
+    <linearGradient id="bronze-medal" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f2a772" />
+      <stop offset="100%" stop-color="#b66a2e" />
+    </linearGradient>
+    <linearGradient id="bronze-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#823d1a" />
+      <stop offset="100%" stop-color="#a44f22" />
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#bronze-ribbon)" />
+    <circle cx="64" cy="64" r="56" fill="url(#bronze-medal)" stroke="#8a4f23" stroke-width="8" />
+    <polygon points="64 26 72.9 49.2 98 49.2 77.5 64.8 86.4 88 64 72.8 41.6 88 50.5 64.8 30 49.2 55.1 49.2" fill="#fff1d6" stroke="#d78e4b" stroke-width="4" stroke-linejoin="round" />
+  </g>
+</svg>

--- a/src/assets/medal-gold.svg
+++ b/src/assets/medal-gold.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
+  <defs>
+    <linearGradient id="gold-medal" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffe680" />
+      <stop offset="100%" stop-color="#d4a200" />
+    </linearGradient>
+    <linearGradient id="gold-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#d4542d" />
+      <stop offset="100%" stop-color="#a52a1b" />
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#gold-ribbon)" />
+    <circle cx="64" cy="64" r="56" fill="url(#gold-medal)" stroke="#b58700" stroke-width="8" />
+    <polygon points="64 26 72.9 49.2 98 49.2 77.5 64.8 86.4 88 64 72.8 41.6 88 50.5 64.8 30 49.2 55.1 49.2" fill="#fff3c2" stroke="#c79806" stroke-width="4" stroke-linejoin="round" />
+  </g>
+</svg>

--- a/src/assets/medal-platinum.svg
+++ b/src/assets/medal-platinum.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
+  <defs>
+    <linearGradient id="platinum-medal" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f5faff" />
+      <stop offset="100%" stop-color="#c7d1da" />
+    </linearGradient>
+    <linearGradient id="platinum-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6e6ef5" />
+      <stop offset="100%" stop-color="#4a4ab8" />
+    </linearGradient>
+    <radialGradient id="platinum-highlight" cx="50%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
+      <stop offset="100%" stop-color="#d3dbe4" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#platinum-ribbon)" />
+    <circle cx="64" cy="64" r="56" fill="url(#platinum-medal)" stroke="#98a4b1" stroke-width="8" />
+    <circle cx="64" cy="54" r="40" fill="url(#platinum-highlight)" />
+    <polygon points="64 22 74.5 47.3 102 47.3 79.8 63.7 89.2 90 64 74.7 38.8 90 48.2 63.7 26 47.3 53.5 47.3" fill="#ffffff" stroke="#a6b2bf" stroke-width="4" stroke-linejoin="round" />
+  </g>
+</svg>

--- a/src/assets/medal-silver.svg
+++ b/src/assets/medal-silver.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
+  <defs>
+    <linearGradient id="silver-medal" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f9f9f9" />
+      <stop offset="100%" stop-color="#b8b8b8" />
+    </linearGradient>
+    <linearGradient id="silver-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7a8691" />
+      <stop offset="100%" stop-color="#55606a" />
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#silver-ribbon)" />
+    <circle cx="64" cy="64" r="56" fill="url(#silver-medal)" stroke="#8f9499" stroke-width="8" />
+    <polygon points="64 26 72.9 49.2 98 49.2 77.5 64.8 86.4 88 64 72.8 41.6 88 50.5 64.8 30 49.2 55.1 49.2" fill="#ffffff" stroke="#a9afb4" stroke-width="4" stroke-linejoin="round" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- replace the medal artwork PNGs with inlineable SVG art and update the scoreboard preload imports
- retain the tuned layout so the new vector medals fit without additional adjustments

## Testing
- npm run lint *(warnings about pre-existing unused parameters remain)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b76c292c8328a4715518a804d811