### PR TITLE
Add first-visit intro tooltip overlay

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -11,6 +11,7 @@ import ScreenChanger from './lib/screen-changer';
 import Sfx from './model/sfx';
 import Storage from './lib/storage';
 import FlashScreen from './model/flash-screen';
+import IntroTooltip from './model/intro-tooltip';
 
 export type IGameState = 'intro' | 'game';
 
@@ -26,6 +27,7 @@ export default class Game extends ParentClass {
   private screenIntro: Intro;
   private gamePlay: GamePlay;
   private state: IGameState;
+  private introTooltip: IntroTooltip;
 
   constructor(canvas: HTMLCanvasElement) {
     super();
@@ -48,6 +50,7 @@ export default class Game extends ParentClass {
       style: 'black',
       easing: 'sineWaveHS'
     });
+    this.introTooltip = new IntroTooltip();
 
     this.transition.setEvent([0.98, 1], () => {
       this.state = 'game';
@@ -73,6 +76,8 @@ export default class Game extends ParentClass {
     // Register screens
     this.screenChanger.register('intro', this.screenIntro);
     this.screenChanger.register('game', this.gamePlay);
+
+    this.introTooltip.showIfNeeded();
   }
 
   public reset(): void {
@@ -134,6 +139,8 @@ export default class Game extends ParentClass {
     this.screenIntro.playButton.onClick(() => {
       if (this.state !== 'intro') return;
 
+      this.introTooltip.dismiss();
+
       // Deactivate buttons
       this.screenIntro.playButton.active = false;
       this.screenIntro.rankingButton.active = false;
@@ -151,6 +158,9 @@ export default class Game extends ParentClass {
   }
 
   public mouseDown({ x, y }: ICoordinate): void {
+    if (this.state === 'intro') {
+      this.introTooltip.dismiss();
+    }
     this.screenIntro.mouseDown({ x, y });
     this.gamePlay.mouseDown({ x, y });
   }
@@ -161,8 +171,10 @@ export default class Game extends ParentClass {
   }
 
   public startAtKeyBoardEvent(): void {
-    if (this.state === 'intro') this.screenIntro.startAtKeyBoardEvent();
-    else this.gamePlay.startAtKeyBoardEvent();
+    if (this.state === 'intro') {
+      this.introTooltip.dismiss();
+      this.screenIntro.startAtKeyBoardEvent();
+    } else this.gamePlay.startAtKeyBoardEvent();
   }
 
   public get currentState(): IGameState {

--- a/src/model/intro-tooltip.ts
+++ b/src/model/intro-tooltip.ts
@@ -1,0 +1,115 @@
+// File Overview: This module belongs to src/model/intro-tooltip.ts.
+import Storage from '../lib/storage';
+
+const INTRO_TOOLTIP_STORAGE_KEY = 'intro-tooltip-dismissed';
+const DEFAULT_TIMEOUT = 6500;
+
+type DismissReason = 'interaction' | 'timeout' | 'programmatic';
+
+export default class IntroTooltip {
+  private container: HTMLDivElement | null = null;
+  private hideTimer: number | null = null;
+  private hasListeners = false;
+  private visible = false;
+  private readonly pointerHandler = this.handleInteraction.bind(this);
+  private readonly keyHandler = this.handleInteraction.bind(this);
+
+  constructor(private readonly timeoutMs: number = DEFAULT_TIMEOUT) {}
+
+  public showIfNeeded(): void {
+    if (this.visible) return;
+    if (Storage.get(INTRO_TOOLTIP_STORAGE_KEY) === true) return;
+
+    this.ensureElements();
+    if (!this.container) return;
+
+    this.container.dataset.state = 'visible';
+    this.container.setAttribute('aria-hidden', 'false');
+    this.visible = true;
+    this.registerListeners();
+
+    if (this.hideTimer !== null) {
+      window.clearTimeout(this.hideTimer);
+    }
+    this.hideTimer = window.setTimeout(() => {
+      this.hide('timeout');
+    }, this.timeoutMs);
+  }
+
+  public dismiss(): void {
+    this.hide('interaction');
+  }
+
+  public hide(reason: DismissReason = 'programmatic'): void {
+    if (!this.visible || !this.container) return;
+
+    this.container.dataset.state = 'hidden';
+    this.container.setAttribute('aria-hidden', 'true');
+    this.visible = false;
+
+    if (this.hideTimer !== null) {
+      window.clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
+
+    if (reason === 'interaction' || reason === 'timeout') {
+      try {
+        Storage.save(INTRO_TOOLTIP_STORAGE_KEY, true);
+      } catch (err) {
+        console.warn('Failed to persist intro tooltip preference', err);
+      }
+    }
+
+    this.unregisterListeners();
+  }
+
+  private handleInteraction(): void {
+    if (!this.visible) return;
+    this.hide('interaction');
+  }
+
+  private ensureElements(): void {
+    if (this.container) return;
+
+    const container = document.createElement('div');
+    container.id = 'intro-tooltip';
+    container.dataset.state = 'hidden';
+    container.setAttribute('aria-hidden', 'true');
+    container.setAttribute('role', 'status');
+    container.setAttribute('aria-live', 'polite');
+
+    const bubble = document.createElement('div');
+    bubble.className = 'intro-tooltip__bubble';
+
+    const title = document.createElement('p');
+    title.className = 'intro-tooltip__title';
+    title.textContent = 'Tap to flap!';
+
+    const description = document.createElement('p');
+    description.className = 'intro-tooltip__description';
+    description.textContent = 'Tap anywhere or press Space to start flying.';
+
+    bubble.appendChild(title);
+    bubble.appendChild(description);
+    container.appendChild(bubble);
+    document.body.appendChild(container);
+
+    this.container = container;
+  }
+
+  private registerListeners(): void {
+    if (this.hasListeners) return;
+
+    window.addEventListener('pointerdown', this.pointerHandler, true);
+    window.addEventListener('keydown', this.keyHandler, true);
+    this.hasListeners = true;
+  }
+
+  private unregisterListeners(): void {
+    if (!this.hasListeners) return;
+
+    window.removeEventListener('pointerdown', this.pointerHandler, true);
+    window.removeEventListener('keydown', this.keyHandler, true);
+    this.hasListeners = false;
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -94,6 +94,73 @@ body {
       }
     }
   }
+
+  > #intro-tooltip {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    padding: 0 1.5rem 4.5rem;
+    pointer-events: none;
+    z-index: 5;
+    opacity: 0;
+    transform: translateY(16px);
+    transition: opacity 220ms ease-out, transform 220ms ease-out;
+
+    &[data-state='visible'] {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    > .intro-tooltip__bubble {
+      pointer-events: none;
+      background: rgba(36, 36, 38, 0.92);
+      color: rgba(255, 255, 255, 0.95);
+      font-family: 'Arial', 'Sans-Serif';
+      font-size: 1rem;
+      line-height: 1.4;
+      padding: 1rem 1.25rem;
+      border-radius: 16px;
+      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+      max-width: min(360px, 80vw);
+      text-align: center;
+      animation: intro-tooltip-float 3.2s ease-in-out infinite;
+    }
+
+    .intro-tooltip__title {
+      margin: 0 0 0.35rem;
+      font-size: 1.05em;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+
+    .intro-tooltip__description {
+      margin: 0;
+      font-size: 0.95em;
+      opacity: 0.88;
+    }
+  }
+}
+
+@keyframes intro-tooltip-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body > #intro-tooltip {
+    transition: none;
+
+    > .intro-tooltip__bubble {
+      animation: none;
+    }
+  }
 }
 
 @keyframes lds-ellipsis1 {


### PR DESCRIPTION
## Summary
- add an intro tooltip overlay that appears once per player and persists a dismissal flag
- integrate the tooltip lifecycle into the intro screen so it hides after interaction or a timeout without blocking input
- style the overlay with subtle motion that respects reduced-motion settings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b786afbc8328901d67c9ecd24529