### PR TITLE
Enhance screen documentation for intro and gameplay flows

### DIFF
--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -1,10 +1,25 @@
 // File Overview: This module belongs to src/screens/gameplay.ts.
 /**
- * Display "Get Ready" & "Instruction"
- * Let the bird swing while waiting...
- * No Pipes
- * Wait for the tap event
- * */
+ * Gameplay screen orchestrating the active run experience once ScreenChanger
+ * hands control off from the intro. It coordinates BirdModel, pipes, banners,
+ * score display, ghost playback, and transition overlays while exposing the
+ * ParentClass lifecycle contract so the screen can be resized or paused and
+ * later re-mounted without state leakage.
+ *
+ * Initialization provisions all dependent models (bird, pipe generator,
+ * countdown, instructions, scoreboard, flash overlays) and connects scoreboard
+ * callbacks to FlashScreen transitions that notify ScreenChanger when the
+ * player restarts. Resetting rewinds environmental models and clears ghost
+ * samples to maintain deterministic restarts.
+ *
+ * Event handlers gate tap/click input based on death state: active runs convert
+ * clicks into flap commands and start ghost recording, while post-death input
+ * is routed exclusively to the scoreboard so the replay and restart buttons
+ * remain responsive. UX-specific touches include delaying scoreboard reveal
+ * behind paired swoosh SFX, pausing the background when the bird dies, hiding
+ * the bird during scoreboard presentation, and rendering a translucent ghost
+ * trail to preview the prior attempt for coaching-oriented feedback.
+ */
 
 import BannerInstruction from '../model/banner-instruction';
 import BirdModel from '../model/bird';

--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -1,13 +1,23 @@
 // File Overview: This module belongs to src/screens/intro.ts.
 /**
- * Display "FlappyBird"
- * Display the bird close to the middle and at the center
+ * Intro screen responsible for bootstrapping the main menu experience that
+ * precedes gameplay. ScreenChanger mounts this class to present the brand
+ * banner, looping bird animation, and the primary interaction controls that
+ * trigger a transition into the gameplay screen.
  *
- * Display "Play" button and include the
- * "Ranking" button but with no function. Just to mimic the
- * original game since ranking only works if the game is
- * connected to Google Play Games or Apple Game Center
- * */
+ * UI initialization wires up BirdModel plus the Play, Ranking, and Speaker
+ * toggle buttons so ParentClass lifecycle callbacks (init/resize/Update/
+ * Display) keep them synchronized with the current canvas dimensions. All
+ * models are created eagerly and cached to ensure ScreenChanger can swap back
+ * without reallocating assets.
+ *
+ * Event hooks funnel mouse/touch activity to each button model and surface the
+ * "start" affordance through both mouseUp and keyboard entry (startAtKeyboard
+ * simply clicks the Play button). UX nuances include always activating the
+ * audio toggle regardless of play state, updating the bird idle animation via
+ * doWave to keep the scene lively, and drawing the scaled title banner after
+ * controls so it never overlaps touch targets.
+ */
 
 import { rescaleDim } from '../utils';
 


### PR DESCRIPTION
## Summary
- replace placeholder headers in the intro and gameplay screens with detailed summaries of their UI setup and ScreenChanger lifecycle hooks
- document how each screen initializes dependent models, routes input events, and manages transitions between screens
- capture notable UX behaviors such as banner rendering order, ghost trail playback, and scoreboard-driven restarts to aid future updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c2310ed88328ae55d6db5d96e093