### PR TITLE
Make pointer listeners passive and set canvas touch-action

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -28,6 +28,7 @@ body {
     border: none;
     background-color: #fff;
     position: absolute;
+    touch-action: none;
   }
 
   > #loading-modal {


### PR DESCRIPTION
## Summary
- gate calls to `preventDefault` behind a helper so we can mark mouse listeners as passive while documenting the touch listeners that must remain active
- add `touch-action: none` to the canvas to prevent the page from scrolling during gameplay

## Testing
- npm run lint *(warns about existing unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b77bec008328af421d42739658e6