### PR TITLE
Align scoreboard medal presentation

### DIFF
--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -277,9 +277,10 @@ export default class ScoreBoard extends ParentObject {
       { width: parentSize.width * 0.22 }
     );
 
+    const medalCenterX = coord.x + parentSize.width * 0.213;
     const pos = {
-      x: coord.x + parentSize.width * 0.145,
-      y: coord.y + parentSize.height * 0.46
+      x: medalCenterX - scaled.width / 2,
+      y: coord.y + parentSize.height * 0.27
     };
 
     context.drawImage(medal, pos.x, pos.y, scaled.width, scaled.height);
@@ -299,7 +300,7 @@ export default class ScoreBoard extends ParentObject {
       context,
       medalTier.label,
       pos.x + scaled.width / 2,
-      pos.y + scaled.height + parentSize.height * 0.04,
+      pos.y + scaled.height + parentSize.height * 0.02,
       parentSize
     );
   }
@@ -332,9 +333,9 @@ export default class ScoreBoard extends ParentObject {
     context.font = `${fontSize}px 'Press Start 2P', 'Roboto', sans-serif`;
     context.textAlign = 'center';
     context.textBaseline = 'top';
-    context.lineWidth = Math.max(parentSize.width * 0.007, 1.5);
-    context.strokeStyle = 'rgba(0, 0, 0, 0.6)';
-    context.fillStyle = '#ffffff';
+    context.lineWidth = Math.max(parentSize.width * 0.006, 1.25);
+    context.strokeStyle = '#543847';
+    context.fillStyle = '#fc7858';
 
     const text = label.toUpperCase();
     context.strokeText(text, centerX, topY);


### PR DESCRIPTION
## Summary
- align the medal icon with the MEDAL heading on the scoreboard for a vertical stack
- tighten the achievement label spacing and recolor it to match the scoreboard typography

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e347e6a1208328b0c9ff58eb683d46