### PR TITLE
Add touch-action safeguards for the main canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Modifying these constants enables quick experimentation with difficulty curves a
 3. **Branching** – Use feature branches (`feature/<description>`) and descriptive commit messages.
 4. **Pull Requests** – Summarize gameplay-visible changes and outline manual test steps for reviewers.
 
+## Mobile Input & Gesture Handling
+
+- The main game canvas (`#main-canvas`) disables browser gesture handling via `touch-action: none` to prevent swipes from triggering navigation or scroll inside the play area.
+- Keep any interactive overlays outside of the canvas or provide their own gesture handling so that page-level scrolling remains available when the game is not focused.
+- Avoid removing the canvas `touch-action` rule when adding new UI; mobile browsers will otherwise re-enable history swipe or pull-to-refresh behaviors.
+
 ## Browser Support
 
 - Chrome / Chromium (desktop & mobile)

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -5,14 +5,17 @@ html {
 
 body {
   white-space: nowrap;
-  height: 100vh;
+  min-height: 100vh;
   width: 100vw;
   padding: 0;
   margin: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  position: relative;
   background-color: #fff;
   transition: background-color 0.5s ease-in-out;
 
@@ -28,6 +31,7 @@ body {
     border: none;
     background-color: #fff;
     position: absolute;
+    touch-action: none;
   }
 
   > #loading-modal {


### PR DESCRIPTION
## Summary
- disable browser gesture navigation on the main game canvas and preserve page scrolling outside the play area
- contain body overscroll to prevent bounce-back while keeping the layout centered
- document mobile gesture handling expectations to avoid regressions when adding overlays

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b7805064832889b450a368c56331