### PR TITLE
Optimize canvas state usage during rendering

### DIFF
--- a/src/lib/stats/index.ts
+++ b/src/lib/stats/index.ts
@@ -70,6 +70,8 @@ export default class Stats {
   private drawContainer(): void {
     const ctx = this.context;
     const { startingPoint, endPoint } = this.containerProps;
+    const previousAlpha = ctx.globalAlpha;
+    const previousFillStyle = ctx.fillStyle;
 
     ctx.beginPath();
     ctx.globalAlpha = this.containerOpacity;
@@ -77,12 +79,19 @@ export default class Stats {
     ctx.fillRect(startingPoint.x, startingPoint.y, endPoint.x, endPoint.y);
     ctx.fill();
     ctx.closePath();
+
+    ctx.globalAlpha = previousAlpha;
+    ctx.fillStyle = previousFillStyle;
   }
 
   private drawText(text: string) {
     const ctx = this.context;
     const { preText, postText, position } = this.textProps;
     const out = `${preText}${text}${postText}`;
+    const previousAlpha = ctx.globalAlpha;
+    const previousFont = ctx.font;
+    const previousFillStyle = ctx.fillStyle;
+    const previousTextAlign = ctx.textAlign;
 
     ctx.beginPath();
     ctx.globalAlpha = 1; // Required
@@ -91,5 +100,10 @@ export default class Stats {
     ctx.textAlign = 'left';
     ctx.fillText(out, position.x, position.y);
     ctx.closePath();
+
+    ctx.globalAlpha = previousAlpha;
+    ctx.font = previousFont;
+    ctx.fillStyle = previousFillStyle;
+    ctx.textAlign = previousTextAlign;
   }
 }

--- a/src/model/background.ts
+++ b/src/model/background.ts
@@ -84,6 +84,7 @@ export default class Background extends ParentClass {
   public Display(context: CanvasRenderingContext2D): void {
     const { width, height } = this.backgroundSize;
     const { x, y } = this.coordinate;
+    const themeImage = this.images.get(this.theme)!;
 
     // Get how many sequence we need to fill the screen
     const sequence = Math.ceil(this.canvasSize.width / width) + 1;
@@ -95,13 +96,7 @@ export default class Background extends ParentClass {
 
     // Draw the background next to each other in given sequence
     for (let i = 0; i < sequence; i++) {
-      context.drawImage(
-        this.images.get(this.theme)!,
-        i * (width - i) - offset,
-        y,
-        width,
-        height
-      );
+      context.drawImage(themeImage, i * (width - i) - offset, y, width, height);
     }
   }
 }

--- a/src/model/banner-instruction.ts
+++ b/src/model/banner-instruction.ts
@@ -143,6 +143,7 @@ export default class BannerInstruction extends ParentClass {
   public Display(context: CanvasRenderingContext2D): void {
     if (this.opacity <= 0) return;
 
+    const previousAlpha = context.globalAlpha;
     context.globalAlpha = this.opacity;
 
     context.drawImage(
@@ -161,6 +162,6 @@ export default class BannerInstruction extends ParentClass {
       this.instructImage.scaled.height
     );
 
-    context.globalAlpha = 1;
+    context.globalAlpha = previousAlpha;
   }
 }

--- a/src/model/bird.ts
+++ b/src/model/bird.ts
@@ -338,19 +338,19 @@ export default class Bird extends ParentClass {
 
   public Display(context: CanvasRenderingContext2D): void {
     const birdKeyString = `${this.color}.${this.wingState}`;
-
-    // Save our previous created picture
-    context.save();
+    const image = this.images.get(birdKeyString)!;
+    const { x, y } = this.coordinate;
+    const previousTransform = context.getTransform();
 
     // Move the imaginary cursor into the bird position
-    context.translate(this.coordinate.x, this.coordinate.y);
+    context.translate(x, y);
 
     // Rotate the context using the code above as mid point
     context.rotate((this.rotation * Math.PI) / 180);
 
     // Start the image at top-left then bottom-right
     context.drawImage(
-      this.images.get(birdKeyString)!,
+      image,
       -this.scaled.width,
       -this.scaled.height,
       this.scaled.width * 2,
@@ -358,6 +358,6 @@ export default class Bird extends ParentClass {
     );
 
     // Restore the previously created picture but keeping the bird
-    context.restore();
+    context.setTransform(previousTransform);
   }
 }

--- a/src/model/flash-screen.ts
+++ b/src/model/flash-screen.ts
@@ -90,10 +90,14 @@ export default class FlashScreen extends ParentClass {
   }
 
   public Display(context: CanvasRenderingContext2D): void {
+    const previousAlpha = context.globalAlpha;
+    const previousFillStyle = context.fillStyle;
+
     context.globalAlpha = this.strong * this.value;
     context.fillStyle = this.style;
     context.fillRect(0, 0, this.canvasSize.width, this.canvasSize.height);
     context.fill();
-    context.globalAlpha = 1;
+    context.globalAlpha = previousAlpha;
+    context.fillStyle = previousFillStyle;
   }
 }

--- a/src/model/pipe.ts
+++ b/src/model/pipe.ts
@@ -156,6 +156,8 @@ export default class Pipe extends ParentClass {
     const posX = this.coordinate.x;
     const posY = this.coordinate.y;
     const radius = this.hollSize / 2;
+    const topImage = this.images.get(`${this.color}.top`)!;
+    const bottomImage = this.images.get(`${this.color}.bottom`)!;
 
     /**
      * To draw off canvas, subtract the height of pipe to holl position.
@@ -166,7 +168,7 @@ export default class Pipe extends ParentClass {
      * */
 
     context.drawImage(
-      this.images.get(`${this.color}.top`)!,
+      topImage,
       posX - width,
       -(this.scaled.top.height - Math.abs(posY - radius)),
       this.scaled.top.width,
@@ -174,7 +176,7 @@ export default class Pipe extends ParentClass {
     );
 
     context.drawImage(
-      this.images.get(`${this.color}.bottom`)!,
+      bottomImage,
       posX - width,
       posY + radius,
       this.scaled.bottom.width,

--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -110,33 +110,38 @@ export default class ScoreBoard extends ParentObject {
   }
 
   public Display(context: CanvasRenderingContext2D): void {
+    const images = this.images;
+
     if ((this.flags & ScoreBoard.FLAG_SHOW_BANNER) !== 0) {
+      const bannerImage = images.get('banner-gameover')!;
       const bgoScaled = rescaleDim(
         {
-          width: this.images.get('banner-gameover')!.width,
-          height: this.images.get('banner-gameover')!.height
+          width: bannerImage.width,
+          height: bannerImage.height
         },
         { width: this.canvasSize.width * 0.7 }
       );
       const anim = this.BounceInAnim.value;
       const yPos = this.canvasSize.height * 0.225 - bgoScaled.height / 2;
 
+      const previousAlpha = context.globalAlpha;
       context.globalAlpha = anim.opacity;
       context.drawImage(
-        this.images.get('banner-gameover')!,
+        bannerImage,
         this.canvasSize.width * 0.5 - bgoScaled.width / 2,
         yPos + anim.value * (this.canvasSize.height * 0.015),
         bgoScaled.width,
         bgoScaled.height
       );
-      context.globalAlpha = 1;
+      context.globalAlpha = previousAlpha;
     }
 
     if ((this.flags & ScoreBoard.FLAG_SHOW_SCOREBOARD) !== 0) {
+      const scoreboardImage = images.get('score-board')!;
       const sbScaled = rescaleDim(
         {
-          width: this.images.get('score-board')!.width,
-          height: this.images.get('score-board')!.height
+          width: scoreboardImage.width,
+          height: scoreboardImage.height
         },
         { width: this.canvasSize.width * 0.85 }
       );
@@ -146,13 +151,7 @@ export default class ScoreBoard extends ParentObject {
       anim.x = this.canvasSize.width * anim.x - sbScaled.width / 2;
       anim.y = this.canvasSize.height * anim.y - sbScaled.height / 2;
 
-      context.drawImage(
-        this.images.get('score-board')!,
-        anim.x,
-        anim.y,
-        sbScaled.width,
-        sbScaled.height
-      );
+      context.drawImage(scoreboardImage, anim.x, anim.y, sbScaled.width, sbScaled.height);
 
       if (this.TimingEventAnim.value && this.currentScore > this.currentGeneratedNumber) {
         this.currentGeneratedNumber++;
@@ -266,10 +265,11 @@ export default class ScoreBoard extends ParentObject {
     coord: ICoordinate,
     parentSize: IDimension
   ): void {
+    const images = this.images;
     const numSize = rescaleDim(
       {
-        width: this.images.get('number-1')!.width,
-        height: this.images.get('number-1')!.height
+        width: images.get('number-1')!.width,
+        height: images.get('number-1')!.height
       },
       { width: parentSize.width * 0.05 }
     );
@@ -280,10 +280,12 @@ export default class ScoreBoard extends ParentObject {
 
     const numArr: string[] = String(this.currentGeneratedNumber).split('');
 
+    const spacing = numSize.width + 5;
     numArr.reverse().forEach((c: string, index: number) => {
+      const digitImage = images.get(`number-${c}`)!;
       context.drawImage(
-        this.images.get(`number-${c}`)!,
-        coord.x - index * (numSize.width + 5),
+        digitImage,
+        coord.x - index * spacing,
         coord.y,
         numSize.width,
         numSize.height
@@ -297,10 +299,11 @@ export default class ScoreBoard extends ParentObject {
     parentSize: IDimension,
     _p0: boolean
   ): void {
+    const images = this.images;
     const numSize = rescaleDim(
       {
-        width: this.images.get('number-1')!.width,
-        height: this.images.get('number-1')!.height
+        width: images.get('number-1')!.width,
+        height: images.get('number-1')!.height
       },
       { width: parentSize.width * 0.05 }
     );
@@ -312,10 +315,12 @@ export default class ScoreBoard extends ParentObject {
 
     const numArr: string[] = String(this.currentHighScore).split('');
 
+    const spacing = numSize.width + 5;
     numArr.reverse().forEach((c: string, index: number) => {
+      const digitImage = images.get(`number-${c}`)!;
       context.drawImage(
-        this.images.get(`number-${c}`)!,
-        coord.x - index * (numSize.width + 5),
+        digitImage,
+        coord.x - index * spacing,
         coord.y,
         numSize.width,
         numSize.height
@@ -326,14 +331,14 @@ export default class ScoreBoard extends ParentObject {
 
     const toastSize = rescaleDim(
       {
-        width: this.images.get('new-icon')!.width,
-        height: this.images.get('new-icon')!.height
+        width: images.get('new-icon')!.width,
+        height: images.get('new-icon')!.height
       },
       { width: parentSize.width * 0.14 }
     );
 
     context.drawImage(
-      this.images.get('new-icon')!,
+      images.get('new-icon')!,
       coord.x * 0.73,
       coord.y * 0.922,
       toastSize.width,


### PR DESCRIPTION
## Summary
- replace per-draw save/restore cycles with manual transform restoration for the bird renderer
- batch canvas state changes (alpha, fill style, text styling) and restore previous values across renderers
- reuse cached sprite references inside loops when drawing backgrounds, pipes, and scoreboard digits

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e1b77a2e1483289ab0ae39b04ed7bd