### PR TITLE
Add live score announcements for screen readers

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,12 @@
   </head>
   <body>
     <canvas id="main-canvas"></canvas>
+    <div
+      id="game-announcer"
+      aria-live="polite"
+      aria-atomic="true"
+      style="position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;"
+    ></div>
     <div id="loading-modal">
       <div>Loading</div>
       <div class="lds-ellipsis">


### PR DESCRIPTION
## Summary
- add a hidden aria-live region in the index markup to serve as the announcer
- queue debounced score announcements from the gameplay screen so screen readers narrate progress without flooding
- reset the live region state whenever the game is initialized or restarted to avoid stale messages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b783f68483289a8b8dc870ee6b50