### PR TITLE
Add gamepad controller support and intro hint

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -5,6 +5,7 @@
 
 import Game from './game';
 import WebSfx from './lib/web-sfx';
+import GamepadManager from './lib/gamepad-manager';
 
 export type IEventParam = MouseEvent | TouchEvent | KeyboardEvent;
 
@@ -166,4 +167,33 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
       );
     }
   });
+
+  const syntheticCenter = () => ({
+    x: canvas.width / 2,
+    y: canvas.height / 2
+  });
+
+  const createSyntheticKeyEvent = (type: 'keydown' | 'keyup') =>
+    new KeyboardEvent(type, { key: ' ' });
+
+  const gamepadManager = new GamepadManager({
+    onPrimaryDown: () => {
+      const evt = createSyntheticKeyEvent('keydown');
+      Game.startAtKeyBoardEvent();
+      mouseDown(syntheticCenter(), evt);
+    },
+    onPrimaryUp: () => {
+      const evt = createSyntheticKeyEvent('keyup');
+      mouseUP(syntheticCenter(), evt, false);
+    },
+    onStart: () => {
+      Game.startAtKeyBoardEvent();
+    },
+    onConnectionChange: (connected, pad) => {
+      Game.notifyGamepadStatus(connected, pad?.id ?? '');
+    }
+  });
+
+  gamepadManager.init();
+  gamepadManager.start();
 };

--- a/src/game.ts
+++ b/src/game.ts
@@ -165,6 +165,10 @@ export default class Game extends ParentClass {
     else this.gamePlay.startAtKeyBoardEvent();
   }
 
+  public notifyGamepadStatus(connected: boolean, label?: string): void {
+    this.screenIntro.setGamepadHint(connected ? label : void 0);
+  }
+
   public get currentState(): IGameState {
     return this.state;
   }

--- a/src/lib/gamepad-manager.ts
+++ b/src/lib/gamepad-manager.ts
@@ -1,0 +1,165 @@
+// File Overview: This module belongs to src/lib/gamepad-manager.ts.
+export interface IGamepadManagerCallbacks {
+  onPrimaryDown: () => void;
+  onPrimaryUp: () => void;
+  onStart?: () => void;
+  onConnectionChange?: (connected: boolean, pad: Gamepad | null) => void;
+}
+
+const isButtonPressed = (button: GamepadButton | undefined): boolean => {
+  if (!button) return false;
+  return button.pressed || button.value > 0.5;
+};
+
+export default class GamepadManager {
+  private activeIndex: number | null;
+  private rafId: number | null;
+  private lastPrimaryPressed: boolean;
+  private lastStartPressed: boolean;
+  private lastConnected: boolean;
+  private lastGamepadId: string | null;
+
+  constructor(private readonly callbacks: IGamepadManagerCallbacks) {
+    this.activeIndex = null;
+    this.rafId = null;
+    this.lastPrimaryPressed = false;
+    this.lastStartPressed = false;
+    this.lastConnected = false;
+    this.lastGamepadId = null;
+  }
+
+  public init(): void {
+    window.addEventListener('gamepadconnected', this.handleConnected);
+    window.addEventListener('gamepaddisconnected', this.handleDisconnected);
+
+    this.updateActiveGamepad();
+  }
+
+  public start(): void {
+    if (this.rafId !== null) return;
+
+    const tick = () => {
+      this.poll();
+      this.rafId = window.requestAnimationFrame(tick);
+    };
+
+    this.rafId = window.requestAnimationFrame(tick);
+  }
+
+  private handleConnected = (evt: GamepadEvent): void => {
+    if (this.activeIndex === null) {
+      this.activeIndex = evt.gamepad.index;
+    }
+
+    this.updateActiveGamepad();
+  };
+
+  private handleDisconnected = (evt: GamepadEvent): void => {
+    if (this.activeIndex === evt.gamepad.index) {
+      const fallback = this.findFirstConnected(evt.gamepad.index);
+      this.activeIndex = fallback?.index ?? null;
+    }
+
+    this.updateActiveGamepad();
+  };
+
+  private poll(): void {
+    const pad = this.updateActiveGamepad();
+
+    if (!pad) {
+      if (this.lastPrimaryPressed) {
+        this.callbacks.onPrimaryUp();
+      }
+
+      this.lastPrimaryPressed = false;
+      this.lastStartPressed = false;
+      return;
+    }
+
+    const primaryPressed = isButtonPressed(pad.buttons[0]);
+
+    if (primaryPressed && !this.lastPrimaryPressed) {
+      this.callbacks.onPrimaryDown();
+    } else if (!primaryPressed && this.lastPrimaryPressed) {
+      this.callbacks.onPrimaryUp();
+    }
+
+    this.lastPrimaryPressed = primaryPressed;
+
+    if (typeof this.callbacks.onStart === 'function') {
+      const startPressed = isButtonPressed(pad.buttons[9]);
+
+      if (startPressed && !this.lastStartPressed) {
+        this.callbacks.onStart();
+      }
+
+      this.lastStartPressed = startPressed;
+    }
+  }
+
+  private updateActiveGamepad(): Gamepad | null {
+    const pads = this.readGamepads();
+
+    let pad: Gamepad | null = null;
+
+    const active = this.activeIndex !== null ? pads[this.activeIndex] ?? null : null;
+    if (active?.connected) {
+      pad = active;
+    }
+
+    if (!pad) {
+      const fallback = this.findFirstConnected();
+      if (fallback) {
+        pad = fallback;
+        this.activeIndex = fallback.index;
+      } else {
+        this.activeIndex = null;
+      }
+    }
+
+    this.notifyConnectionChange(pad);
+
+    return pad;
+  }
+
+  private findFirstConnected(excludeIndex?: number): Gamepad | null {
+    const pads = this.readGamepads();
+
+    for (const pad of pads) {
+      if (!pad?.connected) continue;
+      if (typeof excludeIndex === 'number' && pad.index === excludeIndex) continue;
+      return pad;
+    }
+
+    return null;
+  }
+
+  private notifyConnectionChange(pad: Gamepad | null): void {
+    const connected = Boolean(pad);
+    const id = pad?.id ?? null;
+
+    if (
+      connected !== this.lastConnected ||
+      (connected && id !== this.lastGamepadId)
+    ) {
+      this.callbacks.onConnectionChange?.(connected, pad ?? null);
+    }
+
+    this.lastConnected = connected;
+    this.lastGamepadId = id;
+  }
+
+  private readGamepads(): readonly (Gamepad | null)[] {
+    const nav = navigator as Navigator & {
+      getGamepads?: () => readonly (Gamepad | null)[];
+    };
+
+    if (typeof nav.getGamepads !== 'function') return [];
+
+    try {
+      return nav.getGamepads();
+    } catch {
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a gamepad manager that tracks the first connected controller and polls inputs on each animation frame
- wire the manager into existing event handling so primary/start buttons trigger keyboard/tap flow and pause/restart logic
- surface a controller hint banner on the intro screen when a pad is detected, including connection updates

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b77d90488328964a76423a0ae5ab