### PR TITLE
Service worker: detect updates and show in-app refresh banner

### DIFF
--- a/src/lib/workbox-work-offline/index.ts
+++ b/src/lib/workbox-work-offline/index.ts
@@ -8,24 +8,76 @@
  *   production.
  *
  * Inputs & Outputs
- * - No inputs; executing the default export attaches an event listener and returns `void`.
- * - Logs registration success or failure to the console for diagnostics.
+ * - Optional input callback for update notifications.
+ * - Emits a `flappybird:sw-update-available` window event and shows a lightweight refresh banner
+ *   when an update is installed and waiting while an existing controller is active.
  *
  * Implementation Notes
  * - Keeps the implementation minimal because webpack injects the worker path and Workbox handles
  *   runtime caching configuration.
  */
-export default () => {
+const SW_UPDATE_EVENT = 'flappybird:sw-update-available';
+
+const createUpdateBanner = () => {
+  if (document.getElementById('sw-update-banner')) return;
+
+  const banner = document.createElement('div');
+  const message = document.createElement('span');
+  const refreshButton = document.createElement('button');
+
+  banner.id = 'sw-update-banner';
+  message.textContent = 'Update available.';
+  refreshButton.type = 'button';
+  refreshButton.textContent = 'Refresh';
+
+  refreshButton.addEventListener('click', () => {
+    window.location.reload();
+  });
+
+  banner.append(message, refreshButton);
+  document.body.appendChild(banner);
+};
+
+const emitUpdateAvailable = (registration: ServiceWorkerRegistration) => {
+  window.dispatchEvent(
+    new CustomEvent(SW_UPDATE_EVENT, {
+      detail: {
+        registration,
+      },
+    }),
+  );
+
+  createUpdateBanner();
+};
+
+export default (onUpdateAvailable?: (registration: ServiceWorkerRegistration) => void) => {
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker
         .register('./service-worker.js')
-        .then(() => {
-          console.log('SW registered');
+        .then((registration) => {
+          console.log('SW registered', registration.scope);
+
+          registration.addEventListener('updatefound', () => {
+            const installingWorker = registration.installing;
+            if (!installingWorker) return;
+
+            installingWorker.addEventListener('statechange', () => {
+              if (
+                installingWorker.state === 'installed' &&
+                navigator.serviceWorker.controller
+              ) {
+                emitUpdateAvailable(registration);
+                onUpdateAvailable?.(registration);
+              }
+            });
+          });
         })
-        .catch(() => {
-          console.log('SW registration failed');
+        .catch((err: unknown) => {
+          console.error('SW registration failed:', err);
         });
     });
   }
 };
+
+export { SW_UPDATE_EVENT };

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -138,3 +138,28 @@ body {
     transform: translate(24px, 0);
   }
 }
+
+#sw-update-banner {
+  position: fixed;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: rgba(28, 28, 30, 0.96);
+  color: #fff;
+  font-family: Arial, sans-serif;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+
+  > button {
+    border: 0;
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
### Motivation
- Improve reliability of the service worker update UX so users are informed when a new version is available.
- Provide an app-level hook and event so other parts of the app can react to update availability without coupling to SW internals.
- Surface clearer diagnostics when registration fails to aid debugging.

### Description
- Updated `src/lib/workbox-work-offline/index.ts` to capture the `ServiceWorkerRegistration` returned by `navigator.serviceWorker.register` and listen for `updatefound` and the installing worker's `statechange` transitions.
- When a new worker reaches `installed` while an existing controller is active the code emits a `flappybird:sw-update-available` `CustomEvent`, calls an optional `onUpdateAvailable` callback, and creates a minimal DOM banner with a `Refresh` button that reloads the page.
- Added lightweight styling for the update banner in `src/styles/main.scss` and improved logging so success logs include the `registration.scope` and failures log the full error via `console.error`.
- Left production-only registration behavior unchanged in `src/index.ts` (registration still only invoked when `NODE_ENV === 'production'`).

### Testing
- Ran `npm run lint` and the linter completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94c913aac8328be1eb1b135c476a5)