### PR TITLE
Add configurable settings overlay with persistent preferences

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -15,6 +15,7 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
   }
 
   let clicked = false;
+  let holdTimer: number | undefined;
 
   // Trigger the event once
   let hasMouseDown = false;
@@ -36,10 +37,30 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
     return { x: dx, y: dy };
   };
 
+  const clearHoldTimer = () => {
+    if (holdTimer === undefined) return;
+    window.clearInterval(holdTimer);
+    holdTimer = undefined;
+  };
+
+  const triggerPrimaryAction = () => {
+    Game.onClick(mouse.position);
+  };
+
   const likeClickedEvent = () => {
+    const scheme = Game.currentControlScheme;
+
+    if (scheme === 'hold') {
+      triggerPrimaryAction();
+      if (holdTimer === undefined) {
+        holdTimer = window.setInterval(triggerPrimaryAction, 140);
+      }
+      return;
+    }
+
     if (clicked) return;
 
-    Game.onClick(mouse.position);
+    triggerPrimaryAction();
     clicked = true;
   };
 
@@ -68,6 +89,7 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
     Game.mouseUp(mouse.position);
     mouse.down = false;
     clicked = false;
+    clearHoldTimer();
   };
 
   const mouseDown = ({ x, y }: ICoordinate, evt: IEventParam): void => {
@@ -165,5 +187,10 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
         false
       );
     }
+  });
+
+  Game.setControlSchemeListener(() => {
+    clearHoldTimer();
+    clicked = false;
   });
 };

--- a/src/lib/settings/index.ts
+++ b/src/lib/settings/index.ts
@@ -1,0 +1,203 @@
+// File Overview: This module belongs to src/lib/settings/index.ts.
+import Storage, { type IStoreValue } from '../storage';
+
+type ThemeSetting = 'system' | 'day' | 'night';
+type ControlScheme = 'tap' | 'hold';
+
+type FpsCapOption = 0 | 30 | 60 | 120;
+
+export interface ISettingsState {
+  volume: number;
+  reducedMotion: boolean;
+  theme: ThemeSetting;
+  fpsCap: FpsCapOption;
+  controlScheme: ControlScheme;
+}
+
+export type SettingsKey = keyof ISettingsState;
+export type SettingsListener<T extends SettingsKey = SettingsKey> = (
+  value: ISettingsState[T]
+) => void;
+
+const STORAGE_KEYS: Record<SettingsKey, string> = {
+  volume: 'settings.volume',
+  reducedMotion: 'settings.reducedMotion',
+  theme: 'settings.theme',
+  fpsCap: 'settings.fpsCap',
+  controlScheme: 'settings.controlScheme'
+};
+
+const DEFAULT_STATE: ISettingsState = {
+  volume: 0.6,
+  reducedMotion: false,
+  theme: 'system',
+  fpsCap: 60,
+  controlScheme: 'tap'
+};
+
+export default class SettingsManager {
+  private static instance: SettingsManager;
+  private state: ISettingsState;
+  private listeners: Map<SettingsKey, Set<SettingsListener>>;
+  private systemThemeMatcher?: MediaQueryList;
+
+  private constructor() {
+    new Storage();
+    this.listeners = new Map();
+    this.state = { ...DEFAULT_STATE };
+    this.loadInitialState();
+    this.setupThemeListener();
+  }
+
+  private loadInitialState(): void {
+    (Object.keys(DEFAULT_STATE) as SettingsKey[]).forEach((key) => {
+      const stored = Storage.get(STORAGE_KEYS[key]);
+
+      if (stored === undefined) {
+        return;
+      }
+
+      switch (key) {
+        case 'volume':
+          this.state.volume = Math.min(1, Math.max(0, Number(stored)));
+          break;
+        case 'reducedMotion':
+          this.state.reducedMotion = stored === true || stored === 'true';
+          break;
+        case 'theme':
+          if (stored === 'day' || stored === 'night' || stored === 'system') {
+            this.state.theme = stored;
+          }
+          break;
+        case 'fpsCap':
+          this.state.fpsCap = this.parseFpsCap(stored);
+          break;
+        case 'controlScheme':
+          if (stored === 'tap' || stored === 'hold') {
+            this.state.controlScheme = stored;
+          }
+          break;
+        default:
+          break;
+      }
+    });
+  }
+
+  private parseFpsCap(value: IStoreValue): FpsCapOption {
+    const numeric = Number(value);
+
+    if (numeric === 30 || numeric === 60 || numeric === 120) {
+      return numeric;
+    }
+
+    return 0;
+  }
+
+  public static getInstance(): SettingsManager {
+    if (!SettingsManager.instance) {
+      SettingsManager.instance = new SettingsManager();
+    }
+
+    return SettingsManager.instance;
+  }
+
+  public get<K extends SettingsKey>(key: K): ISettingsState[K] {
+    return this.state[key];
+  }
+
+  public set<K extends SettingsKey>(key: K, value: ISettingsState[K]): void {
+    if (this.state[key] === value) return;
+
+    this.state = { ...this.state, [key]: value } as ISettingsState;
+    this.persist(key, value);
+    this.emit(key, value);
+  }
+
+  private persist<K extends SettingsKey>(key: K, value: ISettingsState[K]): void {
+    switch (key) {
+      case 'volume':
+        Storage.save(STORAGE_KEYS[key], Number(value));
+        break;
+      case 'reducedMotion':
+        Storage.save(STORAGE_KEYS[key], Boolean(value));
+        break;
+      case 'theme':
+        Storage.save(STORAGE_KEYS[key], String(value));
+        break;
+      case 'fpsCap':
+        Storage.save(STORAGE_KEYS[key], Number(value));
+        break;
+      case 'controlScheme':
+        Storage.save(STORAGE_KEYS[key], String(value));
+        break;
+      default:
+        break;
+    }
+  }
+
+  private emit<K extends SettingsKey>(key: K, value: ISettingsState[K]): void {
+    const listeners = this.listeners.get(key);
+    if (!listeners) return;
+
+    listeners.forEach((listener) => {
+      listener(value);
+    });
+  }
+
+  public subscribe<K extends SettingsKey>(
+    key: K,
+    listener: SettingsListener<K>
+  ): () => void {
+    const listeners = this.listeners.get(key) ?? new Set();
+    listeners.add(listener as SettingsListener);
+    this.listeners.set(key, listeners);
+
+    return () => {
+      const existing = this.listeners.get(key);
+      existing?.delete(listener as SettingsListener);
+      if (existing && existing.size < 1) {
+        this.listeners.delete(key);
+      }
+    };
+  }
+
+  public get motionScale(): number {
+    return this.state.reducedMotion ? 0.6 : 1;
+  }
+
+  public applyThemeToDocument(): void {
+    const root = document.documentElement;
+    root.classList.remove('theme-day', 'theme-night');
+
+    if (this.state.theme === 'day') {
+      root.classList.add('theme-day');
+      return;
+    }
+
+    if (this.state.theme === 'night') {
+      root.classList.add('theme-night');
+      return;
+    }
+
+    const prefersDark = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    ).matches;
+
+    root.classList.add(prefersDark ? 'theme-night' : 'theme-day');
+  }
+
+  private setupThemeListener(): void {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    this.systemThemeMatcher = window.matchMedia('(prefers-color-scheme: dark)');
+
+    this.systemThemeMatcher.addEventListener('change', () => {
+      if (this.state.theme === 'system') {
+        this.applyThemeToDocument();
+      }
+    });
+  }
+}
+
+export const settings = SettingsManager.getInstance();
+export type { ThemeSetting, ControlScheme, FpsCapOption };

--- a/src/model/background.ts
+++ b/src/model/background.ts
@@ -4,6 +4,7 @@ import { rescaleDim } from '../utils';
 import ParentClass from '../abstracts/parent-class';
 import SpriteDestructor from '../lib/sprite-destructor';
 import SceneGenerator from './scene-generator';
+import { settings } from '../lib/settings';
 
 export type ITheme = string;
 export type IRecords = Map<ITheme, HTMLImageElement>;
@@ -77,7 +78,8 @@ export default class Background extends ParentClass {
      * We cannot rely on fps since it is not a constant value.
      * Which means is the game will speed up or slow down based on fps
      * */
-    this.coordinate.x += this.canvasSize.width * this.velocity.x;
+    this.coordinate.x +=
+      this.canvasSize.width * this.velocity.x * settings.motionScale;
     this.coordinate.y += this.velocity.y;
   }
 

--- a/src/model/pipe.ts
+++ b/src/model/pipe.ts
@@ -4,6 +4,7 @@ import { rescaleDim } from '../utils';
 import ParentClass from '../abstracts/parent-class';
 import SpriteDestructor from '../lib/sprite-destructor';
 import SceneGenerator from './scene-generator';
+import { settings } from '../lib/settings';
 
 export interface IPipePairPosition {
   top: ICoordinate;
@@ -147,7 +148,7 @@ export default class Pipe extends ParentClass {
    * Pipe Update
    * */
   public Update(): void {
-    this.coordinate.x -= this.velocity.x;
+    this.coordinate.x -= this.velocity.x * settings.motionScale;
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/platform.ts
+++ b/src/model/platform.ts
@@ -4,6 +4,7 @@ import { rescaleDim } from '../utils';
 import { GAME_SPEED } from '../constants';
 import ParentClass from '../abstracts/parent-class';
 import SpriteDestructor from '../lib/sprite-destructor';
+import { settings } from '../lib/settings';
 
 export default class Platform extends ParentClass {
   public platformSize: IDimension;
@@ -47,7 +48,8 @@ export default class Platform extends ParentClass {
      * We use linear interpolation instead of by pixel to move the object.
      * It is to keep the speed same in different Screen Sizes & Screen DPI
      * */
-    this.coordinate.x += this.canvasSize.width * this.velocity.x;
+    this.coordinate.x +=
+      this.canvasSize.width * this.velocity.x * settings.motionScale;
     this.coordinate.y += this.velocity.y;
   }
 

--- a/src/screens/settings.ts
+++ b/src/screens/settings.ts
@@ -1,0 +1,292 @@
+// File Overview: This module belongs to src/screens/settings.ts.
+import ParentClass from '../abstracts/parent-class';
+import { type IScreenChangerObject } from '../lib/screen-changer';
+import { settings } from '../lib/settings';
+import Sfx from '../model/sfx';
+import Game from '../game';
+
+const VOLUME_MAX = 1;
+
+export default class SettingsScreen
+  extends ParentClass
+  implements IScreenChangerObject
+{
+  private readonly game: Game;
+  private container: HTMLDivElement;
+  private panel: HTMLDivElement;
+  private closeButton: HTMLButtonElement;
+  private launcherButton: HTMLButtonElement;
+  private volumeSlider: HTMLInputElement;
+  private volumeValue: HTMLSpanElement;
+  private reducedMotionToggle: HTMLInputElement;
+  private themeSelect: HTMLSelectElement;
+  private fpsSelect: HTMLSelectElement;
+  private controlSelect: HTMLSelectElement;
+  private isOpen: boolean;
+
+  constructor(game: Game) {
+    super();
+    this.game = game;
+    this.container = document.createElement('div');
+    this.panel = document.createElement('div');
+    this.closeButton = document.createElement('button');
+    this.launcherButton = document.createElement('button');
+    this.volumeSlider = document.createElement('input');
+    this.volumeValue = document.createElement('span');
+    this.reducedMotionToggle = document.createElement('input');
+    this.themeSelect = document.createElement('select');
+    this.fpsSelect = document.createElement('select');
+    this.controlSelect = document.createElement('select');
+    this.isOpen = false;
+
+    this.setupDom();
+  }
+
+  private setupDom(): void {
+    const appendToBody = (element: HTMLElement) => {
+      if (document.readyState === 'loading') {
+        window.addEventListener(
+          'DOMContentLoaded',
+          () => {
+            document.body.append(element);
+          },
+          { once: true }
+        );
+        return;
+      }
+
+      document.body.append(element);
+    };
+
+    this.container.className = 'settings-overlay';
+    this.container.setAttribute('role', 'dialog');
+    this.container.setAttribute('aria-modal', 'true');
+    this.container.setAttribute('aria-labelledby', 'settings-title');
+    this.container.hidden = true;
+
+    this.panel.className = 'settings-overlay__panel';
+    this.panel.tabIndex = -1;
+
+    const title = document.createElement('h2');
+    title.id = 'settings-title';
+    title.textContent = 'Settings';
+
+    this.closeButton.type = 'button';
+    this.closeButton.className = 'settings-overlay__close';
+    this.closeButton.textContent = 'Back';
+
+    this.launcherButton.type = 'button';
+    this.launcherButton.className = 'settings-launcher';
+    this.launcherButton.setAttribute('aria-label', 'Open settings');
+    this.launcherButton.innerHTML = '&#9881;';
+    this.launcherButton.hidden = true;
+
+    this.volumeSlider.type = 'range';
+    this.volumeSlider.min = '0';
+    this.volumeSlider.max = '100';
+    this.volumeSlider.step = '1';
+    this.volumeSlider.name = 'volume';
+    this.volumeSlider.id = 'settings-volume';
+
+    const volumeLabel = document.createElement('label');
+    volumeLabel.htmlFor = this.volumeSlider.id;
+    volumeLabel.textContent = 'Audio volume';
+    this.volumeValue.className = 'settings-overlay__value';
+
+    const reducedLabel = document.createElement('label');
+    reducedLabel.htmlFor = 'settings-reduced-motion';
+    reducedLabel.textContent = 'Reduced motion';
+
+    this.reducedMotionToggle.type = 'checkbox';
+    this.reducedMotionToggle.id = reducedLabel.htmlFor;
+    this.reducedMotionToggle.name = 'reducedMotion';
+
+    const themeLabel = document.createElement('label');
+    themeLabel.htmlFor = 'settings-theme';
+    themeLabel.textContent = 'Theme';
+    this.themeSelect.id = themeLabel.htmlFor;
+    this.themeSelect.name = 'theme';
+
+    this.addSelectOption(this.themeSelect, 'system', 'Match system');
+    this.addSelectOption(this.themeSelect, 'day', 'Day');
+    this.addSelectOption(this.themeSelect, 'night', 'Night');
+
+    const fpsLabel = document.createElement('label');
+    fpsLabel.htmlFor = 'settings-fps';
+    fpsLabel.textContent = 'FPS cap';
+    this.fpsSelect.id = fpsLabel.htmlFor;
+    this.fpsSelect.name = 'fpsCap';
+
+    this.addSelectOption(this.fpsSelect, '0', 'Unlimited');
+    this.addSelectOption(this.fpsSelect, '30', '30 FPS');
+    this.addSelectOption(this.fpsSelect, '60', '60 FPS');
+    this.addSelectOption(this.fpsSelect, '120', '120 FPS');
+
+    const controlLabel = document.createElement('label');
+    controlLabel.htmlFor = 'settings-control';
+    controlLabel.textContent = 'Control scheme';
+    this.controlSelect.id = controlLabel.htmlFor;
+    this.controlSelect.name = 'controlScheme';
+
+    this.addSelectOption(this.controlSelect, 'tap', 'Tap / Click');
+    this.addSelectOption(this.controlSelect, 'hold', 'Press and hold');
+
+    const volumeRow = document.createElement('div');
+    volumeRow.className = 'settings-overlay__row';
+    volumeRow.append(volumeLabel, this.volumeSlider, this.volumeValue);
+
+    const reducedRow = document.createElement('div');
+    reducedRow.className = 'settings-overlay__row';
+    reducedRow.append(reducedLabel, this.reducedMotionToggle);
+
+    const themeRow = document.createElement('div');
+    themeRow.className = 'settings-overlay__row';
+    themeRow.append(themeLabel, this.themeSelect);
+
+    const fpsRow = document.createElement('div');
+    fpsRow.className = 'settings-overlay__row';
+    fpsRow.append(fpsLabel, this.fpsSelect);
+
+    const controlRow = document.createElement('div');
+    controlRow.className = 'settings-overlay__row';
+    controlRow.append(controlLabel, this.controlSelect);
+
+    this.panel.append(
+      this.closeButton,
+      title,
+      volumeRow,
+      reducedRow,
+      themeRow,
+      fpsRow,
+      controlRow
+    );
+    this.container.append(this.panel);
+    appendToBody(this.container);
+    appendToBody(this.launcherButton);
+  }
+
+  private addSelectOption(select: HTMLSelectElement, value: string, text: string): void {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = text;
+    select.append(option);
+  }
+
+  public init(): void {
+    this.bindEvents();
+    this.syncUiWithSettings();
+  }
+
+  public Update(): void {
+    // No-op – settings are managed via DOM events.
+  }
+
+  public Display(context: CanvasRenderingContext2D): void {
+    if (!this.isOpen) return;
+
+    context.save();
+    context.fillStyle = 'rgba(0, 0, 0, 0.55)';
+    context.fillRect(0, 0, this.canvasSize.width, this.canvasSize.height);
+    context.restore();
+  }
+
+  private bindEvents(): void {
+    this.closeButton.addEventListener('click', () => {
+      this.game.navigateTo('intro');
+    });
+
+    this.container.addEventListener('click', (event) => {
+      if (event.target === this.container) {
+        this.game.navigateTo('intro');
+      }
+    });
+
+    this.launcherButton.addEventListener('click', () => {
+      this.game.navigateTo('settings');
+    });
+
+    this.volumeSlider.addEventListener('input', () => {
+      const value = Number(this.volumeSlider.value) / 100;
+      settings.set('volume', Math.min(VOLUME_MAX, Math.max(0, value)));
+    });
+
+    this.reducedMotionToggle.addEventListener('change', () => {
+      settings.set('reducedMotion', this.reducedMotionToggle.checked);
+    });
+
+    this.themeSelect.addEventListener('change', () => {
+      const value = this.themeSelect.value as 'system' | 'day' | 'night';
+      settings.set('theme', value);
+    });
+
+    this.fpsSelect.addEventListener('change', () => {
+      settings.set('fpsCap', Number(this.fpsSelect.value) as 0 | 30 | 60 | 120);
+    });
+
+    this.controlSelect.addEventListener('change', () => {
+      settings.set('controlScheme', this.controlSelect.value as 'tap' | 'hold');
+    });
+
+    settings.subscribe('volume', (value) => {
+      this.volumeSlider.value = String(Math.round(value * 100));
+      this.volumeValue.textContent = `${Math.round(value * 100)}%`;
+      Sfx.volume(value);
+    });
+
+    settings.subscribe('reducedMotion', (value) => {
+      this.reducedMotionToggle.checked = value;
+    });
+
+    settings.subscribe('theme', () => {
+      this.themeSelect.value = settings.get('theme');
+      settings.applyThemeToDocument();
+    });
+
+    settings.subscribe('fpsCap', (value) => {
+      this.fpsSelect.value = String(value);
+      this.game.onFpsPreferenceChanged(value);
+    });
+
+    settings.subscribe('controlScheme', (value) => {
+      this.controlSelect.value = value;
+      this.game.onControlSchemeChanged(value);
+    });
+  }
+
+  private syncUiWithSettings(): void {
+    this.volumeSlider.value = String(Math.round(settings.get('volume') * 100));
+    this.volumeValue.textContent = `${Math.round(settings.get('volume') * 100)}%`;
+    this.reducedMotionToggle.checked = settings.get('reducedMotion');
+    this.themeSelect.value = settings.get('theme');
+    this.fpsSelect.value = String(settings.get('fpsCap'));
+    this.controlSelect.value = settings.get('controlScheme');
+    Sfx.volume(settings.get('volume'));
+    settings.applyThemeToDocument();
+    this.game.onFpsPreferenceChanged(settings.get('fpsCap'));
+    this.game.onControlSchemeChanged(settings.get('controlScheme'));
+  }
+
+  public open(): void {
+    if (this.isOpen) return;
+    this.isOpen = true;
+    this.container.hidden = false;
+    window.setTimeout(() => {
+      this.panel.focus({ preventScroll: true });
+      this.closeButton.focus();
+    });
+  }
+
+  public close(): void {
+    if (!this.isOpen) return;
+    this.isOpen = false;
+    this.container.hidden = true;
+  }
+
+  public showLauncher(): void {
+    this.launcherButton.hidden = false;
+  }
+
+  public hideLauncher(): void {
+    this.launcherButton.hidden = true;
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,4 +1,31 @@
 // File Overview: This stylesheet contributes to src/styles/main.scss.
+:root {
+  --app-bg: #fff;
+  --app-text: #1c1c1e;
+  --overlay-bg: rgba(242, 242, 244, 0.5);
+  --panel-bg: rgba(255, 255, 255, 0.96);
+  --panel-border: rgba(0, 0, 0, 0.1);
+  --panel-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+  --accent: #007aff;
+  --accent-contrast: #fff;
+  --muted-text: rgba(105, 105, 110, 1);
+}
+
+:root.theme-day {
+  --app-bg: #f5f8ff;
+  --panel-bg: rgba(255, 255, 255, 0.96);
+}
+
+:root.theme-night {
+  --app-bg: #050a12;
+  --app-text: #f4f6ff;
+  --overlay-bg: rgba(30, 30, 38, 0.6);
+  --panel-bg: rgba(22, 24, 32, 0.95);
+  --panel-border: rgba(255, 255, 255, 0.08);
+  --panel-shadow: 0 16px 48px rgba(0, 0, 0, 0.65);
+  --muted-text: rgba(190, 192, 204, 1);
+}
+
 html {
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
 }
@@ -13,7 +40,8 @@ body {
   justify-content: center;
   align-items: center;
   overflow: hidden;
-  background-color: #fff;
+  background-color: var(--app-bg);
+  color: var(--app-text);
   transition: background-color 0.5s ease-in-out;
 
   > #main-canvas {
@@ -43,7 +71,7 @@ body {
     height: 40vh;
     border: 1px solid rgba(248, 248, 252, 1);
     border-radius: 14px;
-    background-color: rgba(242, 242, 244, 0.5);
+    background-color: var(--overlay-bg);
     backdrop-filter: blur(8px);
 
     > img {
@@ -55,7 +83,7 @@ body {
     > div {
       text-align: center;
       font-family: 'Arial', 'Sans-Serif';
-      color: rgba(105, 105, 110, 1);
+      color: var(--muted-text);
       font-size: 1.7rem;
       letter-spacing: 3px;
       font-weight: 600;
@@ -93,6 +121,161 @@ body {
         }
       }
     }
+  }
+}
+
+.settings-launcher {
+  position: fixed;
+  top: clamp(12px, 3vw, 24px);
+  right: clamp(12px, 3vw, 24px);
+  width: clamp(44px, 7vw, 56px);
+  height: clamp(44px, 7vw, 56px);
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, rgba(0, 122, 255, 0.92), rgba(88, 86, 214, 0.92));
+  color: var(--accent-contrast);
+  font-size: clamp(1.4rem, 3vw, 1.8rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 5;
+
+  &:focus,
+  &:hover {
+    transform: translateY(-2px) scale(1.02);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
+    outline: none;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 4vw, 32px);
+  z-index: 4;
+
+  &__panel {
+    width: min(520px, 100%);
+    max-height: min(520px, 100%);
+    overflow-y: auto;
+    background-color: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 24px;
+    box-shadow: var(--panel-shadow);
+    padding: clamp(16px, 4vw, 32px);
+    display: grid;
+    gap: clamp(16px, 3vw, 24px);
+    color: var(--app-text);
+  }
+
+  h2 {
+    margin: 0;
+    font-size: clamp(1.5rem, 4vw, 2rem);
+    text-align: left;
+  }
+
+  &__close {
+    justify-self: flex-start;
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--accent);
+    color: var(--accent-contrast);
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+    &:hover,
+    &:focus {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 18px rgba(0, 122, 255, 0.35);
+      outline: none;
+    }
+
+    &:active {
+      transform: translateY(1px);
+    }
+  }
+
+  &__row {
+    display: grid;
+    gap: 8px;
+    color: inherit;
+
+    label {
+      font-size: 0.95rem;
+      font-weight: 600;
+    }
+
+    .settings-overlay__value {
+      justify-self: flex-end;
+      font-variant-numeric: tabular-nums;
+      font-weight: 600;
+      color: var(--muted-text);
+    }
+
+    input,
+    select {
+      padding: 0.65rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid var(--panel-border);
+      background: rgba(255, 255, 255, 0.75);
+      font-size: 1rem;
+      font-family: inherit;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+      &:focus {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.25);
+        outline: none;
+      }
+    }
+
+    input[type='range'] {
+      padding: 0;
+      appearance: none;
+      height: 4px;
+      background: linear-gradient(90deg, var(--accent), rgba(255, 255, 255, 0.7));
+      border-radius: 999px;
+
+      &::-webkit-slider-thumb {
+        appearance: none;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: var(--accent);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      &::-moz-range-thumb {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: var(--accent);
+        border: none;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+    }
+  }
+}
+
+body.reduced-motion {
+  transition: none;
+
+  * {
+    transition: none !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a storage-backed settings manager for audio, motion, theme, FPS, and input preferences
- implement a styled settings overlay with an intro launcher and immediate runtime updates
- hook settings into the game loop, input handling, and styling so changes take effect instantly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b7851e708328a9fdd1c0320d0942