### PR TITLE
Add customizable keyboard controls and settings UI

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,47 @@
   </head>
   <body>
     <canvas id="main-canvas"></canvas>
+    <div id="control-settings" class="control-settings" aria-live="polite">
+      <button
+        type="button"
+        id="control-settings__toggle"
+        class="control-settings__toggle"
+        aria-expanded="false"
+        aria-controls="control-settings__form"
+      >
+        Controls
+      </button>
+      <form id="control-settings__form" class="control-settings__form" autocomplete="off">
+        <fieldset>
+          <legend>Jump keys</legend>
+          <p class="control-settings__hint">Click a field and press a key to remap.</p>
+          <div class="control-settings__grid">
+            <label>
+              <span>Key 1</span>
+              <input data-slot="primary" type="text" readonly />
+            </label>
+            <label>
+              <span>Key 2</span>
+              <input data-slot="secondary" type="text" readonly />
+            </label>
+            <label>
+              <span>Key 3</span>
+              <input data-slot="tertiary" type="text" readonly />
+            </label>
+            <label>
+              <span>Key 4</span>
+              <input data-slot="quaternary" type="text" readonly />
+            </label>
+          </div>
+          <p
+            class="control-settings__error"
+            id="control-settings__error"
+            role="alert"
+            hidden
+          ></p>
+        </fieldset>
+      </form>
+    </div>
     <div id="loading-modal">
       <div>Loading</div>
       <div class="lds-ellipsis">

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,12 @@ import '@total-typescript/ts-reset';
 
 import { framer as Framer, rescaleDim } from './utils';
 import { CANVAS_DIMENSION } from './constants';
-import EventHandler from './events';
+import EventHandler, { type IEventController } from './events';
 import GameObject from './game';
 import prepareAssets from './asset-preparation';
 import createRAF, { targetFPS } from '@solid-primitives/raf';
 import SwOffline from './lib/workbox-work-offline';
+import initControlSettings from './settings';
 
 if (process.env.NODE_ENV === 'production') {
   SwOffline();
@@ -30,6 +31,7 @@ const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
 
 let isLoaded = false;
+let eventController: IEventController | undefined;
 
 gameIcon.src = gameSpriteIcon;
 
@@ -68,7 +70,11 @@ const ScreenResize = () => {
 };
 
 const removeLoadingScreen = () => {
-  EventHandler(Game, canvas);
+  const settingsState = initControlSettings((codes) => {
+    eventController?.updateKeyBindings(codes);
+  });
+
+  eventController = EventHandler(Game, canvas, settingsState.activeCodes);
   loadingScreen.style.display = 'none';
   document.body.style.backgroundColor = 'rgba(28, 28, 30, 1)';
 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,297 @@
+// File Overview: This module belongs to src/settings.ts.
+import Storage from './lib/storage';
+
+export type TBindingSlot = 'primary' | 'secondary' | 'tertiary' | 'quaternary';
+
+export interface IBindingEntry {
+  slot: TBindingSlot;
+  code: string;
+  label: string;
+}
+
+export type TBindingsChangeCallback = (codes: string[]) => void;
+
+export interface ISettingsInitResult {
+  activeCodes: string[];
+}
+
+const STORAGE_KEY = 'control-key-bindings';
+const ALWAYS_ALLOWED_CODES = ['NumpadEnter'];
+
+const DEFAULT_BINDINGS: IBindingEntry[] = [
+  { slot: 'primary', code: 'Space', label: 'Space' },
+  { slot: 'secondary', code: 'Enter', label: 'Enter' },
+  { slot: 'tertiary', code: 'ArrowUp', label: 'Arrow Up' },
+  { slot: 'quaternary', code: 'KeyW', label: 'W' }
+];
+
+const isModifierKey = (evt: KeyboardEvent): boolean => {
+  return (
+    evt.key === 'Shift' ||
+    evt.key === 'Meta' ||
+    evt.key === 'Control' ||
+    evt.key === 'Alt'
+  );
+};
+
+const formatLabel = (code: string, key?: string): string => {
+  if (key) {
+    if (key === ' ') return 'Space';
+    if (key.length === 1) return key.toUpperCase();
+    if (key === 'ArrowUp') return 'Arrow Up';
+    if (key === 'ArrowDown') return 'Arrow Down';
+    if (key === 'ArrowLeft') return 'Arrow Left';
+    if (key === 'ArrowRight') return 'Arrow Right';
+    if (key === 'Escape') return 'Escape';
+  }
+
+  if (code.startsWith('Key') && code.length > 3) {
+    return code.substring(3);
+  }
+
+  if (code.startsWith('Digit') && code.length > 5) {
+    return code.substring(5);
+  }
+
+  switch (code) {
+    case 'Space':
+      return 'Space';
+    case 'Enter':
+      return 'Enter';
+    case 'NumpadEnter':
+      return 'Numpad Enter';
+    case 'ArrowUp':
+      return 'Arrow Up';
+    case 'ArrowDown':
+      return 'Arrow Down';
+    case 'ArrowLeft':
+      return 'Arrow Left';
+    case 'ArrowRight':
+      return 'Arrow Right';
+    case 'Escape':
+      return 'Escape';
+    default:
+      return code;
+  }
+};
+
+const sanitizeBindings = (entries: IBindingEntry[]): IBindingEntry[] => {
+  const bySlot = new Map<TBindingSlot, IBindingEntry>();
+
+  for (const entry of entries) {
+    if (!entry.slot) continue;
+    if (!entry.code) continue;
+    const normalizedSlot = entry.slot;
+    if (!bySlot.has(normalizedSlot)) {
+      bySlot.set(normalizedSlot, {
+        slot: normalizedSlot,
+        code: entry.code,
+        label: entry.label || formatLabel(entry.code)
+      });
+    }
+  }
+
+  const result: IBindingEntry[] = [];
+  for (const defaultEntry of DEFAULT_BINDINGS) {
+    const storedEntry = bySlot.get(defaultEntry.slot);
+    if (!storedEntry) {
+      result.push({ ...defaultEntry });
+      continue;
+    }
+
+    result.push({
+      slot: defaultEntry.slot,
+      code: storedEntry.code,
+      label: storedEntry.label || formatLabel(storedEntry.code)
+    });
+  }
+
+  return result;
+};
+
+const loadBindings = (): IBindingEntry[] => {
+  const stored = Storage.get(STORAGE_KEY);
+  if (typeof stored === 'string') {
+    try {
+      const parsed = JSON.parse(stored) as Partial<IBindingEntry>[];
+      if (Array.isArray(parsed)) {
+        return sanitizeBindings(
+          parsed.filter((item): item is IBindingEntry => {
+            return (
+              typeof item.slot === 'string' &&
+              typeof item.code === 'string' &&
+              typeof item.label === 'string'
+            );
+          })
+        );
+      }
+    } catch (err) {
+      console.warn('Failed to parse stored key bindings', err);
+    }
+  }
+
+  return DEFAULT_BINDINGS.map((entry) => ({ ...entry }));
+};
+
+const persistBindings = (entries: IBindingEntry[]) => {
+  Storage.save(STORAGE_KEY, JSON.stringify(entries));
+};
+
+const collectActiveCodes = (entries: IBindingEntry[]): string[] => {
+  return Array.from(
+    new Set([...entries.map((entry) => entry.code), ...Array.from(ALWAYS_ALLOWED_CODES)])
+  );
+};
+
+const updateInputs = (
+  bindings: IBindingEntry[],
+  inputs: NodeListOf<HTMLInputElement>
+): void => {
+  inputs.forEach((input) => {
+    const slot = input.dataset.slot as TBindingSlot | undefined;
+    if (!slot) return;
+    const binding = bindings.find((entry) => entry.slot === slot);
+    if (!binding) return;
+    input.value = binding.label;
+    input.dataset.code = binding.code;
+    input.title = `${binding.label} (${binding.code})`;
+  });
+};
+
+const showError = (element: HTMLElement | null, message?: string) => {
+  if (!element) return;
+  if (!message) {
+    element.textContent = '';
+    element.setAttribute('hidden', '');
+    return;
+  }
+
+  element.textContent = message;
+  element.removeAttribute('hidden');
+};
+
+const resetInputValue = (
+  bindings: IBindingEntry[],
+  input: HTMLInputElement | null
+): void => {
+  if (!input) return;
+  const slot = input.dataset.slot as TBindingSlot | undefined;
+  if (!slot) return;
+  const binding = bindings.find((entry) => entry.slot === slot);
+  if (!binding) return;
+  input.value = binding.label;
+};
+
+const handleCapture = (
+  evt: KeyboardEvent,
+  slot: TBindingSlot,
+  bindings: IBindingEntry[],
+  inputs: NodeListOf<HTMLInputElement>,
+  errorEl: HTMLElement | null,
+  onChange: TBindingsChangeCallback
+): void => {
+  if (evt.key === 'Tab') return;
+
+  if (evt.key === 'Escape') {
+    evt.preventDefault();
+    showError(errorEl);
+    (document.activeElement as HTMLElement | null)?.blur();
+    return;
+  }
+
+  evt.preventDefault();
+
+  if (isModifierKey(evt)) {
+    showError(errorEl, 'Modifier keys cannot be used.');
+    return;
+  }
+
+  const code = evt.code;
+  const label = formatLabel(code, evt.key);
+  const existing = bindings.find((entry) => entry.code === code && entry.slot !== slot);
+  if (existing) {
+    showError(errorEl, `"${label}" is already assigned to another slot.`);
+    updateInputs(bindings, inputs);
+    return;
+  }
+
+  const current = bindings.find((entry) => entry.slot === slot);
+  if (!current) return;
+
+  current.code = code;
+  current.label = label;
+
+  persistBindings(bindings);
+  updateInputs(bindings, inputs);
+  showError(errorEl);
+  onChange(collectActiveCodes(bindings));
+};
+
+const initControlSettings = (onChange: TBindingsChangeCallback): ISettingsInitResult => {
+  new Storage();
+
+  const container = document.querySelector<HTMLDivElement>('#control-settings');
+  const toggleButton = container?.querySelector<HTMLButtonElement>(
+    '#control-settings__toggle'
+  );
+  const form = container?.querySelector<HTMLFormElement>('#control-settings__form');
+  const errorEl = container?.querySelector<HTMLElement>('#control-settings__error') ?? null;
+  const inputs = form?.querySelectorAll<HTMLInputElement>('input[data-slot]') ?? null;
+
+  let bindings = loadBindings();
+
+  const activeCodes = collectActiveCodes(bindings);
+
+  if (!container || !toggleButton || !form || !inputs) {
+    return { activeCodes };
+  }
+
+  let activeSlot: TBindingSlot | null = null;
+
+  updateInputs(bindings, inputs);
+
+  toggleButton.addEventListener('click', () => {
+    const isOpen = !container.classList.contains('is-open');
+    container.classList.toggle('is-open', isOpen);
+    toggleButton.setAttribute('aria-expanded', String(isOpen));
+    if (isOpen) {
+      showError(errorEl);
+      window.setTimeout(() => {
+        inputs[0]?.focus();
+      }, 0);
+    } else {
+      activeSlot = null;
+      showError(errorEl);
+    }
+  });
+
+  form.addEventListener('focusin', (evt) => {
+    const target = evt.target as HTMLInputElement | null;
+    if (!target?.dataset.slot) return;
+    activeSlot = target.dataset.slot as TBindingSlot;
+    target.value = 'Press a key';
+    showError(errorEl, '');
+  });
+
+  form.addEventListener('focusout', (evt) => {
+    const target = evt.target as HTMLInputElement | null;
+    if (!target?.dataset.slot) return;
+    window.setTimeout(() => {
+      resetInputValue(bindings, target);
+    }, 0);
+    if (activeSlot === target.dataset.slot) {
+      activeSlot = null;
+    }
+  });
+
+  form.addEventListener('keydown', (evt) => {
+    if (!activeSlot) return;
+    handleCapture(evt, activeSlot, bindings, inputs, errorEl, onChange);
+  });
+
+  return {
+    activeCodes
+  };
+};
+
+export default initControlSettings;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -96,6 +96,120 @@ body {
   }
 }
 
+.control-settings {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+  z-index: 5;
+  font-family: 'Arial', 'Sans-Serif';
+
+  &__toggle {
+    border: none;
+    background: rgba(242, 242, 244, 0.85);
+    color: rgba(28, 28, 30, 1);
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    border-radius: 999px;
+    padding: 6px 14px;
+    cursor: pointer;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+    transition: background 0.2s ease-in-out, transform 0.15s ease-in-out;
+
+    &:hover,
+    &:focus-visible {
+      background: rgba(255, 255, 255, 0.95);
+      transform: translateY(-1px);
+      outline: none;
+    }
+  }
+
+  &__form {
+    display: none;
+    width: min(260px, 90vw);
+    padding: 12px 16px 16px 16px;
+    border-radius: 12px;
+    background: rgba(242, 242, 244, 0.9);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    backdrop-filter: blur(10px);
+  }
+
+  &.is-open {
+    .control-settings__form {
+      display: block;
+    }
+  }
+
+  &__toggle[aria-expanded='true'] {
+    background: rgba(255, 255, 255, 0.95);
+    transform: translateY(-1px);
+  }
+
+  fieldset {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  legend {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-weight: 700;
+    color: rgba(61, 61, 65, 1);
+  }
+
+  &__hint {
+    font-size: 0.75rem;
+    color: rgba(61, 61, 65, 0.9);
+    margin: 0;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 0.75rem;
+      color: rgba(61, 61, 65, 0.85);
+    }
+
+    input {
+      border: 1px solid rgba(198, 198, 200, 0.8);
+      border-radius: 8px;
+      padding: 6px 8px;
+      font-size: 0.85rem;
+      background: rgba(255, 255, 255, 0.9);
+      color: rgba(28, 28, 30, 0.95);
+      cursor: pointer;
+      transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+
+      &:focus-visible {
+        outline: none;
+        border-color: rgba(52, 120, 246, 0.9);
+        box-shadow: 0 0 0 2px rgba(52, 120, 246, 0.3);
+      }
+    }
+  }
+
+  &__error {
+    margin: 0;
+    font-size: 0.75rem;
+    color: #d83434;
+    min-height: 1em;
+  }
+}
+
 @keyframes lds-ellipsis1 {
   0% {
     transform: scale(0);


### PR DESCRIPTION
## Summary
- add dynamic keyboard binding support for W, ArrowUp, and persisted codes
- introduce a settings panel to remap jump keys and store the configuration
- wire the settings lifecycle into the event handler and style the new UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b77eaab8832895ac94307b4b7f2a