### PR TITLE
Optimize resize handling in index bootstrap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,11 @@ const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
 
 let isLoaded = false;
+let scheduledResizeFrame: number | null = null;
+let prevDisplayWidth = 0;
+let prevDisplayHeight = 0;
+let prevCanvasWidth = 0;
+let prevCanvasHeight = 0;
 
 gameIcon.src = gameSpriteIcon;
 
@@ -86,20 +91,55 @@ const ScreenResize = () => {
 
   const displayWidth = scaledDimension.width / dpr;
   const displayHeight = scaledDimension.height / dpr;
+  const canvasWidth = Math.round(scaledDimension.width);
+  const canvasHeight = Math.round(scaledDimension.height);
 
-  canvas.style.maxWidth = `${displayWidth}px`;
-  canvas.style.maxHeight = `${displayHeight}px`;
-  canvas.style.width = `${displayWidth}px`;
-  canvas.style.height = `${displayHeight}px`;
+  const hasDisplayChange =
+    prevDisplayWidth !== displayWidth || prevDisplayHeight !== displayHeight;
+  const hasCanvasChange =
+    prevCanvasWidth !== canvasWidth || prevCanvasHeight !== canvasHeight;
 
-  canvas.width = Math.round(scaledDimension.width);
-  canvas.height = Math.round(scaledDimension.height);
-  virtualCanvas.width = canvas.width;
-  virtualCanvas.height = canvas.height;
+  if (!hasDisplayChange && !hasCanvasChange) {
+    return;
+  }
 
-  console.log(`Canvas Size: ${canvas.width}x${canvas.height}`);
+  if (hasDisplayChange) {
+    const width = `${displayWidth}px`;
+    const height = `${displayHeight}px`;
+
+    canvas.style.maxWidth = width;
+    canvas.style.maxHeight = height;
+    canvas.style.width = width;
+    canvas.style.height = height;
+
+    prevDisplayWidth = displayWidth;
+    prevDisplayHeight = displayHeight;
+  }
+
+  if (hasCanvasChange) {
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
+    virtualCanvas.width = canvasWidth;
+    virtualCanvas.height = canvasHeight;
+
+    prevCanvasWidth = canvasWidth;
+    prevCanvasHeight = canvasHeight;
+
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`Canvas Size: ${canvas.width}x${canvas.height}`);
+    }
+  }
 
   Game.Resize({ width: canvas.width, height: canvas.height });
+};
+
+const scheduleScreenResize = () => {
+  if (scheduledResizeFrame !== null) return;
+
+  scheduledResizeFrame = window.requestAnimationFrame(() => {
+    scheduledResizeFrame = null;
+    ScreenResize();
+  });
 };
 
 const removeLoadingScreen = () => {
@@ -134,23 +174,23 @@ window.addEventListener('DOMContentLoaded', () => {
 window.addEventListener('resize', () => {
   if (!isLoaded) return;
 
-  ScreenResize();
+  scheduleScreenResize();
 });
 
 window.addEventListener('orientationchange', () => {
   if (!isLoaded) return;
 
-  window.setTimeout(ScreenResize, 0);
+  scheduleScreenResize();
 });
 
 window.visualViewport?.addEventListener('resize', () => {
   if (!isLoaded) return;
 
-  ScreenResize();
+  scheduleScreenResize();
 });
 
 window.visualViewport?.addEventListener('scroll', () => {
   if (!isLoaded) return;
 
-  ScreenResize();
+  scheduleScreenResize();
 });


### PR DESCRIPTION
### Motivation
- Reduce redundant layout work and recalculations during viewport changes by centralizing resize work behind a single scheduler. 
- Avoid unnecessary DOM and canvas mutations to reduce layout thrash and improve responsiveness on resize/visual-viewport events. 
- Keep developer logging useful while preventing noisy console output in production. 
- Preserve the immediate initial sizing when assets are ready while throttling subsequent events.

### Description
- Add `scheduledResizeFrame` and `scheduleScreenResize` that enqueue `ScreenResize` via `requestAnimationFrame` so all viewport listeners use the same RAF-throttled scheduler. 
- Update `ScreenResize` to compute `displayWidth`/`displayHeight` and rounded `canvasWidth`/`canvasHeight`, then diff against `prev*` values to only mutate `canvas.style` or canvas buffer sizes when values change. 
- Gate the canvas size `console.log` behind `process.env.NODE_ENV === 'development'` so logging is development-only. 
- Replace direct calls to `ScreenResize` from listeners (`resize`, `orientationchange`, `visualViewport.resize`, `visualViewport.scroll`) with `scheduleScreenResize`, and keep the initial direct `ScreenResize()` call in the asset-ready path.

### Testing
- Ran linting with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c8f6310832883b327603862d498)