### PR TITLE
Refactor game loop to be delta-time driven

### DIFF
--- a/src/abstracts/button-event-handler.ts
+++ b/src/abstracts/button-event-handler.ts
@@ -84,7 +84,8 @@ export default abstract class ButtonEventHandler {
     this.canvasSize = { width, height };
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
+    void delta;
     this.calcCoord.x =
       this.canvasSize.width * this.coordinate.x + this.additionalTranslate.x;
     this.calcCoord.y =
@@ -94,7 +95,7 @@ export default abstract class ButtonEventHandler {
   public mouseEvent(state: IMouseState, { x, y }: ICoordinate): void {
     if (state === 'down') {
       this.onMouseDown({ x, y });
-    } else if (state === 'up') {
+    } else {
       this.onMouseup({ x, y });
     }
   }

--- a/src/abstracts/parent-class.ts
+++ b/src/abstracts/parent-class.ts
@@ -26,6 +26,6 @@ export default abstract class ParentObject {
   }
 
   public abstract init(): void;
-  public abstract Update(): void;
+  public abstract Update(delta: number): void;
   public abstract Display(context: CanvasRenderingContext2D): void;
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -26,6 +26,7 @@ export default class Game extends ParentClass {
   private screenIntro: Intro;
   private gamePlay: GamePlay;
   private state: IGameState;
+  private static readonly MAX_DELTA = 2.5;
 
   constructor(canvas: HTMLCanvasElement) {
     super();
@@ -100,16 +101,19 @@ export default class Game extends ParentClass {
     this.canvas.height = height;
   }
 
-  public Update(): void {
-    this.transition.Update();
+  public Update(delta: number): void {
+    const safeDelta = Number.isFinite(delta) ? delta : 0;
+    const clampedDelta = Math.min(Math.max(safeDelta, 0), Game.MAX_DELTA);
+
+    this.transition.Update(clampedDelta);
     this.screenChanger.setState(this.state);
 
     if (!this.bgPause) {
-      this.background.Update();
-      this.platform.Update();
+      this.background.Update(clampedDelta);
+      this.platform.Update(clampedDelta);
     }
 
-    this.screenChanger.Update();
+    this.screenChanger.Update(clampedDelta);
   }
 
   public Display(): void {
@@ -128,6 +132,14 @@ export default class Game extends ParentClass {
     this.platform.Display(this.context);
     this.screenChanger.Display(this.context);
     this.transition.Display(this.context);
+  }
+
+  public update(delta: number): void {
+    this.Update(delta);
+  }
+
+  public render(): void {
+    this.Display();
   }
 
   public setEvent(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
 
 let isLoaded = false;
+let lastFrameTime = performance.now();
 
 gameIcon.src = gameSpriteIcon;
 
@@ -39,10 +40,14 @@ fps.text({ x: 50, y: 50 }, '', ' Cycle');
 fps.container({ x: 10, y: 10}, { x: 230, y: 70});
 
 const GameUpdate = (): void => {
-  physicalContext.drawImage(virtualCanvas, 0, 0);
+  const now = performance.now();
+  const delta = (now - lastFrameTime) / (1000 / 60);
+  lastFrameTime = now;
 
-  Game.Update();
-  Game.Display();
+  Game.update(delta);
+  Game.render();
+
+  physicalContext.drawImage(virtualCanvas, 0, 0);
 
   if (process.env.NODE_ENV === 'development') fps.mark();
 
@@ -89,6 +94,7 @@ window.addEventListener('DOMContentLoaded', () => {
     ScreenResize();
 
     // raf(GameUpdate); Issue #16
+    lastFrameTime = performance.now();
     if (!game_running()) game_start(); // Quick fix. Long term :)
 
     if (process.env.NODE_ENV === 'development') removeLoadingScreen();

--- a/src/lib/screen-changer/index.ts
+++ b/src/lib/screen-changer/index.ts
@@ -1,6 +1,6 @@
 // File Overview: This module belongs to src/lib/screen-changer/index.ts.
 export interface IScreenChangerObject {
-  Update(): void;
+  Update(delta: number): void;
   Display(context: CanvasRenderingContext2D): void;
 }
 
@@ -21,14 +21,14 @@ export default class ScreenChanger implements IScreenChangerObject {
     this.objects.set(name, classObject);
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
     const classObject = this.objects.get(this.currentState);
 
     if (classObject === void 0) {
       throw new TypeError(`State ${this.currentState} does not exists`);
     }
 
-    classObject.Update();
+    classObject.Update(delta);
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/background.ts
+++ b/src/model/background.ts
@@ -68,7 +68,7 @@ export default class Background extends ParentClass {
     );
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
     /**
      * We use linear interpolation instead of by pixel to move the object.
      * It is to keep the speed same in different Screen Sizes & Screen DPI.
@@ -77,8 +77,8 @@ export default class Background extends ParentClass {
      * We cannot rely on fps since it is not a constant value.
      * Which means is the game will speed up or slow down based on fps
      * */
-    this.coordinate.x += this.canvasSize.width * this.velocity.x;
-    this.coordinate.y += this.velocity.y;
+    this.coordinate.x += this.canvasSize.width * this.velocity.x * delta;
+    this.coordinate.y += this.velocity.y * delta;
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/banner-instruction.ts
+++ b/src/model/banner-instruction.ts
@@ -132,7 +132,8 @@ export default class BannerInstruction extends ParentClass {
       height * getReadyImagePos.y - this.getReadyImage.scaled.height / 2;
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
+    void delta;
     if (!this.doesTap) {
       this.opacity = 1;
       return;

--- a/src/model/btn-play.ts
+++ b/src/model/btn-play.ts
@@ -29,7 +29,7 @@ export default class PlayButton extends Parent {
     this.img = SpriteDestructor.asset('btn-play');
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
     this.reset();
 
     if (this.isHovered) {
@@ -39,7 +39,7 @@ export default class PlayButton extends Parent {
       });
     }
 
-    super.Update();
+    super.Update(delta);
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/btn-toggle-speaker.ts
+++ b/src/model/btn-toggle-speaker.ts
@@ -36,7 +36,7 @@ export default class ToggleSpeakerBtn extends Parent {
     this.setImg();
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
     this.reset();
 
     if (this.isHovered) {
@@ -48,7 +48,7 @@ export default class ToggleSpeakerBtn extends Parent {
 
     this.setImg();
 
-    super.Update();
+    super.Update(delta);
   }
 
   public Display(ctx: CanvasRenderingContext2D): void {

--- a/src/model/count.ts
+++ b/src/model/count.ts
@@ -55,7 +55,9 @@ export default class Count extends ParentClass {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public Update(): void {}
+  public Update(delta: number): void {
+    void delta;
+  }
 
   public Display(context: CanvasRenderingContext2D): void {
     const numArr: string[] = String(this.currentValue).split('');

--- a/src/model/flash-screen.ts
+++ b/src/model/flash-screen.ts
@@ -72,7 +72,8 @@ export default class FlashScreen extends ParentClass {
     return { ...this.fadeEvent.status, value: this.value };
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
+    void delta;
     if (!this.status.complete || this.status.running) {
       this.value = this.fadeEvent.value;
 

--- a/src/model/pipe-generator.ts
+++ b/src/model/pipe-generator.ts
@@ -120,7 +120,7 @@ export default class PipeGenerator {
     };
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
     if (this.needPipe()) {
       const pipe = new Pipe();
 
@@ -134,7 +134,7 @@ export default class PipeGenerator {
     }
 
     for (let index = 0; index < this.pipes.length; index++) {
-      this.pipes[index].Update();
+      this.pipes[index].Update(delta);
       if (this.pipes[index].isOut()) {
         this.pipes.splice(index, 1);
         index--;

--- a/src/model/pipe.ts
+++ b/src/model/pipe.ts
@@ -146,8 +146,8 @@ export default class Pipe extends ParentClass {
   /**
    * Pipe Update
    * */
-  public Update(): void {
-    this.coordinate.x -= this.velocity.x;
+  public Update(delta: number): void {
+    this.coordinate.x -= this.velocity.x * delta;
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/platform.ts
+++ b/src/model/platform.ts
@@ -42,13 +42,13 @@ export default class Platform extends ParentClass {
     this.coordinate.y = height - this.platformSize.height;
   }
 
-  public Update() {
+  public Update(delta: number): void {
     /**
      * We use linear interpolation instead of by pixel to move the object.
      * It is to keep the speed same in different Screen Sizes & Screen DPI
      * */
-    this.coordinate.x += this.canvasSize.width * this.velocity.x;
-    this.coordinate.y += this.velocity.y;
+    this.coordinate.x += this.canvasSize.width * this.velocity.x * delta;
+    this.coordinate.y += this.velocity.y * delta;
   }
 
   public Display(context: CanvasRenderingContext2D) {

--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -102,11 +102,11 @@ export default class ScoreBoard extends ParentObject {
     this.toggleSpeakerButton.resize(this.canvasSize);
   }
 
-  public Update(): void {
-    this.rankingButton.Update();
-    this.playButton.Update();
-    this.spark.Update();
-    this.toggleSpeakerButton.Update();
+  public Update(delta: number): void {
+    this.rankingButton.Update(delta);
+    this.playButton.Update(delta);
+    this.spark.Update(delta);
+    this.toggleSpeakerButton.Update(delta);
   }
 
   public Display(context: CanvasRenderingContext2D): void {
@@ -173,12 +173,7 @@ export default class ScoreBoard extends ParentObject {
       }
 
       this.displayScore(context, anim, sbScaled);
-      this.displayBestScore(
-        context,
-        anim,
-        sbScaled,
-        (this.flags & ScoreBoard.FLAG_NEW_HIGH_SCORE) !== 0
-      );
+      this.displayBestScore(context, anim, sbScaled);
 
       if (this.FlyInAnim.status.complete && !this.FlyInAnim.status.running) {
         this.TimingEventAnim.start();
@@ -294,8 +289,7 @@ export default class ScoreBoard extends ParentObject {
   private displayBestScore(
     context: CanvasRenderingContext2D,
     coord: ICoordinate,
-    parentSize: IDimension,
-    _p0: boolean
+    parentSize: IDimension
   ): void {
     const numSize = rescaleDim(
       {
@@ -361,7 +355,7 @@ export default class ScoreBoard extends ParentObject {
     this.playButton.onClick(cb);
   }
 
-  public onShowRanks(_cb: IEmptyFunction): void {
+  public onShowRanks(): void {
     /**
      * I don't know what to do on ranking?
      *

--- a/src/model/spark.ts
+++ b/src/model/spark.ts
@@ -83,7 +83,8 @@ export default class Spark extends ParentClass {
     this.dimension = dimension;
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
+    void delta;
     if (this.status === 'stopped') return;
 
     if (this.timingEvent.value) {

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -95,14 +95,14 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.transition.resize(this.canvasSize);
   }
 
-  public Update(): void {
-    this.flashScreen.Update();
-    this.transition.Update();
-    this.scoreBoard.Update();
+  public Update(delta: number): void {
+    this.flashScreen.Update(delta);
+    this.transition.Update(delta);
+    this.scoreBoard.Update(delta);
 
     if (!this.bird.alive) {
       this.game.bgPause = true;
-      this.bird.Update();
+      this.bird.Update(delta);
       return;
     }
 
@@ -113,14 +113,15 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
           y: this.canvasSize.height * 0.48
         },
         1,
-        6
+        6,
+        delta
       );
       return;
     }
 
-    this.bannerInstruction.Update();
-    this.pipeGenerator.Update();
-    this.bird.Update();
+    this.bannerInstruction.Update(delta);
+    this.pipeGenerator.Update(delta);
+    this.bird.Update(delta);
 
     if (this.bird.isDead(this.pipeGenerator.pipes)) {
       this.flashScreen.reset();
@@ -175,7 +176,8 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     // })
   }
 
-  public click({ x, y }: ICoordinate): void {
+  public click(coord: ICoordinate): void {
+    void coord;
     if (this.gameState === 'died') return;
 
     this.state = 'playing';
@@ -184,16 +186,16 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.bird.flap();
   }
 
-  public mouseDown({ x, y }: ICoordinate): void {
+  public mouseDown(coord: ICoordinate): void {
     if (this.gameState !== 'died') return;
 
-    this.scoreBoard.mouseDown({ x, y });
+    this.scoreBoard.mouseDown(coord);
   }
 
-  public mouseUp({ x, y }: ICoordinate): void {
+  public mouseUp(coord: ICoordinate): void {
     if (this.gameState !== 'died') return;
 
-    this.scoreBoard.mouseUp({ x, y });
+    this.scoreBoard.mouseUp(coord);
   }
   public startAtKeyBoardEvent(): void {
     if (this.gameState === 'died') this.scoreBoard.triggerPlayATKeyboardEvent();

--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -52,19 +52,20 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.toggleSpeakerButton.resize({ width, height });
   }
 
-  public Update(): void {
+  public Update(delta: number): void {
     this.bird.doWave(
       {
         x: this.canvasSize.width * 0.5,
         y: this.canvasSize.height * 0.46
       },
       1.4,
-      9
+      9,
+      delta
     );
 
-    this.playButton.Update();
-    this.rankingButton.Update();
-    this.toggleSpeakerButton.Update();
+    this.playButton.Update(delta);
+    this.rankingButton.Update(delta);
+    this.toggleSpeakerButton.Update(delta);
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/utils/waves.ts
+++ b/src/utils/waves.ts
@@ -8,18 +8,46 @@
  *
  * */
 
-/**
- * Return wave value based on time using sine
- * */
-export const sine = (frequency: number, amplitude: number): number => {
-  const time = new Date().getTime();
-  return Math.sin(((time / 1000) * 2 * Math.PI) / (1 / frequency)) * amplitude;
+export interface IWaveState {
+  phase: number;
+}
+
+export const createWaveState = (): IWaveState => ({ phase: 0 });
+
+const FULL_ROTATION = Math.PI * 2;
+
+const advancePhase = (state: IWaveState, delta: number, frequency: number): void => {
+  const deltaSeconds = delta / 60;
+  state.phase = (state.phase + FULL_ROTATION * frequency * deltaSeconds) % FULL_ROTATION;
+  if (state.phase < 0) {
+    state.phase += FULL_ROTATION;
+  }
 };
 
 /**
- * Return wave value based on time using cosine. Its your choice
- * */
-export const cosine = (frequency: number, amplitude: number): number => {
-  const time = new Date().getTime();
-  return Math.sin(((time / 1000) * 2 * Math.PI) / (1 / frequency)) * amplitude;
+ * Return wave value based on accumulated phase using sine. The delta parameter
+ * is normalized against 60 FPS (delta === 1 === 16.66ms).
+ */
+export const sine = (
+  state: IWaveState,
+  delta: number,
+  frequency: number,
+  amplitude: number
+): number => {
+  advancePhase(state, delta, frequency);
+  return Math.sin(state.phase) * amplitude;
+};
+
+/**
+ * Return wave value based on accumulated phase using cosine. The delta parameter
+ * is normalized against 60 FPS (delta === 1 === 16.66ms).
+ */
+export const cosine = (
+  state: IWaveState,
+  delta: number,
+  frequency: number,
+  amplitude: number
+): number => {
+  advancePhase(state, delta, frequency);
+  return Math.cos(state.phase) * amplitude;
 };


### PR DESCRIPTION
## Summary
- compute frame delta in the main loop and drive the new `Game.update(delta)`/`Game.render()` lifecycle
- propagate the delta parameter through game objects, screens, and helpers to scale motion and animations consistently
- clamp oversized deltas to avoid frame skips and update sine-wave utilities to use delta-normalized phases

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b769b2688328ab4d6010905a5a1f