### PR TITLE
Fix lint warnings in button handler and scoreboard

### DIFF
--- a/src/abstracts/button-event-handler.ts
+++ b/src/abstracts/button-event-handler.ts
@@ -106,10 +106,15 @@ export default abstract class ButtonEventHandler {
   }
 
   public mouseEvent(state: IMouseState, { x, y }: ICoordinate): void {
-    if (state === 'down') {
-      this.onMouseDown({ x, y });
-    } else if (state === 'up') {
-      this.onMouseup({ x, y });
+    switch (state) {
+      case 'down':
+        this.onMouseDown({ x, y });
+        break;
+      case 'up':
+        this.onMouseup({ x, y });
+        break;
+      default:
+        break;
     }
   }
 

--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -389,7 +389,7 @@ export default class ScoreBoard extends ParentObject {
     context: CanvasRenderingContext2D,
     coord: ICoordinate,
     parentSize: IDimension,
-    _p0: boolean
+    showNewHighScoreToast: boolean
   ): void {
     const numSize = rescaleDim(
       {
@@ -416,7 +416,7 @@ export default class ScoreBoard extends ParentObject {
       );
     });
 
-    if ((this.flags & ScoreBoard.FLAG_NEW_HIGH_SCORE) === 0) return;
+    if (!showNewHighScoreToast) return;
 
     const toastSize = rescaleDim(
       {
@@ -455,12 +455,8 @@ export default class ScoreBoard extends ParentObject {
     this.playButton.onClick(cb);
   }
 
-  public onShowRanks(_cb: IEmptyFunction): void {
-    /**
-     * I don't know what to do on ranking?
-     *
-     * Should i create API for this?
-     * */
+  public onShowRanks(callback: IEmptyFunction): void {
+    this.rankingButton.onClick(callback);
   }
 
   public mouseDown({ x, y }: ICoordinate): void {


### PR DESCRIPTION
## Summary
- silence the button event handler lint warning by using a switch statement for mouse state transitions
- respect the high score toast flag instead of re-checking internal state and wire the ranking button callback handler

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e464387a7883289e10fd9a1729f15e