### PR TITLE
Add left-handed layout option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import GameObject from './game';
 import prepareAssets from './asset-preparation';
 import createRAF, { targetFPS } from '@solid-primitives/raf';
 import SwOffline from './lib/workbox-work-offline';
+import Settings from './lib/settings';
+import SettingsPanel from './lib/settings/ui';
 
 if (process.env.NODE_ENV === 'production') {
   SwOffline();
@@ -21,6 +23,10 @@ if (process.env.NODE_ENV === 'production') {
  * we'll need double buffer to atleast reduce
  * the frame tearing
  * */
+Settings.init();
+
+const settingsPanel = new SettingsPanel();
+
 const virtualCanvas = document.createElement('canvas');
 const gameIcon = document.createElement('img');
 const canvas = document.querySelector<HTMLCanvasElement>('#main-canvas')!;
@@ -28,6 +34,16 @@ const physicalContext = canvas.getContext('2d')!;
 const loadingScreen = document.querySelector<HTMLDivElement>('#loading-modal')!;
 const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
+
+settingsPanel.onToggle((isLeftHanded: boolean) => {
+  Settings.setLeftHanded(isLeftHanded);
+});
+
+Settings.onChange(({ leftHanded }) => {
+  settingsPanel.setLeftHanded(leftHanded);
+});
+
+settingsPanel.setLeftHanded(Settings.value.leftHanded);
 
 let isLoaded = false;
 
@@ -79,6 +95,7 @@ const removeLoadingScreen = () => {
 const [game_running, game_start] = createRAF(targetFPS(GameUpdate, 60));
 
 window.addEventListener('DOMContentLoaded', () => {
+  settingsPanel.mount();
   loadingScreen.insertBefore(gameIcon, loadingScreen.childNodes[0]);
 
   prepareAssets(() => {

--- a/src/lib/settings/index.ts
+++ b/src/lib/settings/index.ts
@@ -1,0 +1,69 @@
+// File Overview: This module belongs to src/lib/settings/index.ts.
+import Storage from '../storage';
+
+export interface ISettingsState {
+  leftHanded: boolean;
+}
+
+type SettingsListener = (state: ISettingsState) => void;
+
+class SettingsManager {
+  private state: ISettingsState;
+  private listeners: Set<SettingsListener>;
+  private isReady: boolean;
+
+  constructor() {
+    this.state = { leftHanded: false };
+    this.listeners = new Set();
+    this.isReady = false;
+  }
+
+  public init(): void {
+    if (this.isReady) return;
+
+    // Ensure localStorage availability before reading.
+    new Storage();
+
+    const storedLeftHanded = Storage.get('setting-left-handed');
+
+    this.state.leftHanded = typeof storedLeftHanded === 'boolean' ? storedLeftHanded : false;
+    this.isReady = true;
+    this.notify();
+  }
+
+  public get value(): ISettingsState {
+    return { ...this.state };
+  }
+
+  public onChange(listener: SettingsListener): IEmptyFunction {
+    this.listeners.add(listener);
+
+    if (this.isReady) {
+      listener(this.value);
+    }
+
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  public setLeftHanded(enabled: boolean): void {
+    if (this.state.leftHanded === enabled) return;
+
+    this.state.leftHanded = enabled;
+    if (this.isReady) {
+      Storage.save('setting-left-handed', enabled);
+      this.notify();
+    }
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => {
+      listener(this.value);
+    });
+  }
+}
+
+const Settings = new SettingsManager();
+
+export default Settings;

--- a/src/lib/settings/ui.ts
+++ b/src/lib/settings/ui.ts
@@ -1,0 +1,73 @@
+// File Overview: This module belongs to src/lib/settings/ui.ts.
+export type SettingsToggleHandler = (leftHanded: boolean) => void;
+
+export default class SettingsPanel {
+  private root: HTMLDivElement;
+  private toggle: HTMLInputElement;
+  private leftHanded: boolean;
+  private mounted: boolean;
+  private changeHandler?: SettingsToggleHandler;
+
+  constructor() {
+    this.root = document.createElement('div');
+    this.root.id = 'settings-screen';
+    this.toggle = document.createElement('input');
+    this.leftHanded = false;
+    this.mounted = false;
+  }
+
+  public mount(): void {
+    if (this.mounted) return;
+
+    const panel = document.createElement('div');
+    panel.className = 'settings-panel';
+
+    const title = document.createElement('span');
+    title.className = 'settings-panel__title';
+    title.textContent = 'Settings';
+
+    const toggleWrapper = document.createElement('label');
+    toggleWrapper.className = 'settings-panel__toggle';
+
+    const label = document.createElement('span');
+    label.textContent = 'Left-handed layout';
+
+    this.toggle.type = 'checkbox';
+    this.toggle.checked = this.leftHanded;
+    this.toggle.setAttribute('aria-label', 'Toggle left-handed layout');
+
+    this.toggle.addEventListener('change', () => {
+      const isLeftHanded = this.toggle.checked;
+      this.setLeftHanded(isLeftHanded);
+      this.changeHandler?.(isLeftHanded);
+    });
+
+    toggleWrapper.append(this.toggle, label);
+    panel.append(title, toggleWrapper);
+    this.root.append(panel);
+    document.body.appendChild(this.root);
+
+    this.mounted = true;
+    this.applyOrientation();
+  }
+
+  public setLeftHanded(leftHanded: boolean): void {
+    this.leftHanded = leftHanded;
+
+    if (this.mounted) {
+      this.toggle.checked = leftHanded;
+      this.applyOrientation();
+    }
+  }
+
+  public onToggle(handler: SettingsToggleHandler): void {
+    this.changeHandler = handler;
+  }
+
+  private applyOrientation(): void {
+    if (!this.mounted) return;
+
+    this.root.dataset.handed = this.leftHanded ? 'left' : 'right';
+    document.body.dataset.handed = this.leftHanded ? 'left' : 'right';
+  }
+}

--- a/src/model/btn-play.ts
+++ b/src/model/btn-play.ts
@@ -3,6 +3,9 @@ import Parent from '../abstracts/button-event-handler';
 import Sfx from './sfx';
 import SpriteDestructor from '../lib/sprite-destructor';
 
+const PLAY_BUTTON_DEFAULT_X = 0.259;
+const PLAY_BUTTON_MIRROR_X = 0.741;
+
 export default class PlayButton extends Parent {
   protected callback?: IEmptyFunction;
 
@@ -10,7 +13,7 @@ export default class PlayButton extends Parent {
     super();
     this.initialWidth = 0.38;
     this.coordinate = {
-      x: 0.259,
+      x: PLAY_BUTTON_DEFAULT_X,
       y: 0.6998
     };
     this.active = true;
@@ -27,6 +30,10 @@ export default class PlayButton extends Parent {
 
   public init(): void {
     this.img = SpriteDestructor.asset('btn-play');
+  }
+
+  public setLeftHanded(isLeftHanded: boolean): void {
+    this.coordinate.x = isLeftHanded ? PLAY_BUTTON_MIRROR_X : PLAY_BUTTON_DEFAULT_X;
   }
 
   public Update(): void {

--- a/src/model/btn-ranking.ts
+++ b/src/model/btn-ranking.ts
@@ -2,6 +2,9 @@
 import PlayButton from './btn-play'; // Instead of duplicating
 import SpriteDestructor from '../lib/sprite-destructor';
 
+const RANKING_BUTTON_DEFAULT_X = 0.741;
+const RANKING_BUTTON_MIRROR_X = 0.259;
+
 /**
  * Instead of creating everything from scratch
  * Let us depend on PlayButton since they are
@@ -11,10 +14,16 @@ import SpriteDestructor from '../lib/sprite-destructor';
 export default class RankingButton extends PlayButton {
   constructor() {
     super();
-    this.coordinate.x = 0.741;
+    this.coordinate.x = RANKING_BUTTON_DEFAULT_X;
   }
 
   public init(): void {
     this.img = SpriteDestructor.asset('btn-ranking');
+  }
+
+  public override setLeftHanded(isLeftHanded: boolean): void {
+    this.coordinate.x = isLeftHanded
+      ? RANKING_BUTTON_MIRROR_X
+      : RANKING_BUTTON_DEFAULT_X;
   }
 }

--- a/src/model/btn-toggle-speaker.ts
+++ b/src/model/btn-toggle-speaker.ts
@@ -3,6 +3,9 @@ import Parent from '../abstracts/button-event-handler';
 import SpriteDestructor from '../lib/sprite-destructor';
 import Sfx from './sfx';
 
+const TOGGLE_SPEAKER_DEFAULT_X = 0.93;
+const TOGGLE_SPEAKER_MIRROR_X = 0.07;
+
 export default class ToggleSpeakerBtn extends Parent {
   private assets: Map<string, HTMLImageElement>;
   private is_mute: boolean;
@@ -12,7 +15,7 @@ export default class ToggleSpeakerBtn extends Parent {
     this.initialWidth = 0.1;
     this.assets = new Map();
     this.is_mute = false;
-    this.coordinate.x = 0.93;
+    this.coordinate.x = TOGGLE_SPEAKER_DEFAULT_X;
     this.coordinate.y = 0.04;
     this.active = true;
   }
@@ -34,6 +37,12 @@ export default class ToggleSpeakerBtn extends Parent {
     this.assets.set('unmute', SpriteDestructor.asset('btn-speaker'));
 
     this.setImg();
+  }
+
+  public setLeftHanded(isLeftHanded: boolean): void {
+    this.coordinate.x = isLeftHanded
+      ? TOGGLE_SPEAKER_MIRROR_X
+      : TOGGLE_SPEAKER_DEFAULT_X;
   }
 
   public Update(): void {

--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -9,6 +9,7 @@ import ToggleSpeaker from './btn-toggle-speaker';
 import SpriteDestructor from '../lib/sprite-destructor';
 import { Fly, BounceIn, TimingEvent } from '../lib/animation';
 import Storage from '../lib/storage';
+import Settings, { ISettingsState } from '../lib/settings';
 
 export default class ScoreBoard extends ParentObject {
   private static readonly FLAG_SHOW_BANNER = 0b0001;
@@ -29,6 +30,7 @@ export default class ScoreBoard extends ParentObject {
   private currentHighScore: number;
   private TimingEventAnim: TimingEvent;
   private spark: SparkModel;
+  private readonly handleSettingsChange: (settings: ISettingsState) => void;
 
   constructor() {
     super();
@@ -60,6 +62,13 @@ export default class ScoreBoard extends ParentObject {
         fading: 100
       }
     });
+    this.handleSettingsChange = ({ leftHanded }: ISettingsState) => {
+      this.playButton.setLeftHanded(leftHanded);
+      this.rankingButton.setLeftHanded(leftHanded);
+      this.toggleSpeakerButton.setLeftHanded(leftHanded);
+    };
+
+    Settings.onChange(this.handleSettingsChange);
   }
 
   public init(): void {
@@ -91,6 +100,7 @@ export default class ScoreBoard extends ParentObject {
      * */
     const prevScore = Storage.get('highscore') as number;
     this.currentHighScore = typeof prevScore === 'number' ? prevScore : 0;
+    this.handleSettingsChange(Settings.value);
   }
 
   public resize({ width, height }: IDimension): void {

--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -18,6 +18,7 @@ import PlayButton from '../model/btn-play';
 import RankingButton from '../model/btn-ranking';
 import ToggleSpeaker from '../model/btn-toggle-speaker';
 import SpriteDestructor from '../lib/sprite-destructor';
+import Settings, { ISettingsState } from '../lib/settings';
 
 export default class Introduction extends ParentClass implements IScreenChangerObject {
   public playButton: PlayButton;
@@ -26,6 +27,7 @@ export default class Introduction extends ParentClass implements IScreenChangerO
 
   private bird: BirdModel;
   private flappyBirdBanner: HTMLImageElement | undefined;
+  private readonly handleSettingsChange: (settings: ISettingsState) => void;
 
   constructor() {
     super();
@@ -34,6 +36,13 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.rankingButton = new RankingButton();
     this.toggleSpeakerButton = new ToggleSpeaker();
     this.flappyBirdBanner = void 0;
+    this.handleSettingsChange = ({ leftHanded }: ISettingsState) => {
+      this.playButton.setLeftHanded(leftHanded);
+      this.rankingButton.setLeftHanded(leftHanded);
+      this.toggleSpeakerButton.setLeftHanded(leftHanded);
+    };
+
+    Settings.onChange(this.handleSettingsChange);
   }
 
   public init(): void {
@@ -42,6 +51,7 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.rankingButton.init();
     this.toggleSpeakerButton.init();
     this.flappyBirdBanner = SpriteDestructor.asset('banner-flappybird');
+    this.handleSettingsChange(Settings.value);
   }
 
   public resize({ width, height }: IDimension): void {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -94,6 +94,76 @@ body {
       }
     }
   }
+
+  > #settings-screen {
+    position: fixed;
+    top: 1.5rem;
+    right: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.75rem;
+    z-index: 20;
+    pointer-events: auto;
+
+    > .settings-panel {
+      min-width: 14rem;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 0.5rem;
+      padding: 0.75rem 1rem;
+      border-radius: 14px;
+      background-color: rgba(28, 28, 30, 0.72);
+      backdrop-filter: blur(12px);
+      color: rgba(248, 248, 252, 0.92);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+      text-align: right;
+      font-family: 'Arial', 'Sans-Serif';
+
+      > .settings-panel__title {
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        opacity: 0.72;
+      }
+
+      > .settings-panel__toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.55rem;
+        font-size: 0.9rem;
+        cursor: pointer;
+
+        > input[type='checkbox'] {
+          width: 1.15rem;
+          height: 1.15rem;
+          accent-color: rgba(90, 200, 250, 1);
+          cursor: pointer;
+        }
+      }
+    }
+  }
+
+  &[data-handed='left'] {
+    flex-direction: row;
+
+    > #settings-screen {
+      right: auto;
+      left: 1.5rem;
+      align-items: flex-start;
+
+      > .settings-panel {
+        align-items: flex-start;
+        text-align: left;
+
+        > .settings-panel__toggle {
+          flex-direction: row-reverse;
+        }
+      }
+    }
+  }
 }
 
 @keyframes lds-ellipsis1 {


### PR DESCRIPTION
## Summary
- add a persisted settings manager and UI panel for toggling left-handed layout
- mirror intro and scoreboard buttons based on the stored preference
- style the settings overlay to support mirrored orientations

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b77f73548328b5df34f23c8b264a