### PR TITLE
Document unified input handling in events module

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,17 @@
-// File Overview: This module belongs to src/events.ts.
 /**
- * Interactive
+ * Centralizes user input for the game canvas by mapping mouse, touch, and
+ * keyboard events onto a shared "mouse" state that Game consumes. Pointer
+ * coordinates are translated from viewport space to canvas space via
+ * `getBoundingClientRect` so Game always receives device-independent values.
+ * Repeated taps/clicks are debounced through `likeClickedEvent`, which only
+ * forwards the first press in a down/up cycle to `Game.onClick` so score
+ * screens behave consistently. Each first interaction for a press also calls
+ * `WebSfx.init()` to unlock audio playback (required by some browsers) before
+ * delegating to `Game.mouseDown`/`Game.mouseUp`. The shared `hasMouseDown` /
+ * `hasMouseUp` toggles ensure each physical press only fires once per phase.
+ * Keyboard Space/Enter presses call `Game.startAtKeyBoardEvent()` and then
+ * simulate centered pointer events so the Game and WebSfx pipelines stay
+ * synchronized regardless of input type.
  */
 
 import Game from './game';


### PR DESCRIPTION
## Summary
- replace the placeholder header in `src/events.ts` with a detailed doc comment
- describe how mouse, touch, and keyboard input are normalized for `Game`
- call out the click debouncing and audio unlock side effects for future input work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c233b258832887621b62e131b983