### PR TITLE
Add slow-motion window to death transition

### DIFF
--- a/src/model/pipe-generator.ts
+++ b/src/model/pipe-generator.ts
@@ -120,8 +120,8 @@ export default class PipeGenerator {
     };
   }
 
-  public Update(): void {
-    if (this.needPipe()) {
+  public Update(delta = 1, allowSpawn = true): void {
+    if (allowSpawn && this.needPipe()) {
       const pipe = new Pipe();
 
       pipe.init();
@@ -134,7 +134,7 @@ export default class PipeGenerator {
     }
 
     for (let index = 0; index < this.pipes.length; index++) {
-      this.pipes[index].Update();
+      this.pipes[index].Update(delta);
       if (this.pipes[index].isOut()) {
         this.pipes.splice(index, 1);
         index--;

--- a/src/model/pipe.ts
+++ b/src/model/pipe.ts
@@ -146,8 +146,8 @@ export default class Pipe extends ParentClass {
   /**
    * Pipe Update
    * */
-  public Update(): void {
-    this.coordinate.x -= this.velocity.x;
+  public Update(delta = 1): void {
+    this.coordinate.x -= this.velocity.x * delta;
   }
 
   public Display(context: CanvasRenderingContext2D): void {


### PR DESCRIPTION
## Summary
- add a slow motion controller to gameplay that eases the update delta using the flash-screen animation and pauses scoring/pipe spawns while active
- teach the bird, pipes, and pipe generator to respect delta modifiers and gate score increments when slow motion is applied
- reset the slow motion state during scoreboard animations and gameplay resets so the effect is brief and does not affect restarts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b77406788328bbb6ea467e59d8b6