### PR TITLE
Improve keyboard accessibility for game controls

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -123,6 +123,11 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
   // Keyboard event
   document.addEventListener('keydown', (evt: KeyboardEvent) => {
     const { key, keyCode, code } = evt;
+    const target = evt.target as HTMLElement | null;
+
+    if (target?.closest('#ui-controls')) {
+      return;
+    }
 
     if (
       key === ' ' ||
@@ -147,6 +152,11 @@ export default (Game: Game, canvas: HTMLCanvasElement) => {
 
   document.addEventListener('keyup', (evt: KeyboardEvent) => {
     const { key, keyCode, code } = evt;
+    const target = evt.target as HTMLElement | null;
+
+    if (target?.closest('#ui-controls')) {
+      return;
+    }
     if (
       key === ' ' ||
       keyCode === 32 ||

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,19 @@
     <ga4.analytics />
   </head>
   <body>
-    <canvas id="main-canvas"></canvas>
+    <canvas id="main-canvas" tabindex="0">
+      Flappy Bird game canvas. Use the Play button below or press the Space or
+      Enter key to start flying. While playing, keep the canvas focused and tap,
+      click, or press Space/Enter to flap.
+    </canvas>
+    <div id="ui-controls" aria-live="polite" aria-atomic="true">
+      <div class="ui-screen ui-screen--intro" data-screen="intro" hidden>
+        <button type="button" id="intro-play-button">Play</button>
+      </div>
+      <div class="ui-screen ui-screen--scoreboard" data-screen="scoreboard" hidden>
+        <button type="button" id="scoreboard-retry-button">Play again</button>
+      </div>
+    </div>
     <div id="loading-modal">
       <div>Loading</div>
       <div class="lds-ellipsis">

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import GameObject from './game';
 import prepareAssets from './asset-preparation';
 import createRAF, { targetFPS } from '@solid-primitives/raf';
 import SwOffline from './lib/workbox-work-offline';
+import AccessibilityManager from './lib/accessibility-manager';
 
 if (process.env.NODE_ENV === 'production') {
   SwOffline();
@@ -28,6 +29,7 @@ const physicalContext = canvas.getContext('2d')!;
 const loadingScreen = document.querySelector<HTMLDivElement>('#loading-modal')!;
 const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
+const accessibility = new AccessibilityManager(Game, canvas);
 
 let isLoaded = false;
 
@@ -80,6 +82,8 @@ const [game_running, game_start] = createRAF(targetFPS(GameUpdate, 60));
 
 window.addEventListener('DOMContentLoaded', () => {
   loadingScreen.insertBefore(gameIcon, loadingScreen.childNodes[0]);
+
+  accessibility.init();
 
   prepareAssets(() => {
     isLoaded = true;

--- a/src/lib/accessibility-manager.ts
+++ b/src/lib/accessibility-manager.ts
@@ -1,0 +1,80 @@
+// File Overview: This module belongs to src/lib/accessibility-manager.ts.
+import Game, { IAccessibilityCallbacks } from '../game';
+
+export default class AccessibilityManager {
+  private readonly game: Game;
+  private readonly canvas: HTMLCanvasElement;
+  private readonly root: HTMLElement | null;
+  private readonly introScreen: HTMLElement | null;
+  private readonly scoreboardScreen: HTMLElement | null;
+  private readonly introPlayButton: HTMLButtonElement | null;
+  private readonly scoreboardRetryButton: HTMLButtonElement | null;
+
+  constructor(game: Game, canvas: HTMLCanvasElement) {
+    this.game = game;
+    this.canvas = canvas;
+    this.root = document.getElementById('ui-controls');
+    this.introScreen = this.root?.querySelector('[data-screen="intro"]') ?? null;
+    this.scoreboardScreen = this.root?.querySelector('[data-screen="scoreboard"]') ?? null;
+    this.introPlayButton = this.root?.querySelector('#intro-play-button') ?? null;
+    this.scoreboardRetryButton = this.root?.querySelector('#scoreboard-retry-button') ?? null;
+  }
+
+  public init(): void {
+    if (!this.root) return;
+
+    this.toggleScreen(this.introScreen, false);
+    this.toggleScreen(this.scoreboardScreen, false);
+
+    const callbacks: IAccessibilityCallbacks = {
+      onIntroReady: () => {
+        this.toggleScreen(this.introScreen, true);
+        this.toggleScreen(this.scoreboardScreen, false);
+        window.requestAnimationFrame(() => {
+          this.introPlayButton?.focus();
+        });
+      },
+      onGameStart: () => {
+        this.toggleScreen(this.introScreen, false);
+        this.toggleScreen(this.scoreboardScreen, false);
+        window.requestAnimationFrame(() => {
+          this.canvas.focus({ preventScroll: true });
+        });
+      },
+      onScoreboardReady: () => {
+        this.toggleScreen(this.scoreboardScreen, true);
+        window.requestAnimationFrame(() => {
+          this.scoreboardRetryButton?.focus();
+        });
+      },
+      onScoreboardHidden: () => {
+        this.toggleScreen(this.scoreboardScreen, false);
+        window.requestAnimationFrame(() => {
+          this.canvas.focus({ preventScroll: true });
+        });
+      }
+    };
+
+    this.game.registerAccessibilityCallbacks(callbacks);
+
+    this.introPlayButton?.addEventListener('click', () => {
+      this.game.requestIntroPlayFromAccessibility();
+    });
+
+    this.scoreboardRetryButton?.addEventListener('click', () => {
+      this.game.requestScoreboardRestartFromAccessibility();
+    });
+  }
+
+  private toggleScreen(element: HTMLElement | null, visible: boolean): void {
+    if (!element) return;
+
+    if (visible) {
+      element.hidden = false;
+      element.setAttribute('aria-hidden', 'false');
+    } else {
+      element.hidden = true;
+      element.setAttribute('aria-hidden', 'true');
+    }
+  }
+}

--- a/src/model/btn-play.ts
+++ b/src/model/btn-play.ts
@@ -17,6 +17,7 @@ export default class PlayButton extends Parent {
   }
 
   public click(): void {
+    this.active = false;
     Sfx.swoosh();
     this.callback?.();
   }

--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -29,6 +29,7 @@ export default class ScoreBoard extends ParentObject {
   private currentHighScore: number;
   private TimingEventAnim: TimingEvent;
   private spark: SparkModel;
+  private buttonsVisibilityListener?: (visible: boolean) => void;
 
   constructor() {
     super();
@@ -208,10 +209,13 @@ export default class ScoreBoard extends ParentObject {
   }
 
   public showButtons(): void {
+    if ((this.flags & ScoreBoard.FLAG_SHOW_BUTTONS) !== 0) return;
+
     this.flags |= ScoreBoard.FLAG_SHOW_BUTTONS;
     this.playButton.active = true;
     this.rankingButton.active = true;
     this.toggleSpeakerButton.active = true;
+    this.buttonsVisibilityListener?.(true);
   }
 
   private setHighScore(num: number): void {
@@ -355,6 +359,7 @@ export default class ScoreBoard extends ParentObject {
     this.BounceInAnim.reset();
     this.TimingEventAnim.reset();
     this.spark.stop();
+    this.buttonsVisibilityListener?.(false);
   }
 
   public onRestart(cb: IEmptyFunction): void {
@@ -382,6 +387,13 @@ export default class ScoreBoard extends ParentObject {
   }
 
   public triggerPlayATKeyboardEvent(): void {
-    if ((this.flags & ScoreBoard.FLAG_SHOW_BUTTONS) !== 0) this.playButton.click();
+    if ((this.flags & ScoreBoard.FLAG_SHOW_BUTTONS) === 0 || !this.playButton.active) return;
+
+    this.playButton.active = false;
+    this.playButton.click();
+  }
+
+  public onButtonsVisibilityChange(callback: (visible: boolean) => void): void {
+    this.buttonsVisibilityListener = callback;
   }
 }

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -58,6 +58,11 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.showScoreBoard = false;
 
     this.transition.setEvent([0.99, 1], this.reset.bind(this));
+
+    this.scoreBoard.onButtonsVisibilityChange((visible: boolean) => {
+      if (visible) this.game.notifyScoreboardVisible();
+      else this.game.notifyScoreboardHidden();
+    });
   }
 
   public init(): void {
@@ -196,6 +201,10 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.scoreBoard.mouseUp({ x, y });
   }
   public startAtKeyBoardEvent(): void {
+    if (this.gameState === 'died') this.scoreBoard.triggerPlayATKeyboardEvent();
+  }
+
+  public requestRestartFromAccessibility(): void {
     if (this.gameState === 'died') this.scoreBoard.triggerPlayATKeyboardEvent();
   }
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -94,6 +94,68 @@ body {
       }
     }
   }
+
+  > #ui-controls {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    pointer-events: none;
+
+    .ui-screen {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      pointer-events: none;
+      justify-self: center;
+      align-self: center;
+
+      &.ui-screen--intro {
+        align-self: end;
+        margin-bottom: 8vh;
+      }
+
+      &.ui-screen--scoreboard {
+        align-self: end;
+        margin-bottom: 10vh;
+      }
+
+      &[hidden] {
+        display: none;
+      }
+
+      > button {
+        pointer-events: auto;
+        padding: 0.65rem 1.5rem;
+        font-size: 1.05rem;
+        font-family: 'Arial', 'Sans-Serif';
+        border-radius: 999px;
+        border: 2px solid transparent;
+        background: rgba(255, 255, 255, 0.85);
+        color: rgba(28, 28, 30, 1);
+        box-shadow: 0 0.35rem 0.75rem rgba(0, 0, 0, 0.2);
+        cursor: pointer;
+        transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+
+        &:hover {
+          transform: translateY(-2px);
+          box-shadow: 0 0.6rem 1.2rem rgba(0, 0, 0, 0.25);
+        }
+
+        &:focus-visible {
+          outline: none;
+          border-color: #ffbf00;
+          box-shadow: 0 0 0 4px rgba(255, 191, 0, 0.35);
+        }
+
+        &:active {
+          transform: translateY(1px);
+          box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.25);
+        }
+      }
+    }
+  }
 }
 
 @keyframes lds-ellipsis1 {


### PR DESCRIPTION
## Summary
- add canvas fallback instructions and DOM play/retry buttons with accessible focus styling
- introduce an accessibility manager that coordinates focus and screen changes between the DOM controls and game state
- expose new lifecycle hooks so intro and scoreboard actions trigger the same game logic when activated from keyboard controls

## Testing
- npm run lint *(warnings only from existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b7838f6c8328bc5cc31ae4fd470c