### PR TITLE
Organize utility barrel exports by category

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,9 +1,22 @@
-// File Overview: This module belongs to src/utils/index.ts.
+/**
+ * Utility barrel that re-exports the helper modules used across the game.
+ *
+ * Categories exported from this file:
+ * - Math helpers: `rescaleDim`, `lerp`, `clamp`, `randomClamp`, `flipRange`
+ * - Animation helpers: `framer`, `waves`
+ * - DOM helpers: `openInNewTab`
+ */
+
+// Math helpers
 export * from './rescale-dim';
-export * from './framer';
 export * from './linear-interpolation';
 export * from './clamp';
 export * from './random-clamp';
-export * from './waves';
-export * from './flip-range';
+export * from './flip-range'; // Mirrors a value within the provided range for ping-pong style effects
+
+// Animation helpers
+export * from './framer';
+export * from './waves'; // Time-based sine/cosine oscillators useful for subtle ambient motion
+
+// DOM helpers
 export * from './open-in-new-tab';


### PR DESCRIPTION
## Summary
- document the purpose of the utility barrel and the categories of helpers it aggregates
- group exports by math, animation, and DOM helpers for easier discovery
- add inline notes for less obvious helpers like `flipRange` and the wave generators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c231eba0832890eab250b26a775f