### PR TITLE
Add settings toggle for sprite smoothing

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,24 @@
   </head>
   <body>
     <canvas id="main-canvas"></canvas>
+    <div id="settings-panel" class="settings-panel">
+      <h2 class="settings-panel__title">Settings</h2>
+      <label class="settings-toggle">
+        <input
+          type="checkbox"
+          id="settings-smoothing-toggle"
+          class="settings-toggle__control"
+        />
+        <span class="settings-toggle__text">Smooth sprites</span>
+        <span
+          class="settings-toggle__status"
+          data-setting-smoothing-status
+          aria-live="polite"
+        >
+          Off
+        </span>
+      </label>
+    </div>
     <div id="loading-modal">
       <div>Loading</div>
       <div class="lds-ellipsis">

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,12 @@ const gameIcon = document.createElement('img');
 const canvas = document.querySelector<HTMLCanvasElement>('#main-canvas')!;
 const physicalContext = canvas.getContext('2d')!;
 const loadingScreen = document.querySelector<HTMLDivElement>('#loading-modal')!;
+const smoothingToggle = document.querySelector<HTMLInputElement>(
+  '#settings-smoothing-toggle'
+);
+const smoothingStatusLabel = document.querySelector<HTMLSpanElement>(
+  '[data-setting-smoothing-status]'
+);
 const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
 
@@ -37,6 +43,30 @@ gameIcon.src = gameSpriteIcon;
 fps.text({ x: 50, y: 50 }, '', ' Cycle');
 // prettier-ignore
 fps.container({ x: 10, y: 10}, { x: 230, y: 70});
+
+const updateSmoothingUIState = (enabled: boolean) => {
+  if (smoothingToggle) {
+    smoothingToggle.checked = enabled;
+    smoothingToggle.setAttribute('aria-pressed', String(enabled));
+  }
+
+  if (smoothingStatusLabel) {
+    smoothingStatusLabel.textContent = enabled ? 'On' : 'Off';
+    smoothingStatusLabel.dataset.state = enabled ? 'on' : 'off';
+  }
+};
+
+const bindSettingsPanel = () => {
+  if (!smoothingToggle) return;
+
+  updateSmoothingUIState(Game.isSmoothingEnabled);
+
+  smoothingToggle.addEventListener('change', () => {
+    const enabled = smoothingToggle.checked;
+    Game.setSmoothingPreference(enabled);
+    updateSmoothingUIState(enabled);
+  });
+};
 
 const GameUpdate = (): void => {
   physicalContext.drawImage(virtualCanvas, 0, 0);
@@ -85,6 +115,8 @@ window.addEventListener('DOMContentLoaded', () => {
     isLoaded = true;
 
     Game.init();
+
+    bindSettingsPanel();
 
     ScreenResize();
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -30,6 +30,58 @@ body {
     position: absolute;
   }
 
+  > .settings-panel {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 16px;
+    border-radius: 12px;
+    background: rgba(242, 242, 244, 0.8);
+    backdrop-filter: blur(8px);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.15);
+    font-family: 'Arial', 'Sans-Serif';
+    color: rgba(28, 28, 30, 1);
+    min-width: 210px;
+
+    &__title {
+      font-size: 0.9rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin: 0;
+    }
+
+    .settings-toggle {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.95rem;
+      font-weight: 500;
+      cursor: pointer;
+      user-select: none;
+
+      &__control {
+        width: 18px;
+        height: 18px;
+        accent-color: rgba(88, 86, 214, 1);
+        cursor: pointer;
+      }
+
+      &__text {
+        flex: 1;
+      }
+
+      &__status {
+        font-weight: 600;
+        min-width: 32px;
+        text-align: right;
+      }
+    }
+  }
+
   > #loading-modal {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- persist a sprite smoothing preference and apply it from the game loop
- expose a settings panel toggle that updates the stored smoothing setting and styles it in the UI

## Testing
- npm run lint *(warnings: pre-existing unused variable warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b77af3d08328bda76245eae47fbd