### PR TITLE
Adjust medal placement on scoreboard

### DIFF
--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -278,9 +278,15 @@ export default class ScoreBoard extends ParentObject {
     );
 
     const medalCenterX = coord.x + parentSize.width * 0.213;
+    const scoreBoardImage = this.images.get('score-board');
+    const pixelOffset =
+      scoreBoardImage && scoreBoardImage.height > 0
+        ? (parentSize.height / scoreBoardImage.height) * 2
+        : 2;
+
     const pos = {
       x: medalCenterX - scaled.width / 2,
-      y: coord.y + parentSize.height * 0.27
+      y: coord.y + parentSize.height * 0.27 + pixelOffset
     };
 
     context.drawImage(medal, pos.x, pos.y, scaled.width, scaled.height);


### PR DESCRIPTION
## Summary
- shift the medal drawing position downward by a scaled pixel offset so it sits slightly lower on the scoreboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e34c7c1c7c832897bcf2186bbad48b