### PR TITLE
Document lib services with detailed module docblocks

### DIFF
--- a/src/lib/animation/abstracts/default-properties.ts
+++ b/src/lib/animation/abstracts/default-properties.ts
@@ -1,4 +1,20 @@
-// File Overview: This module belongs to src/lib/animation/abstracts/default-properties.ts.
+/**
+ * Shared timeline state for all animation classes.
+ *
+ * Role
+ * - Tracks start timestamps and running/completion flags that concrete animation subclasses use
+ *   to compute progress.
+ * - Serves as the base for `Fading`, `Flying`, and `TimingEvent` so sibling classes operate on a
+ *   consistent notion of elapsed time (`timeDiff`).
+ *
+ * Inputs & Outputs
+ * - Provides `start()`, `stop()`, and `reset()` lifecycle hooks for subclasses.
+ * - Exposes `timeDiff` for measuring the milliseconds since `start()` was invoked.
+ *
+ * Implementation Notes
+ * - Relies on `performance.now()` to avoid `Date` precision issues inside requestAnimationFrame
+ *   loops.
+ */
 export default abstract class DefaultProperties {
   protected isRunning: boolean;
   protected isComplete: boolean;

--- a/src/lib/animation/abstracts/fading.ts
+++ b/src/lib/animation/abstracts/fading.ts
@@ -1,4 +1,19 @@
-// File Overview: This module belongs to src/lib/animation/abstracts/fading.ts.
+/**
+ * Base class for opacity-based transitions.
+ *
+ * Role
+ * - Extends `DefaultProperties` with easing-aware fade helpers used by `FadeOut` and
+ *   `FadeOutIn`.
+ * - Stores configurable duration and easing curve so sibling animations can share timing rules.
+ *
+ * Inputs & Outputs
+ * - Constructor optionally accepts a partial `IFadingOptions` to tweak duration or easing.
+ * - Subclasses access `inUseTransition()` to convert raw progress values into eased opacity.
+ *
+ * Implementation Notes
+ * - Delegates easing selection to `animation/easing.ts` via the `IEasingKey` enumeration, keeping
+ *   easing math centralized.
+ */
 import DefaultProps from './default-properties';
 import { IEasingKey } from '../easing';
 import * as easing from '../easing';

--- a/src/lib/animation/abstracts/flying.ts
+++ b/src/lib/animation/abstracts/flying.ts
@@ -1,4 +1,19 @@
-// File Overview: This module belongs to src/lib/animation/abstracts/flying.ts.
+/**
+ * Base class for position interpolation animations.
+ *
+ * Role
+ * - Provides vector-based lerp helpers for moving sprites between coordinates.
+ * - Shared by the concrete `Fly` animation so movement uses the same timing/easing configuration
+ *   as other animation modules.
+ *
+ * Inputs & Outputs
+ * - Constructor accepts starting/ending coordinates plus optional duration/easing overrides.
+ * - Subclasses read `inUseTransition()` and the stored coordinate options to compute frames.
+ *
+ * Implementation Notes
+ * - Extends `DefaultProperties` for lifecycle management and uses easing functions from
+ *   `animation/easing.ts` to translate elapsed time into normalized interpolation weights.
+ */
 import IDefaultProperties from './default-properties';
 import { IEasingKey } from '../easing';
 import * as easing from '../easing';

--- a/src/lib/animation/anims/bounce-in.ts
+++ b/src/lib/animation/anims/bounce-in.ts
@@ -1,10 +1,21 @@
-// File Overview: This module belongs to src/lib/animation/anims/bounce-in.ts.
 /**
- * From given coordinate, it will bounce up once while fading in
- * Fade-in duration will be 0.5 sec
- * Bounce duration will be 1 sec
+ * Produces a "bounce in" entrance animation that combines a vertical hop with a fade.
  *
- * */
+ * Role
+ * - Extends `DefaultProps` to reuse lifecycle tracking shared across animation siblings.
+ * - Couples easing curves from `easing.ts` so both the opacity and bounce height follow the
+ *   configured durations.
+ *
+ * Inputs & Outputs
+ * - Constructor accepts optional duration overrides for the fade and bounce phases via
+ *   `IBounceInConstructor`.
+ * - `value` exposes the current opacity and positional offset, allowing screens to drive CSS
+ *   styles or canvas transforms.
+ *
+ * Implementation Notes
+ * - Uses the sine-wave easing helper so the bounce peaks halfway through the duration while the
+ *   fade relies on the swing curve, mirroring other fade animations in this folder.
+ */
 import DefaultProps from '../abstracts/default-properties';
 import * as easing from '../easing';
 

--- a/src/lib/animation/anims/fade-out-in.ts
+++ b/src/lib/animation/anims/fade-out-in.ts
@@ -1,4 +1,18 @@
-// File Overview: This module belongs to src/lib/animation/anims/fade-out-in.ts.
+/**
+ * Alternates between fading a sprite out and then back in using a single animation cycle.
+ *
+ * Role
+ * - Inherits the easing/duration configuration from the shared `Fading` abstract so it stays in
+ *   sync with other fade-based effects.
+ *
+ * Inputs & Outputs
+ * - Uses the configured duration twice (once for each direction) and exposes the interpolated
+ *   opacity via the `value` getter, clamping to `1` when idle.
+ *
+ * Implementation Notes
+ * - Relies on the stored `startTime` from `DefaultProperties` to determine where the animation is
+ *   within its out/in cycle before calling `inUseTransition`.
+ */
 import Fading from '../abstracts/fading';
 
 export class FadeOutIn extends Fading {

--- a/src/lib/animation/anims/fade-out.ts
+++ b/src/lib/animation/anims/fade-out.ts
@@ -1,4 +1,18 @@
-// File Overview: This module belongs to src/lib/animation/anims/fade-out.ts.
+/**
+ * Implements a one-way fade-to-transparent animation.
+ *
+ * Role
+ * - Builds on the shared `Fading` base to reuse easing selection and duration management alongside
+ *   sibling fade animations.
+ *
+ * Inputs & Outputs
+ * - Consumes the duration configured on the parent class and exposes the current opacity through
+ *   the `value` getter, returning `0` once the animation completes.
+ *
+ * Implementation Notes
+ * - Uses the `flipRange` utility so the chosen easing curve can be applied in reverse without
+ *   reimplementing easing functions.
+ */
 import AbsFading from '../abstracts/fading';
 import { flipRange } from '../../../utils';
 

--- a/src/lib/animation/anims/flying.ts
+++ b/src/lib/animation/anims/flying.ts
@@ -1,4 +1,18 @@
-// File Overview: This module belongs to src/lib/animation/anims/flying.ts.
+/**
+ * Drives sprite movement between two coordinates with easing.
+ *
+ * Role
+ * - Extends the shared `Flying` abstract so movement animations respect the same timing settings
+ *   as other modules within `animation/`.
+ *
+ * Inputs & Outputs
+ * - Consumes the `from`/`to` coordinates defined on the base class and returns the interpolated
+ *   position via the `value` getter.
+ *
+ * Implementation Notes
+ * - Uses the `lerp` utility with the easing curve selected by `Flying` to avoid manual math for
+ *   each axis and ensures the final frame snaps exactly to the destination.
+ */
 import IFlying from '../abstracts/flying';
 import { lerp } from '../../../utils';
 

--- a/src/lib/animation/anims/timing-event.ts
+++ b/src/lib/animation/anims/timing-event.ts
@@ -1,8 +1,21 @@
-// File Overview: This module belongs to src/lib/animation/anims/timing-event.ts.
 /**
- * I did include this Timing event into animation
- * since it will animate the numbers
- * */
+ * Emits periodic ticks that align with animation timing.
+ *
+ * Role
+ * - Shares the `DefaultProps` lifecycle with other animation classes so HUD counters can be driven
+ *   by the same requestAnimationFrame cadence.
+ * - Complements sibling fade/movement animations by providing a simple cadence trigger (e.g., to
+ *   increment a score display).
+ *
+ * Inputs & Outputs
+ * - Constructor accepts an optional `diff` interval specifying how frequently `value` should return
+ *   `true`.
+ * - `value` returns a boolean flag indicating whether the interval elapsed since the previous tick.
+ *
+ * Implementation Notes
+ * - Resets `startTime` after each trigger to avoid drift and keeps state local so consumers can
+ *   poll without additional bookkeeping.
+ */
 
 import DefaultProps from '../abstracts/default-properties';
 

--- a/src/lib/animation/easing.ts
+++ b/src/lib/animation/easing.ts
@@ -1,4 +1,19 @@
-// File Overview: This module belongs to src/lib/animation/easing.ts.
+/**
+ * Collection of easing curves consumed by animation classes for smooth motion and opacity
+ * transitions.
+ *
+ * Role
+ * - Supplies deterministic easing functions to the abstract bases in `abstracts/` so concrete
+ *   animations can interpolate between values without duplicating math.
+ *
+ * Inputs & Outputs
+ * - Each exported function accepts a normalized progress value (`0`-`1`) and returns a remapped
+ *   value suitable for lerping positions, opacity, or other scalar properties.
+ *
+ * Implementation Notes
+ * - Functions mirror common easing curves (swing, quadratic, cubic bezier, sine wave, etc.) and
+ *   expose a shared `IEasingUtils` interface for type-safe selection.
+ */
 export type IProgressFunction = (t: number) => number;
 
 export interface IEasingUtils {

--- a/src/lib/animation/index.ts
+++ b/src/lib/animation/index.ts
@@ -1,4 +1,15 @@
-// File Overview: This module belongs to src/lib/animation/index.ts.
+/**
+ * Aggregates the public animation primitives for the game loop.
+ *
+ * Role
+ * - Re-exports the individual animation classes so screens can import from a single module.
+ * - Couples concrete animations with their shared abstract bases from `abstracts/` and easing
+ *   helpers in this package.
+ *
+ * Exports
+ * - Animation classes that implement various transition effects (`fade-out`, `bounce-in`, etc.)
+ *   as well as the `timing-event` helper used to throttle repeated callbacks.
+ */
 export * from './anims/fade-out';
 export * from './anims/fade-out-in';
 export * from './anims/flying';

--- a/src/lib/asset-loader/abstraction.ts
+++ b/src/lib/asset-loader/abstraction.ts
@@ -1,4 +1,21 @@
-// File Overview: This module belongs to src/lib/asset-loader/abstraction.ts.
+/**
+ * Defines the shared contract for asset loader drivers (audio, images, etc.).
+ *
+ * Role
+ * - Wraps source URL tracking and load completion bookkeeping that concrete loaders rely on to
+ *   signal when all relevant events have fired.
+ * - Exposes an abstract `test`/`load` interface so `AssetsLoader` can select the appropriate driver
+ *   at runtime without knowing the implementation details.
+ *
+ * Inputs & Outputs
+ * - Constructor accepts the asset source path; subclasses call `eventTracking` until all required
+ *   events resolve the promise with `{ source, object }`.
+ * - Static `regexp` on subclasses is used by the registry to match file extensions.
+ *
+ * Implementation Notes
+ * - `eventTracking` decrements the expected ready count and resolves once the loader-specific
+ *   events (e.g., `load`, `canplay`) finish firing.
+ */
 import { IPromiseResolve } from './interfaces';
 
 class ParentLoader {

--- a/src/lib/asset-loader/index.ts
+++ b/src/lib/asset-loader/index.ts
@@ -1,4 +1,22 @@
-// File Overview: This module belongs to src/lib/asset-loader/index.ts.
+/**
+ * Coordinates loading of external assets (images, audio) through registered loader drivers.
+ *
+ * Role
+ * - Accepts a list of asset URLs, selects the appropriate loader (`audio`, `image`, etc.), and
+ *   caches the resulting DOM objects for later retrieval.
+ * - Provides a simple promise-like `then` API that fires once all assets are ready so game screens
+ *   can begin rendering.
+ *
+ * Inputs & Outputs
+ * - Constructor receives an array of source strings and kicks off loading immediately.
+ * - `then(callback)`: invoked when all requested assets resolve.
+ * - `get(key)`: returns the cached asset instance (`HTMLImageElement` or `HTMLAudioElement`).
+ *
+ * Implementation Notes
+ * - Iterates over the loader registry defined in `loaders/` to find a driver whose `test` method
+ *   matches the source path extension.
+ * - Stores assets in a static map so subsequent calls can fetch them without reloading.
+ */
 import AudioLoader from './loaders/audio';
 import ImageLoader from './loaders/image';
 import { IPromiseResolve, ILoaders } from './interfaces';

--- a/src/lib/asset-loader/interfaces.ts
+++ b/src/lib/asset-loader/interfaces.ts
@@ -1,4 +1,14 @@
-// File Overview: This module belongs to src/lib/asset-loader/interfaces.ts.
+/**
+ * Shared type declarations for the asset loader subsystem.
+ *
+ * Role
+ * - Describes the payload resolved by loader promises and the constructor signature that concrete
+ *   loader implementations must follow.
+ *
+ * Inputs & Outputs
+ * - `IPromiseResolve` defines the `{ source, object }` tuple emitted by each loader.
+ * - `ILoaders` is consumed by `asset-loader/index.ts` to store class constructors in its registry.
+ */
 import { AbstractLoader } from './abstraction';
 
 export interface IPromiseResolve {

--- a/src/lib/asset-loader/loaders/audio.ts
+++ b/src/lib/asset-loader/loaders/audio.ts
@@ -1,4 +1,21 @@
-// File Overview: This module belongs to src/lib/asset-loader/loaders/audio.ts.
+/**
+ * Loader implementation for audio assets.
+ *
+ * Role
+ * - Extends the abstract loader to handle `<audio>` creation and lifecycle events (`load`,
+ *   `canplay`, `canplaythrough`).
+ * - Works in tandem with `loaders/image.ts` so the registry can cover both visual and audio assets
+ *   through a consistent interface.
+ *
+ * Inputs & Outputs
+ * - `test()`: checks whether the supplied source matches supported audio extensions.
+ * - `load()`: returns a promise resolving with `{ source, object: HTMLAudioElement }` once all
+ *   readiness events fire.
+ *
+ * Implementation Notes
+ * - Waits for multiple readiness events to ensure playback can start without buffering hiccups
+ *   before resolving back to `AssetsLoader`.
+ */
 import { IPromiseResolve } from '../interfaces';
 import { AbstractLoader } from '../abstraction';
 

--- a/src/lib/asset-loader/loaders/image.ts
+++ b/src/lib/asset-loader/loaders/image.ts
@@ -1,4 +1,19 @@
-// File Overview: This module belongs to src/lib/asset-loader/loaders/image.ts.
+/**
+ * Loader implementation for image assets.
+ *
+ * Role
+ * - Complements `loaders/audio.ts` by handling `<img>` creation and load/error events.
+ * - Shares the abstract loader contract so `AssetsLoader` can manage heterogeneous asset types
+ *   uniformly.
+ *
+ * Inputs & Outputs
+ * - `test()`: verifies the source filename matches supported image extensions.
+ * - `load()`: resolves with `{ source, object: HTMLImageElement }` once the image is ready to use.
+ *
+ * Implementation Notes
+ * - Only waits for the `load` event (images do not expose additional readiness events) and relies
+ *   on the base `eventTracking` helper to notify the orchestrator when complete.
+ */
 import { IPromiseResolve } from '../interfaces';
 import { AbstractLoader } from '../abstraction';
 

--- a/src/lib/screen-changer/index.ts
+++ b/src/lib/screen-changer/index.ts
@@ -1,4 +1,21 @@
-// File Overview: This module belongs to src/lib/screen-changer/index.ts.
+/**
+ * Simple state machine for switching between registered screen controllers.
+ *
+ * Role
+ * - Stores a map of screen implementations (intro screen, gameplay screen, etc.) that each expose
+ *   `Update` and `Display` methods.
+ * - Provides a `setState` method so the game loop can pivot between registered screens without
+ *   tight coupling.
+ *
+ * Inputs & Outputs
+ * - `register(name, classObject)`: associates an identifier with an `IScreenChangerObject`.
+ * - `setState(state)`: selects which registered object receives subsequent `Update`/`Display`
+ *   calls.
+ *
+ * Implementation Notes
+ * - Throws if an unknown state is requested, making missing registrations easier to diagnose during
+ *   development.
+ */
 export interface IScreenChangerObject {
   Update(): void;
   Display(context: CanvasRenderingContext2D): void;

--- a/src/lib/sprite-destructor/index.ts
+++ b/src/lib/sprite-destructor/index.ts
@@ -1,7 +1,23 @@
-// File Overview: This module belongs to src/lib/sprite-destructor/index.ts.
 /**
- * A sprite destructor
- * */
+ * Extracts sub-images from a sprite sheet and caches them for reuse.
+ *
+ * Role
+ * - Provides a utility for slicing the atlas provided by the asset loader into named sprites and
+ *   storing them in memory for quick lookup.
+ * - Works alongside `asset-loader` (for initial sheet loading) and the rendering code that consumes
+ *   the extracted `HTMLImageElement`s.
+ *
+ * Inputs & Outputs
+ * - Constructed with a base `HTMLImageElement` representing the sprite sheet.
+ * - `cutOut(name, sx, sy, dx, dy)`: draws a subsection of the sheet and schedules it for caching
+ *   under `name`.
+ * - `then(callback)`: resolves when all queued cutouts have been materialized.
+ * - `asset(key)`: returns a cached sprite by name, throwing if it has not been generated yet.
+ *
+ * Implementation Notes
+ * - Uses an off-screen `<canvas>` to render each sub-image, converts it into a data URL, and lazily
+ *   populates a static cache map shared across instances.
+ */
 
 export interface IPromiseImageHandled {
   name: string;

--- a/src/lib/stats/index.ts
+++ b/src/lib/stats/index.ts
@@ -1,4 +1,21 @@
-// File Overview: This module belongs to src/lib/stats/index.ts.
+/**
+ * Lightweight FPS and debug text overlay renderer.
+ *
+ * Role
+ * - Tracks frame timestamps to compute frames-per-second metrics for diagnostics.
+ * - Draws both background containers and formatted text onto a provided canvas context so game
+ *   screens can visualize performance information.
+ *
+ * Inputs & Outputs
+ * - Constructor accepts the target `CanvasRenderingContext2D`.
+ * - `text(position, preText, postText)`: configures the label drawn alongside the FPS value.
+ * - `container(startingPoint, endPoint)`: sets the dimensions for the overlay background.
+ * - `mark()`: records the current frame, updates rolling FPS, and renders the overlay.
+ *
+ * Implementation Notes
+ * - Maintains a sliding window of timestamps rather than averaging to ensure FPS reflects the last
+ *   second of frames.
+ */
 interface ITextProperties {
   position: ICoordinate;
   preText: string;

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,4 +1,24 @@
-// File Overview: This module belongs to src/lib/storage/index.ts.
+/**
+ * Namespaced wrapper around `window.localStorage` used to persist scores and settings per
+ * deployment.
+ *
+ * Role
+ * - Derives a namespace from the current GitHub Pages URL so multiple builds can safely
+ *   share the same origin without colliding keys.
+ * - Provides helpers for Base64-safe stringification (`utoa`/`atou`) and value type tagging.
+ *
+ * Inputs & Outputs
+ * - `save(key, value)`: accepts a string key and a primitive value (`string | number | boolean`).
+ *   The method encodes the value and stores it in `localStorage` if available.
+ * - `get(key)`: returns the original primitive value or `undefined` when not found or when
+ *   storage is unavailable.
+ *
+ * Implementation Notes
+ * - Availability is checked once in the constructor to avoid quota errors in restricted
+ *   environments.
+ * - Values are JSON encoded together with their primitive type before Base64 encoding so
+ *   retrieval can restore the correct type rather than always returning strings.
+ */
 export type IStoreValue = string | number | boolean;
 export interface IData {
   type: IStoreValue;

--- a/src/lib/web-sfx/index.ts
+++ b/src/lib/web-sfx/index.ts
@@ -1,8 +1,26 @@
-// File Overview: This module belongs to src/lib/web-sfx/index.ts.
 /**
- * A library for handling sound Effects
- * Handling Sound Effects
- * */
+ * Web Audio-powered sound effect manager.
+ *
+ * Role
+ * - Instantiates a shared `AudioContext`, downloads and decodes effect files, and exposes helpers
+ *   for playing them with consistent gain control.
+ * - Complements the asset loader by handling audio formats that require Web Audio decoding rather
+ *   than DOM `<audio>` playback.
+ *
+ * Inputs & Outputs
+ * - Constructor receives an object mapping logical names to asset URLs and a callback invoked once
+ *   decoding completes.
+ * - `play(key, endedcb?)`: plays a cached `AudioBuffer` by name and optionally notifies when the
+ *   buffer ends.
+ * - `volume(num)`: adjusts the shared gain node volume.
+ * - `init()`: resumes the audio context on a user gesture and creates the gain node if necessary.
+ *
+ * Implementation Notes
+ * - Maintains a static cache of decoded `AudioBuffer`s keyed by both logical names and original
+ *   paths for flexible lookup.
+ * - Batches concurrent network requests to avoid overwhelming the browser, and tracks
+ *   `AudioContext` readiness so playback calls can fail fast when the context has not yet resumed.
+ */
 
 export type IWebSfxObject = Record<string, string>;
 export type IWebSfxCache = Record<string, AudioBuffer>;

--- a/src/lib/workbox-work-offline/index.ts
+++ b/src/lib/workbox-work-offline/index.ts
@@ -1,7 +1,20 @@
-// File Overview: This module belongs to src/lib/workbox-work-offline/index.ts.
 /**
- * https://webpack.js.org/guides/progressive-web-application/
- * */
+ * Registers the Workbox-generated service worker in production builds.
+ *
+ * Role
+ * - Guards the registration call with feature detection and defers execution until `window.load`
+ *   so webpack's generated worker can precache assets for offline usage.
+ * - Lives alongside Webpack's Workbox plugin output and is imported by the app entry during
+ *   production.
+ *
+ * Inputs & Outputs
+ * - No inputs; executing the default export attaches an event listener and returns `void`.
+ * - Logs registration success or failure to the console for diagnostics.
+ *
+ * Implementation Notes
+ * - Keeps the implementation minimal because webpack injects the worker path and Workbox handles
+ *   runtime caching configuration.
+ */
 export default () => {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- replace placeholder headers across lib modules with descriptive docblocks outlining their roles
- capture animation, asset loading, and sprite/audio helpers' interactions to aid future contributors
- clarify supporting utilities like storage, stats, and service-worker registration with usage notes

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e2c2302cd08328ba0b2b8f720ff084