### PR TITLE
Migrate update flow to deterministic delta-time simulation

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -109,16 +109,16 @@ export default class Game extends ParentClass {
     this.canvas.height = height;
   }
 
-  public Update(): void {
+  public Update(deltaMs: number): void {
     this.transition.Update();
     this.screenChanger.setState(this.state);
 
     if (!this.bgPause) {
-      this.background.Update();
-      this.platform.Update();
+      this.background.Update(deltaMs);
+      this.platform.Update(deltaMs);
     }
 
-    this.screenChanger.Update();
+    this.screenChanger.Update(deltaMs);
   }
 
   public Display(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,8 @@ const Game = new GameObject(virtualCanvas);
 const fps = new Framer(Game.context);
 
 let isLoaded = false;
+let previousFrameTime: number | null = null;
+const MAX_DELTA_MS = 100;
 
 gameIcon.src = gameSpriteIcon;
 
@@ -58,9 +60,14 @@ fps.text({ x: 50, y: 50 }, '', ' Cycle');
 fps.container({ x: 10, y: 10}, { x: 230, y: 70});
 
 const GameUpdate = (): void => {
+  const now = performance.now();
+  const rawDeltaMs = previousFrameTime === null ? 1000 / 60 : now - previousFrameTime;
+  previousFrameTime = now;
+  const deltaMs = Math.min(rawDeltaMs, MAX_DELTA_MS);
+
   physicalContext.drawImage(virtualCanvas, 0, 0);
 
-  Game.Update();
+  Game.Update(deltaMs);
   Game.Display();
 
   if (process.env.NODE_ENV === 'development') fps.mark();
@@ -124,6 +131,7 @@ window.addEventListener('DOMContentLoaded', () => {
     ScreenResize();
 
     // raf(GameUpdate); Issue #16
+    previousFrameTime = performance.now();
     if (!game_running()) game_start(); // Quick fix. Long term :)
 
     if (process.env.NODE_ENV === 'development') removeLoadingScreen();
@@ -135,6 +143,12 @@ window.addEventListener('resize', () => {
   if (!isLoaded) return;
 
   ScreenResize();
+});
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    previousFrameTime = performance.now();
+  }
 });
 
 window.addEventListener('orientationchange', () => {

--- a/src/lib/screen-changer/index.ts
+++ b/src/lib/screen-changer/index.ts
@@ -17,7 +17,7 @@
  *   development.
  */
 export interface IScreenChangerObject {
-  Update(): void;
+  Update(deltaMs: number): void;
   Display(context: CanvasRenderingContext2D): void;
 }
 
@@ -38,14 +38,14 @@ export default class ScreenChanger implements IScreenChangerObject {
     this.objects.set(name, classObject);
   }
 
-  public Update(): void {
+  public Update(deltaMs: number): void {
     const classObject = this.objects.get(this.currentState);
 
     if (classObject === void 0) {
       throw new TypeError(`State ${this.currentState} does not exists`);
     }
 
-    classObject.Update();
+    classObject.Update(deltaMs);
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/background.ts
+++ b/src/model/background.ts
@@ -68,7 +68,8 @@ export default class Background extends ParentClass {
     );
   }
 
-  public Update(): void {
+  public Update(deltaMs: number): void {
+    const deltaScale = deltaMs / (1000 / 60);
     /**
      * We use linear interpolation instead of by pixel to move the object.
      * It is to keep the speed same in different Screen Sizes & Screen DPI.
@@ -77,8 +78,8 @@ export default class Background extends ParentClass {
      * We cannot rely on fps since it is not a constant value.
      * Which means is the game will speed up or slow down based on fps
      * */
-    this.coordinate.x += this.canvasSize.width * this.velocity.x;
-    this.coordinate.y += this.velocity.y;
+    this.coordinate.x += this.canvasSize.width * this.velocity.x * deltaScale;
+    this.coordinate.y += this.velocity.y * deltaScale;
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/bird.ts
+++ b/src/model/bird.ts
@@ -312,7 +312,8 @@ export default class Bird extends ParentClass {
     this.flapWing(flipRange(4, 8.2, f));
   }
 
-  public Update(): void {
+  public Update(deltaMs: number): void {
+    const deltaScale = deltaMs / (1000 / 60);
     // Always above the floor
     if (this.doesHitTheFloor() || (this.flags & Bird.FLAG_DOES_LANDED) !== 0) {
       this.flags |= Bird.FLAG_DOES_LANDED;
@@ -328,10 +329,10 @@ export default class Bird extends ParentClass {
       this.max_lift_velocity,
       this.max_fall_velocity,
       this.velocity.y
-    );
+    ) * deltaScale;
 
     // Slowly reduce the Y velocity by given weights
-    this.velocity.y += this.canvasSize.height * BIRD_WEIGHT;
+    this.velocity.y += this.canvasSize.height * BIRD_WEIGHT * deltaScale;
 
     this.handleRotation();
   }

--- a/src/model/pipe-generator.ts
+++ b/src/model/pipe-generator.ts
@@ -120,7 +120,7 @@ export default class PipeGenerator {
     };
   }
 
-  public Update(): void {
+  public Update(deltaMs: number): void {
     if (this.needPipe()) {
       const pipe = new Pipe();
 
@@ -134,7 +134,7 @@ export default class PipeGenerator {
     }
 
     for (let index = 0; index < this.pipes.length; index++) {
-      this.pipes[index].Update();
+      this.pipes[index].Update(deltaMs);
       if (this.pipes[index].isOut()) {
         this.pipes.splice(index, 1);
         index--;

--- a/src/model/pipe.ts
+++ b/src/model/pipe.ts
@@ -146,8 +146,9 @@ export default class Pipe extends ParentClass {
   /**
    * Pipe Update
    * */
-  public Update(): void {
-    this.coordinate.x -= this.velocity.x;
+  public Update(deltaMs: number): void {
+    const deltaScale = deltaMs / (1000 / 60);
+    this.coordinate.x -= this.velocity.x * deltaScale;
   }
 
   public Display(context: CanvasRenderingContext2D): void {

--- a/src/model/platform.ts
+++ b/src/model/platform.ts
@@ -42,13 +42,14 @@ export default class Platform extends ParentClass {
     this.coordinate.y = height - this.platformSize.height;
   }
 
-  public Update() {
+  public Update(deltaMs: number) {
+    const deltaScale = deltaMs / (1000 / 60);
     /**
      * We use linear interpolation instead of by pixel to move the object.
      * It is to keep the speed same in different Screen Sizes & Screen DPI
      * */
-    this.coordinate.x += this.canvasSize.width * this.velocity.x;
-    this.coordinate.y += this.velocity.y;
+    this.coordinate.x += this.canvasSize.width * this.velocity.x * deltaScale;
+    this.coordinate.y += this.velocity.y * deltaScale;
   }
 
   public Display(context: CanvasRenderingContext2D) {

--- a/src/screens/gameplay.ts
+++ b/src/screens/gameplay.ts
@@ -139,14 +139,14 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     this.transition.resize(this.canvasSize);
   }
 
-  public Update(): void {
+  public Update(deltaMs: number): void {
     this.flashScreen.Update();
     this.transition.Update();
     this.scoreBoard.Update();
 
     if (!this.bird.alive) {
       this.game.bgPause = true;
-      this.bird.Update();
+      this.bird.Update(deltaMs);
       return;
     }
 
@@ -163,8 +163,8 @@ export default class GetReady extends ParentClass implements IScreenChangerObjec
     }
 
     this.bannerInstruction.Update();
-    this.pipeGenerator.Update();
-    this.bird.Update();
+    this.pipeGenerator.Update(deltaMs);
+    this.bird.Update(deltaMs);
     this.recordFrameSample();
 
     if (this.bird.isDead(this.pipeGenerator.pipes)) {

--- a/src/screens/intro.ts
+++ b/src/screens/intro.ts
@@ -62,7 +62,8 @@ export default class Introduction extends ParentClass implements IScreenChangerO
     this.toggleSpeakerButton.resize({ width, height });
   }
 
-  public Update(): void {
+  public Update(deltaMs: number): void {
+    void deltaMs;
     this.bird.doWave(
       {
         x: this.canvasSize.width * 0.5,


### PR DESCRIPTION
### Motivation
- Move the game loop to a delta-time driven update path so object motion is stable across variable frame rates and tab-inactivity periods.
- Prevent large simulation jumps after returning from background by clamping extreme frame deltas and resetting timing when the document becomes visible.

### Description
- Compute per-frame `deltaMs` in `src/index.ts` using `performance.now()`, clamp via `MAX_DELTA_MS = 100`, and pass the clamped `deltaMs` into `Game.Update(deltaMs)`; reset the timing accumulator on `visibilitychange`.
- Change the update contract and propagation from `Game -> ScreenChanger -> screens` to accept `deltaMs` (`src/game.ts`, `src/lib/screen-changer/index.ts`, `src/screens/gameplay.ts`, `src/screens/intro.ts`, `src/model/pipe-generator.ts`).
- Convert motion/physics logic in core moving models to scale by a normalized delta (`deltaMs / (1000 / 60)`), specifically `src/model/bird.ts`, `src/model/pipe.ts`, `src/model/background.ts`, and `src/model/platform.ts`, while keeping rendering in `Display()` methods unchanged.
- Keep pipe generation and lifecycle intact but propagate `deltaMs` when updating each `Pipe` instance so removal and scoring remain deterministic.

### Testing
- Ran `npm run lint` and it completed successfully with no reported lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c8ecffc8328a52fb1ded93f3802)