### PR TITLE
Scale pipe difficulty based on score

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,6 +82,23 @@ export const PIPE_INITIAL_DIMENSION: IDimension = {
   height: 300
 };
 
+export interface IDifficultyBand {
+  /** Minimum score required before this band becomes active. */
+  threshold: number;
+  /** Multiplier applied to the default pipe gap size. */
+  gapScale: number;
+  /** Multiplier applied to the base horizontal speed. */
+  speedMultiplier: number;
+}
+
+export const DIFFICULTY_BANDS: IDifficultyBand[] = [
+  { threshold: 0, gapScale: 1, speedMultiplier: 1 },
+  { threshold: 10, gapScale: 0.95, speedMultiplier: 1.05 },
+  { threshold: 20, gapScale: 0.9, speedMultiplier: 1.1 },
+  { threshold: 35, gapScale: 0.86, speedMultiplier: 1.15 },
+  { threshold: 50, gapScale: 0.82, speedMultiplier: 1.2 }
+];
+
 /**
  * Background
  * */

--- a/src/model/pipe.ts
+++ b/src/model/pipe.ts
@@ -33,6 +33,8 @@ export default class Pipe extends ParentClass {
 
   private images: IPipeRecords;
   private color: IPipeColor;
+  private speedMultiplier: number;
+  private gapScale: number;
 
   constructor() {
     super();
@@ -45,6 +47,8 @@ export default class Pipe extends ParentClass {
     };
     this.isPassed = false;
     this.velocity.x = GAME_SPEED;
+    this.speedMultiplier = 1;
+    this.gapScale = 1;
     this.scaled = {
       top: { width: 0, height: 0 },
       bottom: { width: 0, height: 0 }
@@ -63,9 +67,10 @@ export default class Pipe extends ParentClass {
   /**
    * Set holl position
    * */
-  public setHollPosition(coordinate: ICoordinate): void {
+  public setHollPosition(coordinate: ICoordinate, gapScale = 1): void {
     // Positioning holl
-    this.hollSize = this.canvasSize.height * PIPE_HOLL_SIZE;
+    this.gapScale = gapScale;
+    this.hollSize = this.canvasSize.height * PIPE_HOLL_SIZE * this.gapScale;
 
     /**
      * The Logic is
@@ -101,14 +106,14 @@ export default class Pipe extends ParentClass {
     Pipe.pipeSize = rescaleDim(PIPE_INITIAL_DIMENSION, { width: min });
 
     // Resize holl size
-    this.hollSize = this.canvasSize.height * PIPE_HOLL_SIZE;
+    this.hollSize = this.canvasSize.height * PIPE_HOLL_SIZE * this.gapScale;
 
     // Relocate the pipe holl
     this.coordinate.x = width * (oldX / 100);
     this.coordinate.y = height * (oldY / 100);
 
     // Update velocity. Converting percentages to pixels
-    this.velocity.x = width * GAME_SPEED;
+    this.velocity.x = width * GAME_SPEED * this.speedMultiplier;
 
     this.scaled.top = rescaleDim(
       {
@@ -148,6 +153,11 @@ export default class Pipe extends ParentClass {
    * */
   public Update(): void {
     this.coordinate.x -= this.velocity.x;
+  }
+
+  public setSpeedMultiplier(multiplier: number): void {
+    this.speedMultiplier = multiplier;
+    this.velocity.x = this.canvasSize.width * GAME_SPEED * this.speedMultiplier;
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -122,7 +122,17 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.pipeGenerator.Update();
     this.bird.Update();
 
-    if (this.bird.isDead(this.pipeGenerator.pipes)) {
+    const isDead = this.bird.isDead(this.pipeGenerator.pipes);
+    const difficultyChanged = this.pipeGenerator.setDifficulty(this.bird.score);
+
+    if (difficultyChanged) {
+      const { speedMultiplier } = this.pipeGenerator.getCurrentDifficulty();
+      for (const pipe of this.pipeGenerator.pipes) {
+        pipe.setSpeedMultiplier(speedMultiplier);
+      }
+    }
+
+    if (isDead) {
       this.flashScreen.reset();
       this.flashScreen.start();
 


### PR DESCRIPTION
## Summary
- add configurable difficulty bands with gap and speed multipliers
- update pipe generator to react to difficulty changes and expose helper APIs
- shrink pipe gaps and retune pipe speed as the player’s score increases

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b7674c248328a9bb8a2417a4e98b