### PR TITLE
Add orientation hint for small landscape devices

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,17 @@
   </head>
   <body>
     <canvas id="main-canvas"></canvas>
+    <div
+      id="orientation-hint"
+      role="alert"
+      aria-live="assertive"
+      aria-hidden="true"
+    >
+      <span class="orientation-hint__icon" aria-hidden="true">🔄</span>
+      <span class="orientation-hint__message"
+        >Rotate your device to continue in portrait.</span
+      >
+    </div>
     <div id="loading-modal">
       <div>Loading</div>
       <div class="lds-ellipsis">

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,36 @@ const gameIcon = document.createElement('img');
 const canvas = document.querySelector<HTMLCanvasElement>('#main-canvas')!;
 const physicalContext = canvas.getContext('2d')!;
 const loadingScreen = document.querySelector<HTMLDivElement>('#loading-modal')!;
+const orientationHint = document.querySelector<HTMLDivElement>('#orientation-hint');
 const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
 
 let isLoaded = false;
+
+const SMALL_LANDSCAPE_MAX_SHORT_EDGE = 600;
+
+const shouldShowOrientationHint = () => {
+  if (!orientationHint) return false;
+
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  const isLandscape = width > height;
+  const shortEdge = Math.min(width, height);
+
+  return isLandscape && shortEdge <= SMALL_LANDSCAPE_MAX_SHORT_EDGE;
+};
+
+const updateOrientationHint = () => {
+  if (!orientationHint) return;
+
+  const shouldShow = shouldShowOrientationHint();
+  orientationHint.classList.toggle('is-visible', shouldShow);
+  orientationHint.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+};
+
+const scheduleOrientationHintUpdate = () => {
+  window.requestAnimationFrame(updateOrientationHint);
+};
 
 gameIcon.src = gameSpriteIcon;
 
@@ -81,6 +107,8 @@ const [game_running, game_start] = createRAF(targetFPS(GameUpdate, 60));
 window.addEventListener('DOMContentLoaded', () => {
   loadingScreen.insertBefore(gameIcon, loadingScreen.childNodes[0]);
 
+  updateOrientationHint();
+
   prepareAssets(() => {
     isLoaded = true;
 
@@ -97,7 +125,11 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 window.addEventListener('resize', () => {
+  scheduleOrientationHintUpdate();
+
   if (!isLoaded) return;
 
   ScreenResize();
 });
+
+window.addEventListener('orientationchange', scheduleOrientationHintUpdate);

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -30,6 +30,53 @@ body {
     position: absolute;
   }
 
+  > #orientation-hint {
+    position: fixed;
+    top: 1.5rem;
+    left: 50%;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    transform: translate(-50%, -10px);
+    max-width: min(90vw, 28rem);
+    padding: 0.75rem 1rem;
+    border-radius: 999px;
+    background-color: rgba(12, 12, 12, 0.92);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+    color: rgba(255, 255, 255, 0.94);
+    font-family: 'Arial', 'Sans-Serif';
+    font-size: 0.95rem;
+    font-weight: 600;
+    line-height: 1.35;
+    letter-spacing: 0.02em;
+    text-align: left;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.24s ease, transform 0.24s ease, visibility 0.24s ease;
+
+    &.is-visible {
+      opacity: 1;
+      visibility: visible;
+      transform: translate(-50%, 0);
+    }
+
+    > .orientation-hint__icon {
+      font-size: 1.4rem;
+      filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.35));
+    }
+
+    > .orientation-hint__message {
+      flex: 1 1 auto;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    > #orientation-hint {
+      transition: none;
+    }
+  }
+
   > #loading-modal {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- add an orientation hint container to the base HTML layout for mobile users
- detect small landscape viewports via resize and orientation change events and toggle the hint
- style the hint banner to be accessible, high-contrast, and motion-aware

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1b7871630832895efce7f794d550a