### PR TITLE
Adjust medal position on scoreboard

### DIFF
--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -280,7 +280,7 @@ export default class ScoreBoard extends ParentObject {
     const medalCenterX = coord.x + parentSize.width * 0.213;
     const pos = {
       x: medalCenterX - scaled.width / 2,
-      y: coord.y + parentSize.height * 0.27
+      y: coord.y + parentSize.height * 0.27 + 2
     };
 
     context.drawImage(medal, pos.x, pos.y, scaled.width, scaled.height);


### PR DESCRIPTION
## Summary
- lower the scoreboard medal rendering by two pixels to align it with the ribbon

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e465bd680c8328a6e9a44d6b74baaf