### PR TITLE
Document accessibility status and testing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ A polished, fully offline-capable recreation of the classic Flappy Bird experien
 8. [Configuration](#configuration)
 9. [Progressive Web App Capabilities](#progressive-web-app-capabilities)
 10. [Development Workflow](#development-workflow)
-11. [Browser Support](#browser-support)
+11. [Accessibility](#accessibility)
+12. [Browser Support](#browser-support)
 
 ## Key Features
 
@@ -167,6 +168,31 @@ Modifying these constants enables quick experimentation with difficulty curves a
 2. **Testing** – Manually exercise gameplay changes in multiple viewport sizes and input methods.
 3. **Branching** – Use feature branches (`feature/<description>`) and descriptive commit messages.
 4. **Pull Requests** – Summarize gameplay-visible changes and outline manual test steps for reviewers.
+
+## Accessibility
+
+### Current Support
+
+- **Keyboard Playability** – The canvas listens for `Space` and `Enter` key events, triggering the same handlers used for pointer input so players can flap and restart without a mouse or touch device.【F:src/events.ts†L134-L178】
+
+### Backlog Priorities
+
+- Respect the `prefers-reduced-motion` media query and offer an in-game motion toggle for players who need fewer animations.【F:AGENTS.md†L21-L25】
+- Add keyboard focus management, ARIA roles, and guidance so screen reader users understand the canvas UI and interactive states.【F:AGENTS.md†L21-L25】
+- Provide high-contrast and reduced-glare visual themes, vibration toggles, orientation hints, and a persistable Accessibility/Settings screen.【F:AGENTS.md†L21-L25】
+
+### Manual Testing
+
+Follow the [Accessibility Checklist](docs/accessibility-checklist.md) for full context and expected outcomes.
+
+- **Screen Reader Smoke Test**
+  1. Launch the game locally (`npm run dev`) and open it in your browser.
+  2. Start your preferred screen reader (e.g., NVDA on Windows, VoiceOver on macOS) and move focus to the game canvas.
+  3. Confirm the reader announces available instructions, then use the keyboard controls above to play a round and note any missing narration or focus cues for backlog tracking.
+
+- **Reduced Motion Sanity Check**
+  1. Enable the system-level “Reduce Motion” or “Remove Animations” preference for your OS.
+  2. Refresh the game and observe whether parallax scrolling, sprite animations, and transitions slow down or pause. Record the result so gaps can be prioritized against the backlog items above.
 
 ## Browser Support
 

--- a/docs/accessibility-checklist.md
+++ b/docs/accessibility-checklist.md
@@ -1,0 +1,40 @@
+# Accessibility Checklist
+
+This checklist documents the manual tests needed to understand the Flappy Bird web app's current accessibility posture and to verify future improvements. Record the date, device, browser, and any findings for each run so issues can be triaged.
+
+## Test Environment Setup
+
+1. Install dependencies with `npm install` (first run only).
+2. Start the development server with `npm run dev` and open http://localhost:3000 in your test browser.
+3. Disable browser extensions that might interfere with accessibility tooling.
+
+## Keyboard-Only Playability
+
+- Focus the game canvas (click once if focus management is unavailable).
+- Use the **Space** or **Enter** keys to start and continue flapping.
+- Confirm that gameplay, pausing, and restarting are achievable without a pointing device.
+- Note any missing focus outlines, instructions, or pause controls that would block keyboard users.
+
+## Screen Reader Smoke Test
+
+1. With the game running locally, launch your preferred screen reader:
+   - **Windows** – NVDA or Narrator.
+   - **macOS** – VoiceOver.
+   - **Linux** – Orca.
+2. Navigate to the browser tab and attempt to reach the game canvas using standard navigation commands (`Tab`, rotor, landmarks, etc.).
+3. Document what the screen reader announces when focus enters the canvas and during gameplay events (game start, collision, score changes).
+4. Capture gaps such as silent interactions, lack of instructions, or missing focus order so they can be mapped to backlog fixes.
+
+## Reduced Motion Preference
+
+1. Enable the operating system's reduced-motion setting:
+   - **macOS/iOS** – Settings → Accessibility → Display → Reduce Motion.
+   - **Windows** – Settings → Accessibility → Visual effects → Animation effects (toggle off).
+   - **Android** – Settings → Accessibility → Display size and text → Remove animations.
+2. Refresh the game with the preference enabled and observe parallax scrolling, sprite animation speed, and transition effects.
+3. Note whether any elements respect the preference; if everything animates at full speed, flag this as an open backlog item.
+4. Restore the original system setting after testing.
+
+## Follow-Up Backlog Items
+
+Log unresolved issues against the outstanding accessibility priorities: honoring `prefers-reduced-motion`, adding structured keyboard focus/ARIA support, shipping high-contrast themes, vibration toggles, orientation guidance, and a dedicated Accessibility/Settings screen.


### PR DESCRIPTION
## Summary
- add an accessibility section to the README covering current keyboard support, outstanding backlog items, and manual test flows
- create an accessibility checklist document with detailed steps for keyboard, screen reader, and reduced-motion verification

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e877b710648328b871e9193853fff3