### PR TITLE
Update branding to match Alex-Unnippillil repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jxmked/Flappybird.git"
+    "url": "git+https://github.com/Alex-Unnippillil/flappy-bird.git"
   },
   "keywords": [
     "canvas",
@@ -27,7 +27,7 @@
   "author": "Jovan De Guia",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/jxmked/Flappybird/issues"
+    "url": "https://github.com/Alex-Unnippillil/flappy-bird/issues"
   },
   "homepage": "https://alex-unnippillil.github.io/flappy-bird/",
   "devDependencies": {

--- a/src/model/btn-rate.ts
+++ b/src/model/btn-rate.ts
@@ -25,6 +25,6 @@ export default class RateNutton extends PlayButton {
     // Open new Tab the goto to Github Repository
 
     // Hard Coded
-    openInNewTab('https://github.com/jxmked/Flappybird');
+    openInNewTab('https://github.com/Alex-Unnippillil/flappy-bird');
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -252,12 +252,12 @@ module.exports = function (env, config) {
           },
           'og:site_name': {
             property: 'og:site_name',
-            content: 'jxmked page'
+            content: 'Flappy Bird'
           },
           'og:image:url': {
             property: 'og:image:url',
             content:
-              'https://raw.githubusercontent.com/jxmked/resources/xio/assets/icons/light/Windows/Square310x310Logo.scale-400.png'
+              'https://raw.githubusercontent.com/Alex-Unnippillil/flappy-bird/main/src/assets/icon.png'
           },
           'og:image:width': {
             property: 'og:image:width',
@@ -306,7 +306,7 @@ module.exports = function (env, config) {
           'twitter:image': {
             name: 'twitter:image',
             content:
-              'https://raw.githubusercontent.com/jxmked/resources/xio/assets/icons/light/Windows/Square310x310Logo.scale-400.png'
+              'https://raw.githubusercontent.com/Alex-Unnippillil/flappy-bird/main/src/assets/icon.png'
           },
           'geo.country': {
             name: 'geo.country',


### PR DESCRIPTION
## Summary
- update package metadata and rate button link to point to the Alex-Unnippillil/flappy-bird repository
- replace Open Graph and Twitter image metadata to remove jxmked branding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e71c0964388328b6c04b32d0ca8a55