### PR TITLE
Add pause controls and overlays

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -28,6 +28,15 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
     }
   };
 
+  const pauseToggleBtn = document.querySelector<HTMLButtonElement>('#pause-toggle');
+
+  const updatePauseToggle = (paused: boolean): void => {
+    if (!pauseToggleBtn) return;
+    pauseToggleBtn.setAttribute('aria-pressed', String(paused));
+    pauseToggleBtn.dataset.state = paused ? 'paused' : 'running';
+    pauseToggleBtn.textContent = paused ? 'Resume' : 'Pause';
+  };
+
   const getBoundedPosition = ({ x, y }: ICoordinate): ICoordinate => {
     const { left, top, width, height } = canvas.getBoundingClientRect();
     const dx: number = ((x - left) / width) * canvas.width;
@@ -124,6 +133,12 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
   document.addEventListener('keydown', (evt: KeyboardEvent) => {
     const { key, keyCode, code } = evt;
 
+    if (code === 'KeyP' || key.toLowerCase() === 'p') {
+      if (evt.repeat) return;
+      updatePauseToggle(Game.togglePause());
+      return;
+    }
+
     if (
       key === ' ' ||
       keyCode === 32 ||
@@ -147,6 +162,10 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
 
   document.addEventListener('keyup', (evt: KeyboardEvent) => {
     const { key, keyCode, code } = evt;
+
+    if (code === 'KeyP' || key.toLowerCase() === 'p') {
+      return;
+    }
     if (
       key === ' ' ||
       keyCode === 32 ||
@@ -166,4 +185,20 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
       );
     }
   });
+
+  if (pauseToggleBtn) {
+    pauseToggleBtn.addEventListener('click', (evt: MouseEvent) => {
+      evt.preventDefault();
+      updatePauseToggle(Game.togglePause());
+    });
+
+    window.addEventListener('game:pause', (event) => {
+      const detail = (event as CustomEvent<{ paused: boolean }>).detail;
+      if (detail && typeof detail.paused === 'boolean') {
+        updatePauseToggle(detail.paused);
+      }
+    });
+
+    updatePauseToggle(Game.isPaused);
+  }
 };

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,9 @@
   </head>
   <body>
     <canvas id="main-canvas"></canvas>
+    <button id="pause-toggle" class="pause-toggle" type="button" aria-pressed="false">
+      Pause
+    </button>
     <div id="loading-modal">
       <div>Loading</div>
       <div class="lds-ellipsis">

--- a/src/model/btn-pause.ts
+++ b/src/model/btn-pause.ts
@@ -1,0 +1,48 @@
+// File Overview: This module belongs to src/model/btn-pause.ts.
+import Parent from '../abstracts/button-event-handler';
+import SpriteDestructor from '../lib/sprite-destructor';
+
+export default class PauseButton extends Parent {
+  private toggleCallback?: () => boolean;
+
+  constructor() {
+    super();
+    this.initialWidth = 0.12;
+    this.coordinate.x = 0.88;
+    this.coordinate.y = 0.08;
+    this.active = true;
+  }
+
+  public init(): void {
+    this.img = SpriteDestructor.asset('btn-pause');
+  }
+
+  public registerToggle(callback: () => boolean): void {
+    this.toggleCallback = callback;
+  }
+
+  public click(): void {
+    this.toggleCallback?.();
+  }
+
+  public Update(): void {
+    this.reset();
+
+    if (this.isHovered) {
+      this.move({ x: 0, y: 0.004 });
+    }
+
+    super.Update();
+  }
+
+  public Display(ctx: CanvasRenderingContext2D): void {
+    if (!this.img) return;
+
+    const xLoc = this.calcCoord.x;
+    const yLoc = this.calcCoord.y;
+    const xRad = this.dimension.width / 2;
+    const yRad = this.dimension.height / 2;
+
+    ctx.drawImage(this.img, xLoc - xRad, yLoc - yRad, xRad * 2, yRad * 2);
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -30,6 +30,37 @@ body {
     position: absolute;
   }
 
+  > #pause-toggle {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: none;
+    font-size: 1rem;
+    font-weight: 600;
+    font-family: 'Arial', 'Sans-Serif';
+    color: rgba(28, 28, 30, 1);
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+    z-index: 10;
+
+    &:hover,
+    &:focus {
+      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.95);
+      box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+      outline: none;
+    }
+
+    &[data-state='paused'] {
+      color: rgba(255, 255, 255, 0.95);
+      background: rgba(52, 199, 89, 0.9);
+    }
+  }
+
   > #loading-modal {
     display: flex;
     justify-content: center;

--- a/types/custom.d.ts
+++ b/types/custom.d.ts
@@ -1,17 +1,25 @@
 // File Overview: This module belongs to types/custom.d.ts.
-interface IDimension {
-  width: number;
-  height: number;
-}
+export {};
 
-interface ICoordinate {
-  x: number;
-  y: number;
-}
+declare global {
+  interface IDimension {
+    width: number;
+    height: number;
+  }
 
-interface IVelocity {
-  x: number;
-  y: number;
-}
+  interface ICoordinate {
+    x: number;
+    y: number;
+  }
 
-type IEmptyFunction = (...args) => void;
+  interface IVelocity {
+    x: number;
+    y: number;
+  }
+
+  type IEmptyFunction = (...args) => void;
+
+  interface WindowEventMap {
+    'game:pause': CustomEvent<{ paused: boolean }>;
+  }
+}


### PR DESCRIPTION
## Summary
- add pause state management, overlay rendering, and pause notifications to the core game loop
- integrate a canvas pause button and overlay request handling in the gameplay screen
- provide a DOM pause toggle with styling, keyboard shortcuts, and type-safe pause events

## Testing
- npm run lint *(fails: pre-existing @typescript-eslint no-unsafe-* violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b768be908328880d3460137017d2