### PR TITLE
Add pressure-aware pointer input for bird flaps

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -144,13 +144,13 @@ export default class Game extends ParentClass {
     });
   }
 
-  public onClick({ x, y }: ICoordinate): void {
+  public onClick({ x, y }: ICoordinate, pressure?: number): void {
     if (this.state === 'game') {
-      this.gamePlay.click({ x, y });
+      this.gamePlay.click({ x, y }, pressure);
     }
   }
 
-  public mouseDown({ x, y }: ICoordinate): void {
+  public mouseDown({ x, y }: ICoordinate, _pressure?: number): void {
     this.screenIntro.mouseDown({ x, y });
     this.gamePlay.mouseDown({ x, y });
   }

--- a/src/model/bird.ts
+++ b/src/model/bird.ts
@@ -24,6 +24,8 @@ export default class Bird extends ParentClass {
   private static readonly FLAG_IS_ALIVE = 0b0001;
   private static readonly FLAG_DIED = 0b0010;
   private static readonly FLAG_DOES_LANDED = 0b0100;
+  public static readonly MIN_FLAP_STRENGTH = 0.7;
+  public static readonly MAX_FLAP_STRENGTH = 1.4;
   private flags: number;
 
   /**
@@ -185,7 +187,7 @@ export default class Bird extends ParentClass {
   /**
    * Add lift to bird that slowly decrease by weight
    * */
-  public flap(): void {
+  public flap(strength?: number): void {
     // Prevent flapping when the height of bird is
     // at the very top of canvas or the bird is not alive
     if (this.coordinate.y < 0 || (this.flags & Bird.FLAG_IS_ALIVE) === 0) {
@@ -193,7 +195,12 @@ export default class Bird extends ParentClass {
     }
 
     Sfx.wing();
-    this.velocity.y = this.force;
+    const multiplier =
+      typeof strength === 'number' && Number.isFinite(strength)
+        ? clamp(Bird.MIN_FLAP_STRENGTH, Bird.MAX_FLAP_STRENGTH, strength)
+        : 1;
+
+    this.velocity.y = this.force * multiplier;
     this.lastCoord = this.coordinate.y;
   }
 

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -16,6 +16,7 @@ import ParentClass from '../abstracts/parent-class';
 import PipeGenerator from '../model/pipe-generator';
 import ScoreBoard from '../model/score-board';
 import Sfx from '../model/sfx';
+import { clamp } from '../utils';
 
 export type IGameState = 'died' | 'playing' | 'none';
 export default class GetReady extends ParentClass implements IScreenChangerObject {
@@ -175,13 +176,22 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     // })
   }
 
-  public click({ x, y }: ICoordinate): void {
+  public click(_coordinate: ICoordinate, pressure?: number): void {
     if (this.gameState === 'died') return;
 
     this.state = 'playing';
     this.gameState = 'playing';
     this.bannerInstruction.tap();
-    this.bird.flap();
+
+    if (typeof pressure === 'number' && Number.isFinite(pressure)) {
+      const normalized = clamp(0, 1, pressure);
+      const strength =
+        BirdModel.MIN_FLAP_STRENGTH +
+        (BirdModel.MAX_FLAP_STRENGTH - BirdModel.MIN_FLAP_STRENGTH) * normalized;
+      this.bird.flap(strength);
+    } else {
+      this.bird.flap();
+    }
   }
 
   public mouseDown({ x, y }: ICoordinate): void {


### PR DESCRIPTION
## Summary
- detect pointer events and capture stylus pressure while preserving mouse/touch fallbacks
- propagate normalized pressure through game click handling so bird flaps can scale with input strength
- clamp flap strength in the bird model to stay within safe minimum and maximum multipliers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b76f85788328822c0d89dd3fcee1