### PR TITLE
Replace medal artwork with pixelated sprites

### DIFF
--- a/src/assets/medal-bronze.svg
+++ b/src/assets/medal-bronze.svg
@@ -1,17 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
-  <defs>
-    <linearGradient id="bronze-medal" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#f2a772" />
-      <stop offset="100%" stop-color="#b66a2e" />
-    </linearGradient>
-    <linearGradient id="bronze-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#823d1a" />
-      <stop offset="100%" stop-color="#a44f22" />
-    </linearGradient>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 28" shape-rendering="crispEdges">
   <g fill="none" fill-rule="evenodd">
-    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#bronze-ribbon)" />
-    <circle cx="64" cy="64" r="56" fill="url(#bronze-medal)" stroke="#8a4f23" stroke-width="8" />
-    <polygon points="64 26 72.9 49.2 98 49.2 77.5 64.8 86.4 88 64 72.8 41.6 88 50.5 64.8 30 49.2 55.1 49.2" fill="#fff1d6" stroke="#d78e4b" stroke-width="4" stroke-linejoin="round" />
+    <path fill="#C97B45" d="M6 0H12V1H13V2H14V3H15V4H16V12H15V13H14V14H13V15H12V16H6V15H5V14H4V13H3V12H2V4H3V3H4V2H5V1H6V0Z"/>
+    <path fill="#E8A76A" d="M6 1H7V4H8V5H9V6H8V7H7V12H6V1Z"/>
+    <path fill="#9C5426" d="M12 1H13V2H14V3H15V4H14V5H13V6H12V1Z"/>
+    <path fill="#9C5426" d="M12 9H13V10H14V12H13V13H12V9Z"/>
+    <rect width="3" height="1" x="8" y="4" fill="#FFE1B8"/>
+    <rect width="1" height="1" x="10" y="5" fill="#FFE1B8"/>
+    <rect width="2" height="1" x="9" y="6" fill="#FFE1B8"/>
+    <rect width="1" height="1" x="10" y="7" fill="#FFE1B8"/>
+    <rect width="2" height="1" x="9" y="8" fill="#FFE1B8"/>
+    <rect width="1" height="1" x="10" y="9" fill="#FFE1B8"/>
+    <rect width="3" height="1" x="8" y="10" fill="#FFE1B8"/>
+    <rect width="3" height="1" x="8" y="11" fill="#FFE1B8"/>
+    <path fill="#9B1C1C" d="M4 16H7V26H6V24H5V26H4V16Z"/>
+    <path fill="#9B1C1C" d="M11 16H14V26H13V24H12V26H11V16Z"/>
+    <path fill="#C23030" d="M7 16H11V18H7V16Z"/>
+    <path fill="#C23030" d="M7 20H11V21H7V20Z"/>
   </g>
 </svg>

--- a/src/assets/medal-gold.svg
+++ b/src/assets/medal-gold.svg
@@ -1,17 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
-  <defs>
-    <linearGradient id="gold-medal" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#ffe680" />
-      <stop offset="100%" stop-color="#d4a200" />
-    </linearGradient>
-    <linearGradient id="gold-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#d4542d" />
-      <stop offset="100%" stop-color="#a52a1b" />
-    </linearGradient>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 28" shape-rendering="crispEdges">
   <g fill="none" fill-rule="evenodd">
-    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#gold-ribbon)" />
-    <circle cx="64" cy="64" r="56" fill="url(#gold-medal)" stroke="#b58700" stroke-width="8" />
-    <polygon points="64 26 72.9 49.2 98 49.2 77.5 64.8 86.4 88 64 72.8 41.6 88 50.5 64.8 30 49.2 55.1 49.2" fill="#fff3c2" stroke="#c79806" stroke-width="4" stroke-linejoin="round" />
+    <path fill="#F5B400" d="M6 0H12V1H13V2H14V3H15V4H16V12H15V13H14V14H13V15H12V16H6V15H5V14H4V13H3V12H2V4H3V3H4V2H5V1H6V0Z"/>
+    <path fill="#FFE066" d="M6 1H7V4H8V5H9V6H8V7H7V12H6V1Z"/>
+    <path fill="#D48806" d="M12 1H13V2H14V3H15V4H14V5H13V6H12V1Z"/>
+    <path fill="#D48806" d="M12 9H13V10H14V12H13V13H12V9Z"/>
+    <rect width="3" height="1" x="8" y="4" fill="#FFF8C9"/>
+    <rect width="1" height="7" x="9" y="5" fill="#FFF8C9"/>
+    <rect width="3" height="1" x="8" y="12" fill="#FFF8C9"/>
+    <path fill="#9B1C1C" d="M4 16H7V26H6V24H5V26H4V16Z"/>
+    <path fill="#9B1C1C" d="M11 16H14V26H13V24H12V26H11V16Z"/>
+    <path fill="#C23030" d="M7 16H11V18H7V16Z"/>
+    <path fill="#C23030" d="M7 20H11V21H7V20Z"/>
   </g>
 </svg>

--- a/src/assets/medal-platinum.svg
+++ b/src/assets/medal-platinum.svg
@@ -1,22 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
-  <defs>
-    <linearGradient id="platinum-medal" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#f5faff" />
-      <stop offset="100%" stop-color="#c7d1da" />
-    </linearGradient>
-    <linearGradient id="platinum-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#6e6ef5" />
-      <stop offset="100%" stop-color="#4a4ab8" />
-    </linearGradient>
-    <radialGradient id="platinum-highlight" cx="50%" cy="30%" r="60%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.9" />
-      <stop offset="100%" stop-color="#d3dbe4" stop-opacity="0" />
-    </radialGradient>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 28" shape-rendering="crispEdges">
   <g fill="none" fill-rule="evenodd">
-    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#platinum-ribbon)" />
-    <circle cx="64" cy="64" r="56" fill="url(#platinum-medal)" stroke="#98a4b1" stroke-width="8" />
-    <circle cx="64" cy="54" r="40" fill="url(#platinum-highlight)" />
-    <polygon points="64 22 74.5 47.3 102 47.3 79.8 63.7 89.2 90 64 74.7 38.8 90 48.2 63.7 26 47.3 53.5 47.3" fill="#ffffff" stroke="#a6b2bf" stroke-width="4" stroke-linejoin="round" />
+    <path fill="#E5E7FB" d="M6 0H12V1H13V2H14V3H15V4H16V12H15V13H14V14H13V15H12V16H6V15H5V14H4V13H3V12H2V4H3V3H4V2H5V1H6V0Z"/>
+    <path fill="#F7F8FF" d="M6 1H7V4H8V5H9V6H8V7H7V12H6V1Z"/>
+    <path fill="#B3BBE5" d="M12 1H13V2H14V3H15V4H14V5H13V6H12V1Z"/>
+    <path fill="#B3BBE5" d="M12 9H13V10H14V12H13V13H12V9Z"/>
+    <rect width="3" height="1" x="8" y="4" fill="#FFFFFF"/>
+    <rect width="1" height="8" x="8" y="5" fill="#FFFFFF"/>
+    <rect width="2" height="1" x="9" y="5" fill="#FFFFFF"/>
+    <rect width="1" height="1" x="10" y="6" fill="#FFFFFF"/>
+    <rect width="1" height="1" x="9" y="7" fill="#FFFFFF"/>
+    <rect width="2" height="1" x="9" y="8" fill="#FFFFFF"/>
+    <path fill="#9B1C1C" d="M4 16H7V26H6V24H5V26H4V16Z"/>
+    <path fill="#9B1C1C" d="M11 16H14V26H13V24H12V26H11V16Z"/>
+    <path fill="#C23030" d="M7 16H11V18H7V16Z"/>
+    <path fill="#C23030" d="M7 20H11V21H7V20Z"/>
   </g>
 </svg>

--- a/src/assets/medal-silver.svg
+++ b/src/assets/medal-silver.svg
@@ -1,17 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 160">
-  <defs>
-    <linearGradient id="silver-medal" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#f9f9f9" />
-      <stop offset="100%" stop-color="#b8b8b8" />
-    </linearGradient>
-    <linearGradient id="silver-ribbon" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#7a8691" />
-      <stop offset="100%" stop-color="#55606a" />
-    </linearGradient>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 28" shape-rendering="crispEdges">
   <g fill="none" fill-rule="evenodd">
-    <path d="M32 128h16l16 32 16-32h16l-32 32z" fill="url(#silver-ribbon)" />
-    <circle cx="64" cy="64" r="56" fill="url(#silver-medal)" stroke="#8f9499" stroke-width="8" />
-    <polygon points="64 26 72.9 49.2 98 49.2 77.5 64.8 86.4 88 64 72.8 41.6 88 50.5 64.8 30 49.2 55.1 49.2" fill="#ffffff" stroke="#a9afb4" stroke-width="4" stroke-linejoin="round" />
+    <path fill="#C1C4D1" d="M6 0H12V1H13V2H14V3H15V4H16V12H15V13H14V14H13V15H12V16H6V15H5V14H4V13H3V12H2V4H3V3H4V2H5V1H6V0Z"/>
+    <path fill="#E6E8F3" d="M6 1H7V4H8V5H9V6H8V7H7V12H6V1Z"/>
+    <path fill="#8F95A5" d="M12 1H13V2H14V3H15V4H14V5H13V6H12V1Z"/>
+    <path fill="#8F95A5" d="M12 9H13V10H14V12H13V13H12V9Z"/>
+    <rect width="3" height="1" x="8" y="4" fill="#FFFFFF"/>
+    <rect width="1" height="1" x="10" y="5" fill="#FFFFFF"/>
+    <rect width="2" height="1" x="9" y="6" fill="#FFFFFF"/>
+    <rect width="2" height="1" x="8" y="7" fill="#FFFFFF"/>
+    <rect width="1" height="1" x="8" y="8" fill="#FFFFFF"/>
+    <rect width="3" height="1" x="8" y="9" fill="#FFFFFF"/>
+    <rect width="1" height="1" x="10" y="10" fill="#FFFFFF"/>
+    <rect width="3" height="1" x="8" y="11" fill="#FFFFFF"/>
+    <path fill="#9B1C1C" d="M4 16H7V26H6V24H5V26H4V16Z"/>
+    <path fill="#9B1C1C" d="M11 16H14V26H13V24H12V26H11V16Z"/>
+    <path fill="#C23030" d="M7 16H11V18H7V16Z"/>
+    <path fill="#C23030" d="M7 20H11V21H7V20Z"/>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- replace the bronze, silver, gold, and platinum medal SVGs with crisp pixel-art versions and matching ribbon colors
- add pixel-styled numerals (and a platinum monogram) so the medals better match the provided reference art

## Testing
- not run (asset-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e3ee931dd083288f94d559e2fc8f5a