### PR TITLE
feat: run game loop in an offscreen worker

### DIFF
--- a/src/abstracts/button-event-handler.ts
+++ b/src/abstracts/button-event-handler.ts
@@ -17,6 +17,8 @@
  * */
 
 import { rescaleDim } from '../utils';
+import type { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 
 export type IMouseState = 'down' | 'up';
 
@@ -24,7 +26,7 @@ export default abstract class ButtonEventHandler {
   public active: boolean;
 
   protected coordinate: ICoordinate;
-  protected img: HTMLImageElement | undefined;
+  protected img: SpriteAsset | undefined;
   protected initialWidth: number; // lerp - %
   protected dimension: IDimension;
   protected calcCoord: ICoordinate;
@@ -151,5 +153,5 @@ export default abstract class ButtonEventHandler {
    * touch event, sliding the finger out of button
    * */
   public abstract click(): void;
-  public abstract Display(context: CanvasRenderingContext2D): void;
+  public abstract Display(context: RenderingContext2D): void;
 }

--- a/src/abstracts/parent-class.ts
+++ b/src/abstracts/parent-class.ts
@@ -1,4 +1,6 @@
 // File Overview: This module belongs to src/abstracts/parent-class.ts.
+import type { RenderingContext2D } from '../types/rendering-context';
+
 export default abstract class ParentObject {
   protected canvasSize: IDimension;
   public velocity: IVelocity;
@@ -27,5 +29,5 @@ export default abstract class ParentObject {
 
   public abstract init(): void;
   public abstract Update(): void;
-  public abstract Display(context: CanvasRenderingContext2D): void;
+  public abstract Display(context: RenderingContext2D): void;
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,12 +3,18 @@
  * Interactive
  */
 
-import Game from './game';
 import WebSfx from './lib/web-sfx';
 
 export type IEventParam = MouseEvent | TouchEvent | KeyboardEvent;
 
-export default (Game: Game, canvas: HTMLCanvasElement) => {
+export interface GameInputTarget {
+  onClick(position: ICoordinate): void;
+  mouseDown(position: ICoordinate): void;
+  mouseUp(position: ICoordinate): void;
+  startAtKeyBoardEvent(): void;
+}
+
+export default (Game: GameInputTarget, canvas: HTMLCanvasElement) => {
   interface IMouse {
     down: boolean;
     position: ICoordinate;

--- a/src/game.ts
+++ b/src/game.ts
@@ -17,8 +17,8 @@ export type IGameState = 'intro' | 'game';
 export default class Game extends ParentClass {
   public background: BgModel;
   public platform: PlatformModel;
-  public canvas: HTMLCanvasElement;
-  public context: CanvasRenderingContext2D;
+  public canvas: HTMLCanvasElement | OffscreenCanvas;
+  public context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   public pipeGenerator: PipeGenerator;
   public bgPause: boolean;
   private screenChanger: ScreenChanger;
@@ -27,15 +27,21 @@ export default class Game extends ParentClass {
   private gamePlay: GamePlay;
   private state: IGameState;
 
-  constructor(canvas: HTMLCanvasElement) {
+  constructor(canvas: HTMLCanvasElement | OffscreenCanvas) {
     super();
     this.screenChanger = new ScreenChanger();
     this.background = new BgModel();
     this.canvas = canvas;
-    this.context = this.canvas.getContext('2d', {
+    const context = this.canvas.getContext('2d', {
       desynchronized: true,
       alpha: false
-    })!;
+    });
+
+    if (!context) {
+      throw new Error('Failed to acquire 2D rendering context');
+    }
+
+    this.context = context as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
     this.platform = new PlatformModel();
     this.pipeGenerator = new PipeGenerator();
     this.screenIntro = new Intro();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,99 +5,273 @@ import '@total-typescript/ts-reset';
 
 import { framer as Framer, rescaleDim } from './utils';
 import { CANVAS_DIMENSION } from './constants';
-import EventHandler from './events';
+import EventHandler, { GameInputTarget } from './events';
 import GameObject from './game';
 import prepareAssets from './asset-preparation';
 import createRAF, { targetFPS } from '@solid-primitives/raf';
 import SwOffline from './lib/workbox-work-offline';
+import SpriteDestructor, { SpriteAsset } from './lib/sprite-destructor';
+import Storage from './lib/storage';
+import Sfx from './model/sfx';
+import type {
+  SpriteBitmapTransfer,
+  WorkerToMainMessage,
+  WorkerAudioMessage
+} from './workers/messages';
 
 if (process.env.NODE_ENV === 'production') {
   SwOffline();
 }
 
-/**
- * Enabling desynchronized to reduce latency
- * but the frame tearing may experience so
- * we'll need double buffer to atleast reduce
- * the frame tearing
- * */
-const virtualCanvas = document.createElement('canvas');
+const isDevelopment = process.env.NODE_ENV === 'development';
+
 const gameIcon = document.createElement('img');
 const canvas = document.querySelector<HTMLCanvasElement>('#main-canvas')!;
-const physicalContext = canvas.getContext('2d')!;
 const loadingScreen = document.querySelector<HTMLDivElement>('#loading-modal')!;
-const Game = new GameObject(virtualCanvas);
-const fps = new Framer(Game.context);
-
-let isLoaded = false;
 
 gameIcon.src = gameSpriteIcon;
 
-// prettier-ignore
-fps.text({ x: 50, y: 50 }, '', ' Cycle');
-// prettier-ignore
-fps.container({ x: 10, y: 10}, { x: 230, y: 70});
+new Storage();
 
-const GameUpdate = (): void => {
-  physicalContext.drawImage(virtualCanvas, 0, 0);
+const supportsOffscreen = typeof (canvas as HTMLCanvasElement).transferControlToOffscreen === 'function';
 
-  Game.Update();
-  Game.Display();
+const isImageBitmap = (asset: SpriteAsset): asset is ImageBitmap =>
+  typeof (asset as ImageBitmap).close === 'function';
 
-  if (process.env.NODE_ENV === 'development') fps.mark();
-
-  // raf(GameUpdate); Issue #16
-};
-
-const ScreenResize = () => {
+const applyCanvasSize = (): IDimension => {
   const sizeResult = rescaleDim(CANVAS_DIMENSION, {
     height: window.innerHeight * 2 - 50
   });
 
-  canvas.style.maxWidth = String(sizeResult.width / 2) + 'px';
-  canvas.style.maxHeight = String(sizeResult.height / 2) + 'px';
-
-  canvas.height = sizeResult.height;
+  canvas.style.maxWidth = `${sizeResult.width / 2}px`;
+  canvas.style.maxHeight = `${sizeResult.height / 2}px`;
   canvas.width = sizeResult.width;
-  virtualCanvas.height = sizeResult.height;
-  virtualCanvas.width = sizeResult.width;
+  canvas.height = sizeResult.height;
 
   console.log(`Canvas Size: ${sizeResult.width}x${sizeResult.height}`);
 
-  Game.Resize(sizeResult);
+  return sizeResult;
 };
 
-const removeLoadingScreen = () => {
-  EventHandler(Game, canvas);
+const removeLoadingScreen = (target: GameInputTarget) => {
+  EventHandler(target, canvas);
   loadingScreen.style.display = 'none';
   document.body.style.backgroundColor = 'rgba(28, 28, 30, 1)';
 };
 
-//
-// Quick Fix. Locking to 60fps
-// Quick fix.Long term :)
-const [game_running, game_start] = createRAF(targetFPS(GameUpdate, 60));
+const createSpriteBitmapPayload = async (): Promise<SpriteBitmapTransfer[]> => {
+  const sprites = Array.from(SpriteDestructor.entries());
+  const payload: SpriteBitmapTransfer[] = [];
+
+  for (const [name, asset] of sprites) {
+    if (isImageBitmap(asset)) {
+      payload.push({ name, bitmap: asset });
+      continue;
+    }
+
+    const bitmap = await createImageBitmap(asset);
+    payload.push({ name, bitmap });
+  }
+
+  return payload;
+};
+
+type GameRuntime = {
+  resize: () => void;
+  start: () => Promise<void>;
+};
+
+const setupMainThreadGame = (): GameRuntime => {
+  const virtualCanvas = document.createElement('canvas');
+  const physicalContext = canvas.getContext('2d')!;
+  const Game = new GameObject(virtualCanvas);
+  const fps = new Framer(Game.context);
+
+  fps.text({ x: 50, y: 50 }, '', ' Cycle');
+  fps.container({ x: 10, y: 10 }, { x: 230, y: 70 });
+
+  const render = () => {
+    physicalContext.drawImage(virtualCanvas, 0, 0);
+    Game.Update();
+    Game.Display();
+
+    if (isDevelopment) fps.mark();
+  };
+
+  const [running, start] = createRAF(targetFPS(render, 60));
+
+  const resize = () => {
+    const size = applyCanvasSize();
+    virtualCanvas.width = size.width;
+    virtualCanvas.height = size.height;
+    Game.Resize(size);
+  };
+
+  const startGame = async () => {
+    Game.init();
+    resize();
+
+    if (!running()) start();
+
+    if (isDevelopment) removeLoadingScreen(Game);
+    else window.setTimeout(() => removeLoadingScreen(Game), 1000);
+  };
+
+  return {
+    resize,
+    start: async () => {
+      await startGame();
+    }
+  };
+};
+
+const setupWorkerGame = (): GameRuntime => {
+  const worker = new Worker(new URL('./workers/game-worker.ts', import.meta.url), {
+    type: 'module'
+  });
+  const offscreenCanvas = canvas.transferControlToOffscreen();
+
+  const [running, start] = createRAF(
+    targetFPS((time) => {
+      if (!workerReady) return;
+      worker.postMessage({ type: 'frame', time });
+    }, 60)
+  );
+
+  let workerReady = false;
+  let pendingSize: IDimension | null = null;
+
+  const forwardInput: GameInputTarget = {
+    onClick(position: ICoordinate) {
+      worker.postMessage({ type: 'pointer', kind: 'click', position });
+    },
+    mouseDown(position: ICoordinate) {
+      worker.postMessage({ type: 'pointer', kind: 'down', position });
+    },
+    mouseUp(position: ICoordinate) {
+      worker.postMessage({ type: 'pointer', kind: 'up', position });
+    },
+    startAtKeyBoardEvent() {
+      worker.postMessage({ type: 'keyboard', action: 'start' });
+    }
+  };
+
+  const handleAudio = (message: WorkerAudioMessage) => {
+    switch (message.action) {
+      case 'init':
+        void Sfx.init();
+        break;
+      case 'volume':
+        if (typeof message.volume === 'number') {
+          Sfx.volume(message.volume);
+        }
+        break;
+      case 'play':
+        switch (message.sound) {
+          case 'die':
+            Sfx.die();
+            break;
+          case 'point':
+            Sfx.point();
+            break;
+          case 'swoosh':
+            Sfx.swoosh();
+            break;
+          case 'wing':
+            Sfx.wing();
+            break;
+          case 'hit':
+            Sfx.hit(() => {
+              if (typeof message.callbackId === 'number') {
+                worker.postMessage({ type: 'audio-callback', id: message.callbackId });
+              }
+            });
+            break;
+        }
+        break;
+    }
+  };
+
+  worker.addEventListener('message', (event: MessageEvent<WorkerToMainMessage>) => {
+    const data = event.data;
+
+    switch (data.type) {
+      case 'audio':
+        handleAudio(data);
+        break;
+      case 'storage':
+        Storage.save(data.key, data.value);
+        break;
+      case 'ready':
+        workerReady = true;
+        if (pendingSize) {
+          worker.postMessage({ type: 'resize', size: pendingSize });
+          pendingSize = null;
+        }
+
+        if (!running()) start();
+
+        if (isDevelopment) removeLoadingScreen(forwardInput);
+        else window.setTimeout(() => removeLoadingScreen(forwardInput), 1000);
+        break;
+    }
+  });
+
+  const resize = () => {
+    const size = applyCanvasSize();
+    pendingSize = size;
+
+    if (workerReady) {
+      worker.postMessage({ type: 'resize', size });
+      pendingSize = null;
+    }
+  };
+
+  const startGame = async () => {
+    const size = applyCanvasSize();
+    pendingSize = size;
+    const sprites = await createSpriteBitmapPayload();
+    const transferables = sprites.map(({ bitmap }) => bitmap);
+    const storagePayload = { highscore: Storage.get('highscore') };
+
+    const transferList: Transferable[] = [offscreenCanvas, ...transferables];
+
+    worker.postMessage(
+      {
+        type: 'init',
+        canvas: offscreenCanvas,
+        size,
+        isDev: isDevelopment,
+        sprites,
+        storage: storagePayload
+      },
+      transferList
+    );
+  };
+
+  return {
+    resize,
+    start: async () => {
+      await startGame();
+    }
+  };
+};
+
+const runtime: GameRuntime = supportsOffscreen ? setupWorkerGame() : setupMainThreadGame();
+
+let isLoaded = false;
 
 window.addEventListener('DOMContentLoaded', () => {
   loadingScreen.insertBefore(gameIcon, loadingScreen.childNodes[0]);
 
-  prepareAssets(() => {
+  prepareAssets(async () => {
     isLoaded = true;
-
-    Game.init();
-
-    ScreenResize();
-
-    // raf(GameUpdate); Issue #16
-    if (!game_running()) game_start(); // Quick fix. Long term :)
-
-    if (process.env.NODE_ENV === 'development') removeLoadingScreen();
-    else window.setTimeout(removeLoadingScreen, 1000);
+    await runtime.start();
   });
 });
 
 window.addEventListener('resize', () => {
   if (!isLoaded) return;
 
-  ScreenResize();
+  runtime.resize();
 });

--- a/src/lib/screen-changer/index.ts
+++ b/src/lib/screen-changer/index.ts
@@ -1,7 +1,9 @@
 // File Overview: This module belongs to src/lib/screen-changer/index.ts.
+import type { RenderingContext2D } from '../../types/rendering-context';
+
 export interface IScreenChangerObject {
   Update(): void;
-  Display(context: CanvasRenderingContext2D): void;
+  Display(context: RenderingContext2D): void;
 }
 
 export default class ScreenChanger implements IScreenChangerObject {
@@ -31,7 +33,7 @@ export default class ScreenChanger implements IScreenChangerObject {
     classObject.Update();
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     const classObject = this.objects.get(this.currentState);
 
     if (classObject === void 0) {

--- a/src/lib/sprite-destructor/index.ts
+++ b/src/lib/sprite-destructor/index.ts
@@ -8,6 +8,8 @@ export interface IPromiseImageHandled {
   img: HTMLImageElement;
 }
 
+export type SpriteAsset = HTMLImageElement | ImageBitmap;
+
 export type ICallbackModify = (
   name: string,
   img: HTMLImageElement
@@ -21,7 +23,7 @@ export default class SpriteDestructor {
   /**
    * Cache for later use
    * */
-  private static readonly cached = new Map<string, HTMLImageElement>();
+  private static readonly cached = new Map<string, SpriteAsset>();
 
   private loading: Promise<IPromiseImageHandled>[];
 
@@ -45,7 +47,7 @@ export default class SpriteDestructor {
 
         for (const result of resolved) {
           if (result.status === 'fulfilled' && 'value' in result) {
-            SpriteDestructor.cached.set(result.value.name, result.value.img);
+            SpriteDestructor.register(result.value.name, result.value.img);
             continue;
           }
           ++error_count;
@@ -61,7 +63,15 @@ export default class SpriteDestructor {
     );
   }
 
-  public static asset(key: string): HTMLImageElement {
+  public static register(name: string, asset: SpriteAsset): void {
+    SpriteDestructor.cached.set(name, asset);
+  }
+
+  public static entries(): IterableIterator<[string, SpriteAsset]> {
+    return SpriteDestructor.cached.entries();
+  }
+
+  public static asset(key: string): SpriteAsset {
     if (SpriteDestructor.cached.has(key)) return SpriteDestructor.cached.get(key)!;
 
     throw new TypeError(`Key: ${key} does not defined on SpriteDestructor`);

--- a/src/lib/stats/index.ts
+++ b/src/lib/stats/index.ts
@@ -13,12 +13,12 @@ interface IContainerProperties {
 export default class Stats {
   private fps: number;
   private timeArray: number[];
-  private context: CanvasRenderingContext2D;
+  private context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
   private containerOpacity: number;
   private textProps: ITextProperties;
   private containerProps: IContainerProperties;
 
-  constructor(context: CanvasRenderingContext2D) {
+  constructor(context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D) {
     this.fps = 0;
     this.timeArray = [];
     this.context = context;

--- a/src/model/background.ts
+++ b/src/model/background.ts
@@ -2,11 +2,12 @@
 import { BG_SPEED } from '../constants';
 import { rescaleDim } from '../utils';
 import ParentClass from '../abstracts/parent-class';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 import SceneGenerator from './scene-generator';
 
 export type ITheme = string;
-export type IRecords = Map<ITheme, HTMLImageElement>;
+export type IRecords = Map<ITheme, SpriteAsset>;
 export default class Background extends ParentClass {
   /**
    * background dimension.
@@ -18,7 +19,7 @@ export default class Background extends ParentClass {
 
   constructor() {
     super();
-    this.images = new Map<ITheme, HTMLImageElement>();
+    this.images = new Map<ITheme, SpriteAsset>();
     this.theme = 'day';
 
     this.velocity.x = BG_SPEED;
@@ -81,7 +82,7 @@ export default class Background extends ParentClass {
     this.coordinate.y += this.velocity.y;
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     const { width, height } = this.backgroundSize;
     const { x, y } = this.coordinate;
 

--- a/src/model/banner-instruction.ts
+++ b/src/model/banner-instruction.ts
@@ -3,7 +3,8 @@ import { rescaleDim } from '../utils';
 
 import { FadeOut } from '../lib/animation';
 import ParentClass from '../abstracts/parent-class';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 
 export interface IImagePositions {
   instructImage: ICoordinate;
@@ -35,7 +36,7 @@ export interface ITextureProperties {
 
   // System Variables
   position: ICoordinate;
-  image: HTMLImageElement | undefined;
+  image: SpriteAsset | undefined;
   scaled: IDimension;
 }
 
@@ -140,7 +141,7 @@ export default class BannerInstruction extends ParentClass {
     this.opacity = this.fadeOut.value;
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     if (this.opacity <= 0) return;
 
     context.globalAlpha = this.opacity;

--- a/src/model/bird.ts
+++ b/src/model/bird.ts
@@ -14,11 +14,12 @@ import { clamp, flipRange, rescaleDim, sine as sineWave } from '../utils';
 import ParentClass from '../abstracts/parent-class';
 import Pipe from './pipe';
 import Sfx from './sfx';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 import SceneGenerator from './scene-generator';
 
 export type IBirdColor = string;
-export type IBirdRecords = Map<IBirdColor, HTMLImageElement>;
+export type IBirdRecords = Map<IBirdColor, SpriteAsset>;
 
 export default class Bird extends ParentClass {
   private static readonly FLAG_IS_ALIVE = 0b0001;
@@ -76,7 +77,7 @@ export default class Bird extends ParentClass {
   constructor() {
     super();
     this.color = 'yellow';
-    this.images = new Map<string, HTMLImageElement>();
+    this.images = new Map<string, SpriteAsset>();
     this.force = 0;
     this.scaled = {
       width: 0,
@@ -336,7 +337,7 @@ export default class Bird extends ParentClass {
     this.handleRotation();
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     const birdKeyString = `${this.color}.${this.wingState}`;
 
     // Save our previous created picture

--- a/src/model/btn-play.ts
+++ b/src/model/btn-play.ts
@@ -2,6 +2,7 @@
 import Parent from '../abstracts/button-event-handler';
 import Sfx from './sfx';
 import SpriteDestructor from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 
 export default class PlayButton extends Parent {
   protected callback?: IEmptyFunction;
@@ -42,7 +43,7 @@ export default class PlayButton extends Parent {
     super.Update();
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     const xLoc = this.calcCoord.x;
     const yLoc = this.calcCoord.y;
     const xRad = this.dimension.width / 2;

--- a/src/model/btn-toggle-speaker.ts
+++ b/src/model/btn-toggle-speaker.ts
@@ -1,10 +1,11 @@
 // File Overview: This module belongs to src/model/btn-toggle-speaker.ts.
 import Parent from '../abstracts/button-event-handler';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
 import Sfx from './sfx';
+import type { RenderingContext2D } from '../types/rendering-context';
 
 export default class ToggleSpeakerBtn extends Parent {
-  private assets: Map<string, HTMLImageElement>;
+  private assets: Map<string, SpriteAsset>;
   private is_mute: boolean;
 
   constructor() {
@@ -51,7 +52,7 @@ export default class ToggleSpeakerBtn extends Parent {
     super.Update();
   }
 
-  public Display(ctx: CanvasRenderingContext2D): void {
+  public Display(ctx: RenderingContext2D): void {
     const xLoc = this.calcCoord.x;
     const yLoc = this.calcCoord.y;
     const xRad = this.dimension.width / 2;

--- a/src/model/count.ts
+++ b/src/model/count.ts
@@ -3,9 +3,10 @@ import { COUNT_COORDINATE, COUNT_DIMENSION } from '../constants';
 import { rescaleDim } from '../utils';
 
 import ParentClass from '../abstracts/parent-class';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 
-export type INumberString = Record<string, HTMLImageElement>;
+export type INumberString = Record<string, SpriteAsset>;
 
 export default class Count extends ParentClass {
   private currentValue: number;
@@ -57,7 +58,7 @@ export default class Count extends ParentClass {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   public Update(): void {}
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     const numArr: string[] = String(this.currentValue).split('');
     const totalWidth = numArr.length * this.numberDimension.width;
     let lastWidth: number = this.coordinate.x - totalWidth / 2;

--- a/src/model/flash-screen.ts
+++ b/src/model/flash-screen.ts
@@ -1,5 +1,6 @@
 // File Overview: This module belongs to src/model/flash-screen.ts.
 import ParentClass from '../abstracts/parent-class';
+import type { RenderingContext2D } from '../types/rendering-context';
 import { FadeOut } from '../lib/animation';
 import { IEasingKey } from '../lib/animation/easing';
 import { IFadingStatus } from '../lib/animation/abstracts/fading';
@@ -89,7 +90,7 @@ export default class FlashScreen extends ParentClass {
     }
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     context.globalAlpha = this.strong * this.value;
     context.fillStyle = this.style;
     context.fillRect(0, 0, this.canvasSize.width, this.canvasSize.height);

--- a/src/model/pipe.ts
+++ b/src/model/pipe.ts
@@ -2,7 +2,8 @@
 import { GAME_SPEED, PIPE_HOLL_SIZE, PIPE_INITIAL_DIMENSION } from '../constants';
 import { rescaleDim } from '../utils';
 import ParentClass from '../abstracts/parent-class';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 import SceneGenerator from './scene-generator';
 
 export interface IPipePairPosition {
@@ -15,7 +16,7 @@ export interface IPipeScaled {
 }
 
 export type IPipeColor = string;
-export type IPipeRecords = Map<IPipeColor, HTMLImageElement>;
+export type IPipeRecords = Map<IPipeColor, SpriteAsset>;
 
 export default class Pipe extends ParentClass {
   /**
@@ -36,7 +37,7 @@ export default class Pipe extends ParentClass {
 
   constructor() {
     super();
-    this.images = new Map<string, HTMLImageElement>();
+    this.images = new Map<string, SpriteAsset>();
     this.color = 'green';
     this.hollSize = 0;
     this.pipePosition = {
@@ -150,7 +151,7 @@ export default class Pipe extends ParentClass {
     this.coordinate.x -= this.velocity.x;
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     const width = Pipe.pipeSize.width / 2;
 
     const posX = this.coordinate.x;

--- a/src/model/platform.ts
+++ b/src/model/platform.ts
@@ -3,11 +3,12 @@ import { rescaleDim } from '../utils';
 
 import { GAME_SPEED } from '../constants';
 import ParentClass from '../abstracts/parent-class';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 
 export default class Platform extends ParentClass {
   public platformSize: IDimension;
-  private img: undefined | HTMLImageElement;
+  private img: undefined | SpriteAsset;
 
   constructor() {
     super();
@@ -51,7 +52,7 @@ export default class Platform extends ParentClass {
     this.coordinate.y += this.velocity.y;
   }
 
-  public Display(context: CanvasRenderingContext2D) {
+  public Display(context: RenderingContext2D) {
     /**
      * Similar to the background but drawing the image into bottom of screen
      * */

--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -6,7 +6,8 @@ import SparkModel from './spark';
 import PlayButton from './btn-play';
 import RankingButton from './btn-ranking';
 import ToggleSpeaker from './btn-toggle-speaker';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 import { Fly, BounceIn, TimingEvent } from '../lib/animation';
 import Storage from '../lib/storage';
 
@@ -18,7 +19,7 @@ export default class ScoreBoard extends ParentObject {
 
   private flags: number;
 
-  private images: Map<string, HTMLImageElement>;
+  private images: Map<string, SpriteAsset>;
   private playButton: PlayButton;
   private rankingButton: RankingButton;
   private toggleSpeakerButton: ToggleSpeaker;
@@ -33,7 +34,7 @@ export default class ScoreBoard extends ParentObject {
   constructor() {
     super();
     this.flags = 0;
-    this.images = new Map<string, HTMLImageElement>();
+    this.images = new Map<string, SpriteAsset>();
     this.playButton = new PlayButton();
     this.rankingButton = new RankingButton();
     this.toggleSpeakerButton = new ToggleSpeaker();
@@ -109,7 +110,7 @@ export default class ScoreBoard extends ParentObject {
     this.toggleSpeakerButton.Update();
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     if ((this.flags & ScoreBoard.FLAG_SHOW_BANNER) !== 0) {
       const bgoScaled = rescaleDim(
         {
@@ -224,12 +225,12 @@ export default class ScoreBoard extends ParentObject {
   }
 
   private addMedal(
-    context: CanvasRenderingContext2D,
+    context: RenderingContext2D,
     coord: ICoordinate,
     parentSize: IDimension
   ): void {
     if (this.currentScore < 10) return; // So sad having a no medal :)
-    let medal: HTMLImageElement | undefined;
+    let medal: SpriteAsset | undefined;
 
     if (this.currentScore >= 10 && this.currentScore < 20) {
       medal = this.images.get('coin-10');
@@ -262,7 +263,7 @@ export default class ScoreBoard extends ParentObject {
   }
 
   private displayScore(
-    context: CanvasRenderingContext2D,
+    context: RenderingContext2D,
     coord: ICoordinate,
     parentSize: IDimension
   ): void {
@@ -292,7 +293,7 @@ export default class ScoreBoard extends ParentObject {
   }
 
   private displayBestScore(
-    context: CanvasRenderingContext2D,
+    context: RenderingContext2D,
     coord: ICoordinate,
     parentSize: IDimension,
     _p0: boolean

--- a/src/model/spark.ts
+++ b/src/model/spark.ts
@@ -1,11 +1,12 @@
 // File Overview: This module belongs to src/model/spark.ts.
 import ParentClass from '../abstracts/parent-class';
 import { rescaleDim, randomClamp } from '../utils';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 import { TimingEvent } from '../lib/animation';
 
 export default class Spark extends ParentClass {
-  private images: Map<string, HTMLImageElement>;
+  private images: Map<string, SpriteAsset>;
   private scaled: IDimension;
   private status: string;
   private timingEvent: TimingEvent;
@@ -16,7 +17,7 @@ export default class Spark extends ParentClass {
 
   constructor() {
     super();
-    this.images = new Map<string, HTMLImageElement>();
+    this.images = new Map<string, SpriteAsset>();
     this.timingEvent = new TimingEvent({
       diff: 200
     });
@@ -96,7 +97,7 @@ export default class Spark extends ParentClass {
     }
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     if (this.status === 'stopped') return;
     context.drawImage(
       this.images.get(this.sparkList[this.currentSparkIndex])!,

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -16,6 +16,7 @@ import ParentClass from '../abstracts/parent-class';
 import PipeGenerator from '../model/pipe-generator';
 import ScoreBoard from '../model/score-board';
 import Sfx from '../model/sfx';
+import type { RenderingContext2D } from '../types/rendering-context';
 
 export type IGameState = 'died' | 'playing' | 'none';
 export default class GetReady extends ParentClass implements IScreenChangerObject {
@@ -128,10 +129,10 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
 
       this.gameState = 'died';
 
-      window.setTimeout(() => {
+      setTimeout(() => {
         this.scoreBoard.setScore(this.bird.score);
         this.showScoreBoard = true;
-        window.setTimeout(() => {
+        setTimeout(() => {
           this.scoreBoard.showBoard();
           Sfx.swoosh();
         }, 700);
@@ -145,7 +146,7 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     }
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     if (this.state === 'playing' || this.state === 'waiting') {
       this.bannerInstruction.Display(context);
 

--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -17,7 +17,8 @@ import ParentClass from '../abstracts/parent-class';
 import PlayButton from '../model/btn-play';
 import RankingButton from '../model/btn-ranking';
 import ToggleSpeaker from '../model/btn-toggle-speaker';
-import SpriteDestructor from '../lib/sprite-destructor';
+import SpriteDestructor, { SpriteAsset } from '../lib/sprite-destructor';
+import type { RenderingContext2D } from '../types/rendering-context';
 
 export default class Introduction extends ParentClass implements IScreenChangerObject {
   public playButton: PlayButton;
@@ -25,7 +26,7 @@ export default class Introduction extends ParentClass implements IScreenChangerO
   public toggleSpeakerButton: ToggleSpeaker;
 
   private bird: BirdModel;
-  private flappyBirdBanner: HTMLImageElement | undefined;
+  private flappyBirdBanner: SpriteAsset | undefined;
 
   constructor() {
     super();
@@ -67,7 +68,7 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.toggleSpeakerButton.Update();
   }
 
-  public Display(context: CanvasRenderingContext2D): void {
+  public Display(context: RenderingContext2D): void {
     this.toggleSpeakerButton.Display(context);
     this.playButton.Display(context);
     this.rankingButton.Display(context);

--- a/src/types/rendering-context.ts
+++ b/src/types/rendering-context.ts
@@ -1,0 +1,4 @@
+// File Overview: This module belongs to src/types/rendering-context.ts.
+export type RenderingContext2D =
+  | CanvasRenderingContext2D
+  | OffscreenCanvasRenderingContext2D;

--- a/src/workers/game-worker.ts
+++ b/src/workers/game-worker.ts
@@ -1,0 +1,163 @@
+// File Overview: This module belongs to src/workers/game-worker.ts.
+import GameObject from '../game';
+import { framer as Framer } from '../utils';
+import SpriteDestructor from '../lib/sprite-destructor';
+import Storage from '../lib/storage';
+import Sfx from '../model/sfx';
+import type { SpriteAsset } from '../lib/sprite-destructor';
+import type { IStoreValue } from '../lib/storage';
+import type {
+  MainToWorkerMessage,
+  WorkerToMainMessage,
+  WorkerInitMessage,
+  SpriteBitmapTransfer
+} from './messages';
+import { WorkerAudioMessage, WorkerStorageMessage, WorkerReadyMessage } from './messages';
+
+const postWorkerMessage = (message: WorkerToMainMessage) => {
+  self.postMessage(message);
+};
+
+const audioCallbacks = new Map<number, IEmptyFunction>();
+let audioCallbackId = 0;
+
+const bridgeAudio = () => {
+  Sfx.init = async () => {
+    postWorkerMessage({ type: 'audio', action: 'init' });
+  };
+
+  Sfx.volume = (num: number): void => {
+    Sfx.currentVolume = num;
+    postWorkerMessage({ type: 'audio', action: 'volume', volume: num });
+  };
+
+  const play = (sound: NonNullable<WorkerAudioMessage['sound']>) => () => {
+    postWorkerMessage({ type: 'audio', action: 'play', sound });
+  };
+
+  Sfx.die = play('die');
+  Sfx.point = play('point');
+  Sfx.swoosh = play('swoosh');
+  Sfx.wing = play('wing');
+
+  Sfx.hit = (cb?: IEmptyFunction) => {
+    const callbackId = cb ? ++audioCallbackId : undefined;
+    if (callbackId && cb) {
+      audioCallbacks.set(callbackId, cb);
+    }
+
+    postWorkerMessage({
+      type: 'audio',
+      action: 'play',
+      sound: 'hit',
+      callbackId
+    });
+  };
+};
+
+const registerSprites = (sprites: SpriteBitmapTransfer[]) => {
+  for (const { name, bitmap } of sprites) {
+    SpriteDestructor.register(name, bitmap as SpriteAsset);
+  }
+};
+
+const seedStorage = (entries: Record<string, IStoreValue | undefined>) => {
+  for (const [key, value] of Object.entries(entries)) {
+    Storage.primeFallback(key, value);
+  }
+
+  Storage.registerFallbackHandler((key, value) => {
+    const message: WorkerStorageMessage = {
+      type: 'storage',
+      action: 'save',
+      key,
+      value
+    };
+    postWorkerMessage(message);
+  });
+};
+
+let game: GameObject | undefined;
+let framer: InstanceType<typeof Framer> | undefined;
+let isDevelopment = false;
+let lastFrame = 0;
+const frameInterval = 1000 / 60;
+
+const handleFrame = (time: number) => {
+  if (!game) return;
+  if (time - lastFrame < frameInterval) return;
+  lastFrame = time;
+
+  game.Update();
+  game.Display();
+
+  if (isDevelopment) {
+    framer?.mark();
+  }
+};
+
+const initializeGame = (data: WorkerInitMessage) => {
+  bridgeAudio();
+  registerSprites(data.sprites);
+  new Storage();
+  seedStorage(data.storage);
+
+  game = new GameObject(data.canvas);
+  game.init();
+  game.Resize(data.size);
+
+  framer = new Framer(game.context);
+  framer.text({ x: 50, y: 50 }, '', ' Cycle');
+  framer.container({ x: 10, y: 10 }, { x: 230, y: 70 });
+
+  isDevelopment = data.isDev;
+  lastFrame = 0;
+
+  const ready: WorkerReadyMessage = { type: 'ready' };
+  postWorkerMessage(ready);
+};
+
+const handlePointer = (message: MainToWorkerMessage) => {
+  if (!game || message.type !== 'pointer') return;
+
+  switch (message.kind) {
+    case 'down':
+      game.mouseDown(message.position);
+      break;
+    case 'up':
+      game.mouseUp(message.position);
+      break;
+    case 'click':
+      game.onClick(message.position);
+      break;
+  }
+};
+
+self.addEventListener('message', (event: MessageEvent<MainToWorkerMessage>) => {
+  const data = event.data;
+
+  switch (data.type) {
+    case 'init':
+      initializeGame(data);
+      break;
+    case 'frame':
+      handleFrame(data.time);
+      break;
+    case 'resize':
+      game?.Resize(data.size);
+      break;
+    case 'pointer':
+      handlePointer(data);
+      break;
+    case 'keyboard':
+      game?.startAtKeyBoardEvent();
+      break;
+    case 'audio-callback':
+      if (audioCallbacks.has(data.id)) {
+        const callback = audioCallbacks.get(data.id)!;
+        audioCallbacks.delete(data.id);
+        callback();
+      }
+      break;
+  }
+});

--- a/src/workers/messages.ts
+++ b/src/workers/messages.ts
@@ -1,0 +1,78 @@
+// File Overview: This module belongs to src/workers/messages.ts.
+import type { IStoreValue } from '../lib/storage';
+
+export interface SpriteBitmapTransfer {
+  name: string;
+  bitmap: ImageBitmap;
+}
+
+export interface WorkerInitMessage {
+  type: 'init';
+  canvas: OffscreenCanvas;
+  size: IDimension;
+  isDev: boolean;
+  sprites: SpriteBitmapTransfer[];
+  storage: Record<string, IStoreValue | undefined>;
+}
+
+export interface FrameMessage {
+  type: 'frame';
+  time: number;
+}
+
+export interface ResizeMessage {
+  type: 'resize';
+  size: IDimension;
+}
+
+export type PointerEventKind = 'click' | 'down' | 'up';
+
+export interface PointerMessage {
+  type: 'pointer';
+  kind: PointerEventKind;
+  position: ICoordinate;
+}
+
+export interface KeyboardMessage {
+  type: 'keyboard';
+  action: 'start';
+}
+
+export interface AudioCallbackMessage {
+  type: 'audio-callback';
+  id: number;
+}
+
+export type MainToWorkerMessage =
+  | WorkerInitMessage
+  | FrameMessage
+  | ResizeMessage
+  | PointerMessage
+  | KeyboardMessage
+  | AudioCallbackMessage;
+
+export type AudioAction = 'init' | 'play' | 'volume';
+
+export interface WorkerAudioMessage {
+  type: 'audio';
+  action: AudioAction;
+  sound?: 'die' | 'point' | 'hit' | 'swoosh' | 'wing';
+  volume?: number;
+  callbackId?: number;
+}
+
+export interface WorkerStorageMessage {
+  type: 'storage';
+  action: 'save';
+  key: string;
+  value: IStoreValue;
+}
+
+export interface WorkerReadyMessage {
+  type: 'ready';
+}
+
+export type WorkerToMainMessage =
+  | WorkerAudioMessage
+  | WorkerStorageMessage
+  | WorkerReadyMessage;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
 
     /* Language and Environment */
     "target": "es5" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    "lib": ["dom", "es2019"] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+    "lib": [
+      "dom",
+      "webworker",
+      "es2019"
+    ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -26,7 +30,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "es6" /* Specify what module code is generated. */,
+    "module": "esnext" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
## Summary
- detect OffscreenCanvas support in the bootstrap and start a worker-driven game loop when available
- forward inputs, audio, and storage updates between the main thread and worker using typed postMessage contracts
- broaden rendering types to cover OffscreenCanvas contexts so existing drawing code runs unchanged in the worker

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b77b6d6883289f68e6cb6f2896b6