### PR TITLE
Update Flappy Bird social sharing metadata

### DIFF
--- a/src/assets/social/flappy-bird-card.svg
+++ b/src/assets/social/flappy-bird-card.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">Flappy Bird Web App</title>
+  <desc id="desc">Social sharing card for the Flappy Bird web application</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4ad8ff" />
+      <stop offset="100%" stop-color="#1a8cff" />
+    </linearGradient>
+    <filter id="shadow" x="-15%" y="-15%" width="130%" height="130%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="20" stdDeviation="30" flood-color="#045" flood-opacity="0.35" />
+    </filter>
+  </defs>
+  <rect width="1200" height="630" rx="42" fill="url(#bg)" />
+  <g transform="translate(220 160)" fill="#fff" filter="url(#shadow)">
+    <path d="M178 70c48-8 94 14 102 62 6 33-8 66-34 87l58 58-80 0-38-38c-34 6-69-4-92-30-27-31-24-78 7-105 21-18 49-26 77-22z" fill="#fff"/>
+    <path d="M120 140c0-22 18-40 40-40s40 18 40 40-18 40-40 40-40-18-40-40z" fill="#0b3d91"/>
+    <circle cx="160" cy="140" r="18" fill="#fff"/>
+    <circle cx="166" cy="136" r="8" fill="#0b3d91"/>
+    <path d="M232 134l78-14c8-2 16 4 16 12v44c0 8-8 14-16 12l-78-14z" fill="#ffcf3f"/>
+    <path d="M52 152h62c10 0 18 8 18 18v22c0 10-8 18-18 18H40z" fill="#ff8f3f"/>
+  </g>
+  <g fill="#fff">
+    <text x="540" y="170" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="64" font-weight="600" letter-spacing="4">FLAPPY BIRD</text>
+    <text x="540" y="240" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="32" font-weight="400" letter-spacing="2">Classic arcade fun in your browser</text>
+  </g>
+  <g fill="#0b3d91" opacity="0.4">
+    <circle cx="1020" cy="120" r="18" />
+    <circle cx="1080" cy="220" r="10" />
+    <circle cx="980" cy="260" r="14" />
+  </g>
+</svg>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,10 @@ const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 
+const SOCIAL_CARD_PATH = 'assets/social/flappy-bird-card.svg';
+const homepageUrl = new URL(package.homepage);
+const socialImageUrl = new URL(SOCIAL_CARD_PATH, homepageUrl).toString();
+
 
 
 /**
@@ -252,24 +256,31 @@ module.exports = function (env, config) {
           },
           'og:site_name': {
             property: 'og:site_name',
-            content: 'jxmked page'
+            content: 'Flappy Bird Web App'
+          },
+          'og:image': {
+            property: 'og:image',
+            content: socialImageUrl
           },
           'og:image:url': {
             property: 'og:image:url',
-            content:
-              'https://raw.githubusercontent.com/jxmked/resources/xio/assets/icons/light/Windows/Square310x310Logo.scale-400.png'
+            content: socialImageUrl
+          },
+          'og:image:type': {
+            property: 'og:image:type',
+            content: 'image/svg+xml'
           },
           'og:image:width': {
             property: 'og:image:width',
-            content: '1240'
+            content: '1200'
           },
           'og:image:height': {
             property: 'og:image:height',
-            content: '1240'
+            content: '630'
           },
           'og:image:alt': {
             property: 'og:image:alt',
-            content: 'Logo'
+            content: 'Stylised Flappy Bird illustration and title lockup'
           },
           'apple-meta-01': {
             name: 'apple-mobile-web-app-capable',
@@ -293,7 +304,7 @@ module.exports = function (env, config) {
           },
           'twitter:card': {
             name: 'twitter:card',
-            content: 'app'
+            content: 'summary_large_image'
           },
           'twitter:title': {
             name: 'twitter:title',
@@ -305,8 +316,11 @@ module.exports = function (env, config) {
           },
           'twitter:image': {
             name: 'twitter:image',
-            content:
-              'https://raw.githubusercontent.com/jxmked/resources/xio/assets/icons/light/Windows/Square310x310Logo.scale-400.png'
+            content: socialImageUrl
+          },
+          'twitter:image:alt': {
+            name: 'twitter:image:alt',
+            content: 'Stylised Flappy Bird illustration and title lockup'
           },
           'geo.country': {
             name: 'geo.country',
@@ -331,6 +345,17 @@ module.exports = function (env, config) {
       new MiniCssExtractPlugin({
         filename: CONFIG.output.name + '.css',
         chunkFilename: CONFIG.output.chunk + '.css'
+      }),
+
+      // Copy static social sharing assets without fingerprinting.
+      new CopyPlugin({
+        patterns: [
+          {
+            from: path.resolve(__dirname, CONFIG.input.dir, 'assets/social'),
+            to: path.resolve(__dirname, CONFIG.output.dir, 'assets/social'),
+            noErrorOnMissing: true
+          }
+        ]
       }),
 
       // Placeholder values injected into the HTML template.


### PR DESCRIPTION
## Summary
- replace the legacy Open Graph and Twitter metadata with Flappy Bird specific titles and artwork
- add a dedicated SVG social preview card and make it available in the build output

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e82888f6808328aceb00f526590206