### PR TITLE
Improve canvas rendering on high-DPI displays

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -28,10 +28,16 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
     }
   };
 
+  const getLogicalSize = () => ({
+    width: Number(canvas.dataset.logicalWidth ?? canvas.width),
+    height: Number(canvas.dataset.logicalHeight ?? canvas.height)
+  });
+
   const getBoundedPosition = ({ x, y }: ICoordinate): ICoordinate => {
     const { left, top, width, height } = canvas.getBoundingClientRect();
-    const dx: number = ((x - left) / width) * canvas.width;
-    const dy: number = ((y - top) / height) * canvas.height;
+    const logicalSize = getLogicalSize();
+    const dx: number = ((x - left) / width) * logicalSize.width;
+    const dy: number = ((y - top) / height) * logicalSize.height;
 
     return { x: dx, y: dy };
   };
@@ -135,10 +141,12 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
     ) {
       Game.startAtKeyBoardEvent();
 
+      const logicalSize = getLogicalSize();
+
       mouseDown(
         {
-          x: canvas.width / 2,
-          y: canvas.height / 2
+          x: logicalSize.width / 2,
+          y: logicalSize.height / 2
         },
         evt
       );
@@ -156,10 +164,12 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
       code === 'NumpadEnter' ||
       code === 'Enter'
     ) {
+      const logicalSize = getLogicalSize();
+
       mouseUP(
         {
-          x: canvas.width / 2,
-          y: canvas.height / 2
+          x: logicalSize.width / 2,
+          y: logicalSize.height / 2
         },
         evt,
         false

--- a/src/game.ts
+++ b/src/game.ts
@@ -26,6 +26,7 @@ export default class Game extends ParentClass {
   private screenIntro: Intro;
   private gamePlay: GamePlay;
   private state: IGameState;
+  private devicePixelRatio: number;
 
   constructor(canvas: HTMLCanvasElement) {
     super();
@@ -42,6 +43,7 @@ export default class Game extends ParentClass {
     this.gamePlay = new GamePlay(this);
     this.state = 'intro';
     this.bgPause = false;
+    this.devicePixelRatio = 1;
     this.transition = new FlashScreen({
       interval: 700,
       strong: 1,
@@ -78,10 +80,11 @@ export default class Game extends ParentClass {
   public reset(): void {
     this.background.reset();
     this.platform.reset();
-    this.Resize(this.canvasSize);
+    this.Resize(this.canvasSize, this.devicePixelRatio);
   }
 
-  public Resize({ width, height }: IDimension): void {
+  public Resize({ width, height }: IDimension, devicePixelRatio = 1): void {
+    this.devicePixelRatio = devicePixelRatio;
     super.resize({ width, height });
     this.background.resize(this.canvasSize);
     this.platform.resize(this.canvasSize);
@@ -96,8 +99,14 @@ export default class Game extends ParentClass {
 
     this.screenIntro.resize(this.canvasSize);
     this.gamePlay.resize(this.canvasSize);
-    this.canvas.width = width;
-    this.canvas.height = height;
+    const scaledWidth = Math.round(width * this.devicePixelRatio);
+    const scaledHeight = Math.round(height * this.devicePixelRatio);
+
+    this.canvas.width = scaledWidth;
+    this.canvas.height = scaledHeight;
+
+    this.context.setTransform(1, 0, 0, 1, 0, 0);
+    this.context.scale(this.devicePixelRatio, this.devicePixelRatio);
   }
 
   public Update(): void {
@@ -113,7 +122,7 @@ export default class Game extends ParentClass {
   }
 
   public Display(): void {
-    this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.context.clearRect(0, 0, this.canvasSize.width, this.canvasSize.height);
     // Remove smoothing effect of an image
     this.context.imageSmoothingEnabled = false;
     this.context.imageSmoothingQuality = 'high';

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,21 +50,30 @@ const GameUpdate = (): void => {
 };
 
 const ScreenResize = () => {
-  const sizeResult = rescaleDim(CANVAS_DIMENSION, {
-    height: window.innerHeight * 2 - 50
+  const devicePixelRatio = window.devicePixelRatio || 1;
+  const logicalHeight = Math.max(window.innerHeight - 50, 1);
+  const logicalSize = rescaleDim(CANVAS_DIMENSION, {
+    height: logicalHeight
   });
+  const physicalWidth = Math.round(logicalSize.width * devicePixelRatio);
+  const physicalHeight = Math.round(logicalSize.height * devicePixelRatio);
 
-  canvas.style.maxWidth = String(sizeResult.width / 2) + 'px';
-  canvas.style.maxHeight = String(sizeResult.height / 2) + 'px';
+  canvas.style.width = `${logicalSize.width}px`;
+  canvas.style.height = `${logicalSize.height}px`;
+  canvas.dataset.logicalWidth = String(logicalSize.width);
+  canvas.dataset.logicalHeight = String(logicalSize.height);
+  canvas.dataset.devicePixelRatio = String(devicePixelRatio);
 
-  canvas.height = sizeResult.height;
-  canvas.width = sizeResult.width;
-  virtualCanvas.height = sizeResult.height;
-  virtualCanvas.width = sizeResult.width;
+  canvas.width = physicalWidth;
+  canvas.height = physicalHeight;
+  virtualCanvas.width = physicalWidth;
+  virtualCanvas.height = physicalHeight;
 
-  console.log(`Canvas Size: ${sizeResult.width}x${sizeResult.height}`);
+  console.log(
+    `Canvas Size: ${logicalSize.width}x${logicalSize.height} (DPR: ${devicePixelRatio})`
+  );
 
-  Game.Resize(sizeResult);
+  Game.Resize(logicalSize, devicePixelRatio);
 };
 
 const removeLoadingScreen = () => {


### PR DESCRIPTION
## Summary
- detect the device pixel ratio during resize and size the physical and logical canvases accordingly
- scale the virtual canvas context with the device pixel ratio to keep rendering sharp while maintaining double buffering
- update event handling to use the logical canvas size so pointer and keyboard interactions stay aligned after scaling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b776e6b08328a72ff54375edf552