### PR TITLE
Add themed ghost replay toggle

### DIFF
--- a/src/model/bird.ts
+++ b/src/model/bird.ts
@@ -365,6 +365,10 @@ export default class Bird extends ParentClass {
     return this.rotation;
   }
 
+  public getWingState(): number {
+    return this.wingState;
+  }
+
   public getSize(): IDimension {
     return { ...this.scaled };
   }

--- a/src/model/btn-ghost-toggle.ts
+++ b/src/model/btn-ghost-toggle.ts
@@ -1,0 +1,250 @@
+// File Overview: This module belongs to src/model/btn-ghost-toggle.ts.
+import ButtonEventHandler from '../abstracts/button-event-handler';
+import SpriteDestructor from '../lib/sprite-destructor';
+import Sfx from './sfx';
+
+type ToggleCallback = (enabled: boolean) => void;
+
+export default class GhostToggleButton extends ButtonEventHandler {
+  private enabled: boolean;
+  private callback?: ToggleCallback;
+  private icon: HTMLCanvasElement;
+
+  constructor() {
+    super();
+    this.initialWidth = 0.32;
+    this.coordinate.x = 0.5;
+    this.coordinate.y = 0.868;
+    this.enabled = true;
+    this.icon = document.createElement('canvas');
+    this.active = false;
+  }
+
+  public init(): void {
+    const base = SpriteDestructor.asset('bird-yellow-mid');
+    this.icon = document.createElement('canvas');
+    this.icon.width = base.width;
+    this.icon.height = base.height;
+    const ctx = this.icon.getContext('2d');
+
+    if (!ctx) {
+      return;
+    }
+
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, this.icon.width, this.icon.height);
+    ctx.globalAlpha = 1;
+    ctx.drawImage(base, 0, 0, base.width, base.height);
+    ctx.globalCompositeOperation = 'source-atop';
+    const gradient = ctx.createLinearGradient(0, 0, 0, this.icon.height);
+    gradient.addColorStop(0, '#f1f3f8');
+    gradient.addColorStop(0.45, '#c8ccd8');
+    gradient.addColorStop(1, '#959bad');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, this.icon.width, this.icon.height);
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.globalAlpha = 0.26;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, this.icon.width, this.icon.height * 0.5);
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = 'source-over';
+  }
+
+  public resize(size: IDimension): void {
+    this.canvasSize = { ...size };
+    const width = size.width * this.initialWidth;
+    const height = width * 0.36;
+    this.dimension = { width, height };
+  }
+
+  public Update(): void {
+    this.reset();
+
+    if (this.isHovered) {
+      this.move({ x: 0, y: 0.006 });
+    }
+
+    super.Update();
+  }
+
+  public click(): void {
+    Sfx.swoosh();
+    this.enabled = !this.enabled;
+    this.callback?.(this.enabled);
+  }
+
+  public onToggle(callback: ToggleCallback): void {
+    this.callback = callback;
+  }
+
+  public setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  public get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  private static roundRect(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    radius: number
+  ): void {
+    const r = Math.min(radius, Math.min(width, height) / 2);
+
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + width - r, y);
+    ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+    ctx.lineTo(x + width, y + height - r);
+    ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+    ctx.lineTo(x + r, y + height);
+    ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+    ctx.lineTo(x, y + r);
+    ctx.quadraticCurveTo(x, y, x + r, y);
+    ctx.closePath();
+  }
+
+  public Display(ctx: CanvasRenderingContext2D): void {
+    const { width, height } = this.dimension;
+    const x = this.calcCoord.x;
+    const y = this.calcCoord.y;
+
+    ctx.save();
+    ctx.translate(x, y);
+
+    const radius = height / 2;
+    ctx.shadowColor = 'rgba(48, 56, 88, 0.35)';
+    ctx.shadowBlur = height * 0.6;
+    ctx.shadowOffsetY = height * 0.2;
+
+    GhostToggleButton.roundRect(ctx, -width / 2, -height / 2, width, height, radius);
+    const baseGradient = ctx.createLinearGradient(0, -height / 2, 0, height / 2);
+
+    if (this.enabled) {
+      baseGradient.addColorStop(0, '#909bb5');
+      baseGradient.addColorStop(0.55, '#7884a1');
+      baseGradient.addColorStop(1, '#636f8b');
+    } else {
+      baseGradient.addColorStop(0, '#d6d2cc');
+      baseGradient.addColorStop(0.55, '#c1bbb5');
+      baseGradient.addColorStop(1, '#a8a29c');
+    }
+
+    ctx.fillStyle = baseGradient;
+    ctx.fill();
+
+    if (this.isHovered) {
+      ctx.globalAlpha = 0.18;
+      ctx.fillStyle = '#ffffff';
+      GhostToggleButton.roundRect(ctx, -width / 2, -height / 2, width, height, radius);
+      ctx.fill();
+      ctx.globalAlpha = 1;
+    }
+
+    ctx.shadowColor = 'transparent';
+    ctx.lineWidth = height * 0.08;
+    ctx.strokeStyle = this.enabled
+      ? 'rgba(255, 255, 255, 0.38)'
+      : 'rgba(255, 255, 255, 0.28)';
+    ctx.stroke();
+
+    const sheen = ctx.createLinearGradient(0, -height / 2, 0, height / 2);
+    sheen.addColorStop(0, 'rgba(255,255,255,0.6)');
+    sheen.addColorStop(0.4, 'rgba(255,255,255,0)');
+    sheen.addColorStop(1, 'rgba(255,255,255,0.08)');
+    ctx.globalAlpha = 0.85;
+    GhostToggleButton.roundRect(
+      ctx,
+      -width / 2 + height * 0.05,
+      -height / 2 + height * 0.05,
+      width - height * 0.1,
+      height - height * 0.1,
+      radius - height * 0.05
+    );
+    ctx.fillStyle = sheen;
+    ctx.fill();
+    ctx.globalAlpha = 1;
+
+    ctx.shadowColor = 'rgba(86, 98, 132, 0.45)';
+    ctx.shadowBlur = height * 0.25;
+    ctx.shadowOffsetY = height * 0.12;
+    const iconScale = height * 0.74;
+    const iconAspect = this.icon.height / Math.max(1, this.icon.width);
+    const iconWidth = iconScale;
+    const iconHeight = iconScale * iconAspect;
+
+    ctx.globalAlpha = this.enabled ? 0.68 : 0.45;
+    ctx.drawImage(
+      this.icon,
+      -width * 0.32 - iconWidth / 2,
+      -iconHeight / 2,
+      iconWidth,
+      iconHeight
+    );
+
+    ctx.globalAlpha = 1;
+    ctx.shadowBlur = 0;
+    ctx.shadowOffsetY = 0;
+    ctx.shadowColor = 'transparent';
+
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.92)';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+    ctx.font = `${height * 0.42}px 'Arial Black', 'Arial', sans-serif`;
+    ctx.fillText('GHOST', -width * 0.08, -height * 0.18);
+
+    ctx.font = `${height * 0.36}px 'Arial', sans-serif`;
+    ctx.fillStyle = this.enabled
+      ? 'rgba(237, 244, 255, 0.92)'
+      : 'rgba(230, 229, 232, 0.72)';
+    ctx.fillText(this.enabled ? 'ON' : 'OFF', -width * 0.08, height * 0.3);
+
+    const indicatorRadius = height * 0.22;
+    ctx.beginPath();
+    ctx.arc(width * 0.32, 0, indicatorRadius, 0, Math.PI * 2);
+    const indicator = ctx.createRadialGradient(
+      width * 0.32 - indicatorRadius * 0.2,
+      -indicatorRadius * 0.2,
+      indicatorRadius * 0.1,
+      width * 0.32,
+      0,
+      indicatorRadius
+    );
+
+    if (this.enabled) {
+      indicator.addColorStop(0, 'rgba(255,255,255,0.95)');
+      indicator.addColorStop(1, 'rgba(182, 214, 255, 0.85)');
+    } else {
+      indicator.addColorStop(0, 'rgba(255,255,255,0.75)');
+      indicator.addColorStop(1, 'rgba(190, 190, 200, 0.65)');
+    }
+
+    ctx.fillStyle = indicator;
+    ctx.fill();
+    ctx.lineWidth = height * 0.06;
+    ctx.strokeStyle = 'rgba(255,255,255,0.35)';
+    ctx.stroke();
+
+    ctx.lineWidth = height * 0.08;
+    ctx.lineCap = 'round';
+
+    ctx.beginPath();
+    if (this.enabled) {
+      ctx.strokeStyle = 'rgba(70, 82, 120, 0.65)';
+      ctx.moveTo(width * 0.26, 0);
+      ctx.lineTo(width * 0.32, indicatorRadius * 0.32);
+      ctx.lineTo(width * 0.38, -indicatorRadius * 0.35);
+    } else {
+      ctx.strokeStyle = 'rgba(90, 90, 100, 0.55)';
+      ctx.moveTo(width * 0.27, 0);
+      ctx.lineTo(width * 0.37, 0);
+    }
+    ctx.stroke();
+
+    ctx.restore();
+  }
+}

--- a/src/model/btn-ghost-toggle.ts
+++ b/src/model/btn-ghost-toggle.ts
@@ -173,18 +173,20 @@ export default class GhostToggleButton extends ButtonEventHandler {
     ctx.shadowBlur = height * 0.25;
     ctx.shadowOffsetY = height * 0.12;
     const iconScale = height * 0.74;
-    const iconAspect = this.icon.height / Math.max(1, this.icon.width);
-    const iconWidth = iconScale;
-    const iconHeight = iconScale * iconAspect;
+    if (this.icon.width > 0 && this.icon.height > 0) {
+      const iconAspect = this.icon.height / this.icon.width;
+      const iconWidth = iconScale;
+      const iconHeight = iconScale * iconAspect;
 
-    ctx.globalAlpha = this.enabled ? 0.68 : 0.45;
-    ctx.drawImage(
-      this.icon,
-      -width * 0.32 - iconWidth / 2,
-      -iconHeight / 2,
-      iconWidth,
-      iconHeight
-    );
+      ctx.globalAlpha = this.enabled ? 0.68 : 0.45;
+      ctx.drawImage(
+        this.icon,
+        -width * 0.32 - iconWidth / 2,
+        -iconHeight / 2,
+        iconWidth,
+        iconHeight
+      );
+    }
 
     ctx.globalAlpha = 1;
     ctx.shadowBlur = 0;

--- a/src/model/score-board.ts
+++ b/src/model/score-board.ts
@@ -11,6 +11,7 @@ import SparkModel from './spark';
 import PlayButton from './btn-play';
 import RankingButton from './btn-ranking';
 import ToggleSpeaker from './btn-toggle-speaker';
+import GhostToggleButton from './btn-ghost-toggle';
 import SpriteDestructor from '../lib/sprite-destructor';
 import { Fly, BounceIn, TimingEvent } from '../lib/animation';
 import Storage from '../lib/storage';
@@ -27,6 +28,7 @@ export default class ScoreBoard extends ParentObject {
   private playButton: PlayButton;
   private rankingButton: RankingButton;
   private toggleSpeakerButton: ToggleSpeaker;
+  private ghostToggleButton: GhostToggleButton;
   private FlyInAnim: Fly;
   private BounceInAnim: BounceIn;
   private currentScore: number;
@@ -34,6 +36,8 @@ export default class ScoreBoard extends ParentObject {
   private currentHighScore: number;
   private TimingEventAnim: TimingEvent;
   private spark: SparkModel;
+  private ghostEnabled: boolean;
+  private ghostToggleHandler?: (enabled: boolean) => void;
   private readonly medalTiers: {
     threshold: number;
     imageKey: string;
@@ -46,10 +50,13 @@ export default class ScoreBoard extends ParentObject {
     this.playButton = new PlayButton();
     this.rankingButton = new RankingButton();
     this.toggleSpeakerButton = new ToggleSpeaker();
+    this.ghostToggleButton = new GhostToggleButton();
     this.spark = new SparkModel();
     this.currentHighScore = 0;
     this.currentGeneratedNumber = 0;
     this.currentScore = 0;
+    this.ghostEnabled = true;
+    this.ghostToggleHandler = undefined;
     this.medalTiers = [
       { threshold: 10, imageKey: 'medal-platinum' },
       { threshold: 5, imageKey: 'medal-gold' },
@@ -93,10 +100,12 @@ export default class ScoreBoard extends ParentObject {
     this.rankingButton.init();
     this.playButton.init();
     this.toggleSpeakerButton.init();
+    this.ghostToggleButton.init();
 
     this.playButton.active = false;
     this.rankingButton.active = false;
     this.toggleSpeakerButton.active = false;
+    this.ghostToggleButton.active = false;
     this.spark.init();
 
     /**
@@ -106,6 +115,19 @@ export default class ScoreBoard extends ParentObject {
      * */
     const prevScore = Storage.get('highscore') as number;
     this.currentHighScore = typeof prevScore === 'number' ? prevScore : 0;
+
+    const storedGhostPreference = Storage.get('ghost-enabled');
+    if (typeof storedGhostPreference === 'boolean') {
+      this.ghostEnabled = storedGhostPreference;
+    }
+
+    this.ghostToggleButton.setEnabled(this.ghostEnabled);
+    this.ghostToggleButton.onToggle((enabled: boolean) => {
+      if (this.ghostEnabled === enabled) return;
+      this.ghostEnabled = enabled;
+      Storage.save('ghost-enabled', enabled);
+      this.ghostToggleHandler?.(enabled);
+    });
   }
 
   private preloadImage(key: string, src: string): void {
@@ -125,6 +147,7 @@ export default class ScoreBoard extends ParentObject {
     this.playButton.resize(this.canvasSize);
     this.spark.resize(this.canvasSize);
     this.toggleSpeakerButton.resize(this.canvasSize);
+    this.ghostToggleButton.resize(this.canvasSize);
   }
 
   public Update(): void {
@@ -132,6 +155,7 @@ export default class ScoreBoard extends ParentObject {
     this.playButton.Update();
     this.spark.Update();
     this.toggleSpeakerButton.Update();
+    this.ghostToggleButton.Update();
   }
 
   public Display(context: CanvasRenderingContext2D): void {
@@ -218,6 +242,7 @@ export default class ScoreBoard extends ParentObject {
       this.rankingButton.Display(context);
       this.playButton.Display(context);
       this.toggleSpeakerButton.Display(context);
+      this.ghostToggleButton.Display(context);
     }
   }
 
@@ -241,6 +266,8 @@ export default class ScoreBoard extends ParentObject {
     this.playButton.active = true;
     this.rankingButton.active = true;
     this.toggleSpeakerButton.active = true;
+    this.ghostToggleButton.active = true;
+    this.ghostToggleButton.setEnabled(this.ghostEnabled);
   }
 
   private setHighScore(num: number): void {
@@ -395,6 +422,7 @@ export default class ScoreBoard extends ParentObject {
     this.playButton.active = false;
     this.rankingButton.active = false;
     this.toggleSpeakerButton.active = false;
+    this.ghostToggleButton.active = false;
     this.currentGeneratedNumber = 0;
     this.FlyInAnim.reset();
     this.BounceInAnim.reset();
@@ -410,16 +438,26 @@ export default class ScoreBoard extends ParentObject {
     this.rankingButton.onClick(callback);
   }
 
+  public onToggleGhost(callback: (enabled: boolean) => void): void {
+    this.ghostToggleHandler = callback;
+  }
+
+  public isGhostEnabled(): boolean {
+    return this.ghostEnabled;
+  }
+
   public mouseDown({ x, y }: ICoordinate): void {
     this.playButton.mouseEvent('down', { x, y });
     this.rankingButton.mouseEvent('down', { x, y });
     this.toggleSpeakerButton.mouseEvent('down', { x, y });
+    this.ghostToggleButton.mouseEvent('down', { x, y });
   }
 
   public mouseUp({ x, y }: ICoordinate): void {
     this.playButton.mouseEvent('up', { x, y });
     this.rankingButton.mouseEvent('up', { x, y });
     this.toggleSpeakerButton.mouseEvent('up', { x, y });
+    this.ghostToggleButton.mouseEvent('up', { x, y });
   }
 
   public triggerPlayATKeyboardEvent(): void {

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -31,12 +31,14 @@ import ParentClass from '../abstracts/parent-class';
 import PipeGenerator from '../model/pipe-generator';
 import ScoreBoard from '../model/score-board';
 import Sfx from '../model/sfx';
+import SpriteDestructor from '../lib/sprite-destructor';
 
 interface BirdGhostSample {
   frame: number;
   time: number;
   position: ICoordinate;
   rotation: number;
+  wingState: number;
 }
 
 export type IGameState = 'died' | 'playing' | 'none';
@@ -61,6 +63,8 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
   private runStartTime: number | null;
   private ghostDuration: number;
   private hasSavedGhost: boolean;
+  private ghostSpriteFrames: HTMLCanvasElement[];
+  private ghostEnabled: boolean;
 
   constructor(game: MainGameController) {
     super();
@@ -94,8 +98,29 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.runStartTime = null;
     this.ghostDuration = 0;
     this.hasSavedGhost = false;
+    this.ghostSpriteFrames = [];
+    this.ghostEnabled = true;
 
     this.transition.setEvent([0.99, 1], this.reset.bind(this));
+
+    this.scoreBoard.onToggleGhost((enabled: boolean) => {
+      this.ghostEnabled = enabled;
+
+      if (!enabled) {
+        this.ghostPlaybackStart = null;
+        return;
+      }
+
+      if (
+        this.state === 'playing' &&
+        this.gameState !== 'died' &&
+        this.ghostPath &&
+        this.ghostPath.length > 0
+      ) {
+        this.ghostPlaybackStart = performance.now();
+        this.ghostPlaybackIndex = 0;
+      }
+    });
   }
 
   public init(): void {
@@ -106,6 +131,8 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.setButtonEvent();
     this.flashScreen.init();
     this.transition.init();
+    this.prepareGhostSprites();
+    this.ghostEnabled = this.scoreBoard.isGhostEnabled();
   }
 
   public reset(): void {
@@ -126,6 +153,7 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.hasSavedGhost = false;
     this.ghostPlaybackStart = null;
     this.ghostPlaybackIndex = 0;
+    this.ghostEnabled = this.scoreBoard.isGhostEnabled();
   }
 
   public resize({ width, height }: IDimension): void {
@@ -259,7 +287,7 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.runStartTime = now;
     this.hasSavedGhost = false;
 
-    if (this.ghostPath && this.ghostPath.length > 0) {
+    if (this.ghostEnabled && this.ghostPath && this.ghostPath.length > 0) {
       this.ghostPlaybackStart = now;
       this.ghostPlaybackIndex = 0;
     } else {
@@ -282,7 +310,8 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
       frame: this.frameIndex,
       time,
       position: { ...this.bird.coordinate },
-      rotation: this.bird.getRotation()
+      rotation: this.bird.getRotation(),
+      wingState: this.bird.getWingState()
     };
 
     this.frameIndex += 1;
@@ -310,10 +339,15 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
 
   private displayGhost(context: CanvasRenderingContext2D): void {
     if (
+      !this.ghostEnabled ||
       !this.ghostPath ||
       this.ghostPath.length === 0 ||
       this.ghostPlaybackStart === null
     ) {
+      return;
+    }
+
+    if (this.ghostSpriteFrames.length === 0) {
       return;
     }
 
@@ -354,32 +388,119 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     }
 
     const size = this.bird.getSize();
-    const radius = Math.max(size.width, size.height) * 0.6;
+    const drawWidth = size.width * 2;
+    const drawHeight = size.height * 2;
+    const sprite = this.getGhostSpriteFrame(current.wingState);
 
     context.save();
-    context.globalAlpha = 0.35;
     context.translate(x, y);
     context.rotate((rotation * Math.PI) / 180);
-    context.fillStyle = '#ffffff';
+    context.globalAlpha = 0.5;
+    context.shadowColor = 'rgba(120, 136, 176, 0.38)';
+    context.shadowBlur = Math.max(drawWidth, drawHeight) * 0.45;
+    context.shadowOffsetY = drawHeight * 0.08;
+    context.drawImage(sprite, -size.width, -size.height, drawWidth, drawHeight);
+    context.shadowBlur = 0;
+    context.shadowOffsetY = 0;
+    context.shadowColor = 'transparent';
+    context.globalAlpha = 0.28;
+    context.fillStyle = 'rgba(212, 218, 238, 0.6)';
     context.beginPath();
-    context.ellipse(0, 0, radius, radius * 0.75, 0, 0, Math.PI * 2);
+    context.ellipse(0, drawHeight * 0.38, size.width * 0.85, size.height * 0.55, 0, 0, Math.PI * 2);
     context.fill();
     context.restore();
 
-    if (this.ghostPlaybackIndex > 0) {
-      context.save();
-      context.globalAlpha = 0.15;
-      context.strokeStyle = '#ffffff';
-      context.lineWidth = 2;
-      context.beginPath();
-      const start = this.ghostPath[0].position;
-      context.moveTo(start.x, start.y);
-      for (let i = 1; i <= this.ghostPlaybackIndex; i++) {
-        const sample = this.ghostPath[i].position;
-        context.lineTo(sample.x, sample.y);
-      }
-      context.stroke();
-      context.restore();
+    this.drawGhostTrail(context);
+  }
+
+  private prepareGhostSprites(): void {
+    const frames: HTMLCanvasElement[] = [];
+    const wingKeys: ('up' | 'mid' | 'down')[] = ['up', 'mid', 'down'];
+
+    for (const key of wingKeys) {
+      try {
+        const base = SpriteDestructor.asset(`bird-yellow-${key}`);
+        const canvas = document.createElement('canvas');
+        canvas.width = base.width;
+        canvas.height = base.height;
+        const ctx = canvas.getContext('2d');
+
+        if (!ctx) {
+          continue;
+        }
+
+        ctx.imageSmoothingEnabled = false;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.globalAlpha = 1;
+        ctx.drawImage(base, 0, 0, base.width, base.height);
+        ctx.globalCompositeOperation = 'source-atop';
+        const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height);
+        gradient.addColorStop(0, '#f4f6fb');
+        gradient.addColorStop(0.45, '#c9cedd');
+        gradient.addColorStop(1, '#8f95a9');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.globalAlpha = 0.24;
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, canvas.width, canvas.height * 0.55);
+        ctx.globalAlpha = 1;
+        ctx.globalCompositeOperation = 'source-over';
+
+        frames.push(canvas);
+      } catch (err) {}
     }
+
+    this.ghostSpriteFrames = frames;
+  }
+
+  private getGhostSpriteFrame(wingState: number): HTMLCanvasElement {
+    if (this.ghostSpriteFrames.length < 3) {
+      return this.ghostSpriteFrames[0] ?? document.createElement('canvas');
+    }
+
+    const index = Math.max(0, Math.min(2, wingState));
+    return this.ghostSpriteFrames[index];
+  }
+
+  private drawGhostTrail(context: CanvasRenderingContext2D): void {
+    if (!this.ghostPath || this.ghostPlaybackIndex < 1) {
+      return;
+    }
+
+    const endIndex = this.ghostPlaybackIndex;
+    const startIndex = Math.max(0, endIndex - 24);
+
+    context.save();
+    const start = this.ghostPath[startIndex].position;
+    const end = this.ghostPath[endIndex].position;
+    const gradient = context.createLinearGradient(start.x, start.y, end.x, end.y);
+    gradient.addColorStop(0, 'rgba(200, 208, 230, 0)');
+    gradient.addColorStop(1, 'rgba(200, 210, 235, 0.45)');
+    context.strokeStyle = gradient;
+    context.lineWidth = Math.max(2, this.canvasSize.width * 0.005);
+    context.lineCap = 'round';
+    context.lineJoin = 'round';
+    context.globalAlpha = 0.6;
+    context.beginPath();
+    context.moveTo(start.x, start.y);
+    for (let i = startIndex + 1; i <= endIndex; i++) {
+      const sample = this.ghostPath[i].position;
+      context.lineTo(sample.x, sample.y);
+    }
+    context.stroke();
+
+    const sparkleCount = Math.max(2, Math.floor((endIndex - startIndex) / 5));
+    context.globalAlpha = 0.4;
+    context.fillStyle = 'rgba(224, 232, 255, 0.7)';
+    for (let i = 0; i < sparkleCount; i++) {
+      const index = Math.max(startIndex, endIndex - i * 4);
+      const sample = this.ghostPath[index].position;
+      const radius = Math.max(2, this.canvasSize.width * 0.004) * (1 - i / sparkleCount);
+      context.beginPath();
+      context.arc(sample.x, sample.y, radius, 0, Math.PI * 2);
+      context.fill();
+    }
+    context.restore();
   }
 }

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -448,7 +448,9 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
         ctx.globalCompositeOperation = 'source-over';
 
         frames.push(canvas);
-      } catch (err) {}
+      } catch (err) {
+        console.warn('Failed to prepare ghost sprite:', err);
+      }
     }
 
     this.ghostSpriteFrames = frames;


### PR DESCRIPTION
## Summary
- add a translucent ghost replay that uses tinted bird sprites and a polished trail
- add a ghost replay toggle on the game over scoreboard and persist the preference
- create a themed ghost toggle button and wire it into gameplay state changes

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fbbd665cc8328a600177d69cde026)